### PR TITLE
Multiple values in a single field support when parsing value dots

### DIFF
--- a/R/idf.R
+++ b/R/idf.R
@@ -2367,13 +2367,24 @@ idf_run <- function (self, private, epw, dir = NULL, wait = TRUE,
         )
     }
 
+    # save the model to the output dir if necessary
+    if (is.null(private$m_path) || !utils::file_test("-f", private$m_path)) {
+        abort("error_idf_not_local",
+            paste0(
+                "The Idf object is not created from local file or local file has ",
+                "been deleted from disk. Please save Idf using $save() before run."
+            )
+        )
+    }
+
     # stop if unsaved
-    if (self$is_unsaved())
+    if (self$is_unsaved()) {
         abort("error_idf_not_saved",
             paste0("Idf has been modified since read or last saved. ",
                 "Please save Idf using $save() before run."
             )
         )
+    }
 
     # add Output:SQLite if necessary
     add_sql <- idf_add_output_sqlite(self)

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -128,7 +128,7 @@ sep_name_dots <- function (..., .can_name = TRUE) {
 }
 # }}}
 # sep_value_dots {{{
-sep_value_dots <- function (..., .empty = !in_final_mode(), .duplicate = FALSE) {
+sep_value_dots <- function (..., .empty = !in_final_mode()) {
     l <- list(...)
 
     # stop if empty input
@@ -164,10 +164,17 @@ sep_value_dots <- function (..., .empty = !in_final_mode(), .duplicate = FALSE) 
     }
 
     abort_invalid_format <- function (id) {
-        abort_invalid_input(id, "invalid_format",
-            c("Each object must be an empty list or a list where ",
-              "each element being a non-NA single string or number.")
-        )
+        if (.empty) {
+            abort_invalid_input(id, "invalid_format",
+                c("Each object must be an empty list or a list where ",
+                  "each element being a non-NA single string or number.")
+            )
+        } else {
+            abort_invalid_input(id, "invalid_format",
+                c("Each object must be a list where ",
+                  "each element being a non-NA single string or number.")
+            )
+        }
     }
 
     abort_empty_dot <- function (id) {

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -345,7 +345,13 @@ sep_value_dots <- function (..., .empty = !in_final_mode()) {
                     value_num <- apply2(as.list(rep(NA_real_, sum(len))), each_len, rep)
 
                     # init default value indicator
-                    defaulted <- each_length(value_list) == 0L
+                    defaulted <- each_len == 0L
+                    if (!.default && any(defaulted)) {
+                        abort_invalid_format(rleid[defaulted])
+                    }
+                    # init defaulted values
+                    value_chr[defaulted] <- NA_character_
+                    value_num[defaulted] <- NA_real_
 
                     # contains NA: "cls = list(NA), list(cls = list(NA))" {{{
                     # put this before check comment to make sure there is no NA

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -341,8 +341,8 @@ sep_value_dots <- function (..., .empty = !in_final_mode()) {
                     value_list <- unname(fld_val)
 
                     # init value in character and numeric format
-                    value_chr <- rep(NA_character_, sum(len))
-                    value_num <- rep(NA_real_, sum(len))
+                    value_chr <- apply2(as.list(rep(NA_character_, sum(len))), each_len, rep)
+                    value_num <- apply2(as.list(rep(NA_real_, sum(len))), each_len, rep)
 
                     # init default value indicator
                     defaulted <- each_length(value_list) == 0L

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -1168,6 +1168,7 @@ get_idf_value <- function (idd_env, idf_env, class = NULL, object = NULL, field 
     val
 }
 # }}}
+
 # get_idf_value_all_node {{{
 get_idf_value_all_node <- function (idf_env) {
     idf_env$value[type_enum == IDDFIELD_TYPE$node & !is.na(value_chr), unique(value_chr)]
@@ -1585,7 +1586,7 @@ add_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .all = FALSE
             # set matched field index
             set(val, NULL, "field_index", fld_out$field_index)
             # remove input field name
-            set(val, NULL, "field_name", NULL)
+            if (has_name(val, "field_in")) set(val, NULL, "field_in", NULL)
         }
 
         # now all field indices have been detected
@@ -1756,15 +1757,15 @@ match_set_idf_data <- function (idd_env, idf_env, l) {
 
     if (any(is.na(val$field_name))) {
         val <- fill_unnamed_field_index(idd_env, idf_env, val)
-        idx <- val$field_index
     } else {
         # just to verify field names
         fld_out <- get_idd_field(idd_env, class = val$class_id, field = val$field_name)
         # set matched field index
         set(val, NULL, "field_index", fld_out$field_index)
         # remove input field name
-        set(val, NULL, "field_name", NULL)
+        if (has_name(val, "field_in")) set(val, NULL, "field_in", NULL)
     }
+
     list(object = obj, value = val)
 }
 # }}}

--- a/tests/testthat/test_impl-idf.R
+++ b/tests/testthat/test_impl-idf.R
@@ -480,6 +480,7 @@ test_that("VALUE DOTS", {
     expect_error(sep_value_dots(cls = list(NA)), class = "error_dot_invalid_format")
     expect_error(sep_value_dots(cls = list(NULL, NA)), class = "error_dot_invalid_format")
     expect_error(sep_value_dots(list(cls = list(NULL, NA))), class = "error_dot_invalid_format")
+    expect_error(sep_value_dots(cls1 = list(fld1 = c(NA_character_, 1)), .scalar = FALSE), class = "error_dot_invalid_format")
 
     # multiple .comment
     expect_error(sep_value_dots(cls = list(.comment = c("a"), .comment = NULL)), class = "error_dot_multi_comment")
@@ -552,6 +553,32 @@ test_that("VALUE DOTS", {
             defaulted = c(rep(TRUE, 4L), FALSE, FALSE, TRUE, FALSE, FALSE,
                 rep(TRUE, 4L), FALSE, TRUE, FALSE, TRUE
             )
+        )
+    )
+
+    # multiple values support
+    expect_silent(
+        l <- sep_value_dots(
+            cls1 = list(fld1 = c(1, 2, 3), fld2 = c("a", "b", "c")),
+            list(cls2 = list(fld3 = c(4, 5), fld4 = c("d", "e"))),
+            .scalar = FALSE
+        )
+    )
+    expect_equivalent(l$object,
+        data.table(rleid = 1L:2L,
+            object_rleid = rep(1L, 2L),
+            name = paste0("cls", 1L:2L),
+            empty = rep(FALSE, 2L),
+            comment = rep(list(NULL), 2L)
+        )
+    )
+    expect_equivalent(l$value,
+        data.table(rleid = c(rep(1L, 2L), rep(2L, 2L)),
+            object_rleid = rep(1L, 4L),
+            field_name = paste0("fld", 1L:4L),
+            value_chr = list(c("1", "2", "3"), c("a", "b", "c"), c("4", "5"), c("d", "e")),
+            value_num = list(c(1, 2, 3), rep(NA_real_, 3L), c(4, 5), rep(NA_real_, 2L)),
+            defaulted = rep(FALSE, 4L)
         )
     )
 })


### PR DESCRIPTION
Support multiple values in a single field:

```r
sep_value_dots(A = list(B = c(1, 2, 3), C = c("a", "b", "c")))
```

This is mainly used for another project which uses eplusr's input parsing functionality to generate multiple IDFs for sensitivity analyses.