### PR TITLE
Add new syntax in `$set()` to set all values in same class.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,10 @@
   does come in with a penalty on the performance. It can make adding or
   modifying large mounts of [Idf] and [IdfObject]s extremely slow. Default value
   make sure autocompletion works in interactive mode.
+* A new syntax `class := list(field = value)` in `$set()` has been added. Note
+  the use of `:=` instead of `=`. The main difference is that, unlike `=`, the
+  left hand side of `:=` should be a valid class name in current `Idf` object.
+  It will set the field of all objects in specified class to specified value.
 
 ## Bug fixes
 

--- a/R/idf.R
+++ b/R/idf.R
@@ -2097,8 +2097,8 @@ idf_dup_object <- function (self, private, object, new_name = NULL) {
 }
 # }}}
 # idf_add {{{
-idf_add <- function (self, private, ..., .default = TRUE, .all = FALSE) {
-    add <- add_idf_object(private$idd_env(), private$idf_env(), ..., .default = .default, .all = .all)
+idf_add <- function (self, private, ..., .default = TRUE, .all = FALSE, .env = parent.frame(2)) {
+    add <- add_idf_object(private$idd_env(), private$idf_env(), ..., .default = .default, .all = .all, .env = .env)
     merge_idf_data(private$idf_env(), add)
 
     # log
@@ -2117,8 +2117,8 @@ idf_add_object <- function (self, private, class, value = NULL, comment = NULL, 
 }
 # }}}
 # idf_set {{{
-idf_set <- function (self, private, ..., .default = TRUE) {
-    set <- set_idf_object(private$idd_env(), private$idf_env(), ..., .default = .default)
+idf_set <- function (self, private, ..., .default = TRUE, .env = parent.frame(2)) {
+    set <- set_idf_object(private$idd_env(), private$idf_env(), ..., .default = .default, .env = .env)
     merge_idf_data(private$idf_env(), set, by_object = TRUE)
 
     # log

--- a/R/idf.R
+++ b/R/idf.R
@@ -501,6 +501,12 @@ NULL
 #' as the **new** comments for modified object, overwriting the old ones. Names
 #' in list element are treated as field names.
 #'
+#' There is a special syntax `class := list(field = value)` in `$set()` has been
+#' added. Note the use of `:=` instead of `=`. The main difference is that,
+#' unlike `=`, the left hand side of `:=` should be a valid class name in
+#' current `Idf` object.  It will set the field of all objects in specified
+#' class to specified value.
+#'
 #' **Note**:
 #'
 #' * You can delete a field by assigning `NULL` to it, e.g. `list(fld =
@@ -537,14 +543,7 @@ NULL
 #' * Delete field value: `model$set(Object_Name = list(Field_1 = NULL), .default = FALSE)`.
 #' * Assign default field value: `model$set(Object_Name = list(Field_1 = NULL), .default = TRUE)`.
 #' * Variable input: `a <- list(Object_Name = list(Field_1 = val1)); model$set(a, .default = TRUE)`.
-#' * Set all values of field `fld` in a class `cls`:
-#'
-#' ```
-#' ids <- model$object_id("cls", simplify = TRUE)
-#' val <- rep(list(list(fld = val)), times = length(ids))
-#' names(val) <- paste0("..", ids)
-#' model$set(val)
-#' ```
+#' * Set all values of field `fld` in a class `cls`: `model$set(cls := list(fld = val))`.
 #' }
 #'
 #' \subsection{Deleting Existing Objects}{

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -1825,6 +1825,7 @@ match_set_idf_data <- function (idd_env, idf_env, l) {
         l$value[obj_nm, on = c("rleid", "object_rleid"), `:=`(sgl_object_id = i.object_id)]
         l$value <- cls_nm[, list(rleid, object_id)][l$value, on = "rleid", allow.cartesian = TRUE][
             !is.na(sgl_object_id), object_id := sgl_object_id]
+        set(l$value, NULL, c("i.object_rleid", "sgl_object_id"), NULL)
     }
 
     # combine

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -1825,7 +1825,7 @@ match_set_idf_data <- function (idd_env, idf_env, l) {
         l$value[obj_nm, on = c("rleid", "object_rleid"), `:=`(sgl_object_id = i.object_id)]
         l$value <- cls_nm[, list(rleid, object_id)][l$value, on = "rleid", allow.cartesian = TRUE][
             !is.na(sgl_object_id), object_id := sgl_object_id]
-        set(l$value, NULL, c("i.object_rleid", "sgl_object_id"), NULL)
+        set(l$value, NULL, "sgl_object_id", NULL)
     }
 
     # combine

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -128,18 +128,29 @@ sep_name_dots <- function (..., .can_name = TRUE) {
 }
 # }}}
 # sep_value_dots {{{
-sep_value_dots <- function (..., .empty = !in_final_mode(), .scalar = TRUE, .null = TRUE) {
-    l <- list(...)
+sep_value_dots <- function (..., .empty = !in_final_mode(), .scalar = TRUE, .null = TRUE, .env = parent.frame()) {
+    l <- eval(substitute(alist(...)))
 
     # stop if empty input
-    if (!length(l)) {
-        abort("error_empty_input", "Please give object(s) to add or set")
+    if (!length(l)) abort("error_empty_input", "Please give object(s) to modify.")
+
+    dot_nm <- names2(l)
+    is_cls <- rep(FALSE, length(l))
+
+    # only the first depth is supported
+    for (i in seq_along(l)) {
+        if (!is.null(l[[i]]) && length(l[[i]]) > 2L && is.call(l[[i]]) && as.character(l[[i]][[1L]]) == ":=") {
+            dot_nm[[i]] <- as.character(l[[i]][[2L]])
+            l[[i]] <- l[[i]][-c(1:2)][[1L]]
+            is_cls[[i]] <- TRUE
+        }
+        l[i] <- list(eval(l[[i]], envir = .env))
     }
 
     dt_dot <- data.table(rleid = seq_along(l),
         object_rleid = as.list(rep(1L, length(l))),
         dep = vapply(l, vec_depth, integer(1L)),
-        dot = l, dot_nm = names2(l)
+        dot = l, dot_nm = dot_nm, class = is_cls
     )
 
     if (.scalar) {
@@ -512,7 +523,7 @@ sep_value_dots <- function (..., .empty = !in_final_mode(), .scalar = TRUE, .nul
     }
     # }}}
 
-    flat <- lapply(split(dt_dot, by = "dep"), flatten_input)
+    flat <- lapply(split(copy(dt_dot)[, class := NULL], by = "dep"), flatten_input)
 
     list(object = rbindlist(lapply(flat, .subset2, "object"), use.names = TRUE),
          value = rbindlist(lapply(flat, .subset2, "value"), use.names = TRUE),
@@ -1564,9 +1575,14 @@ dup_idf_object <- function (idd_env, idf_env, ...) {
 }
 # }}}
 # add_idf_object {{{
-add_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .all = FALSE) {
+add_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .all = FALSE, .env = parent.frame()) {
     # .null in sep_value_dots controls whether list(field = NULL) is acceptable
-    l <- sep_value_dots(..., .empty = TRUE, .null = TRUE)
+    l <- sep_value_dots(..., .empty = TRUE, .null = TRUE, .env = .env)
+
+    # stop if `:=`
+    if (any(l$dot$class)) {
+        abort("error_invalid_add_class", "`:=` can only be used when setting objects not adding.")
+    }
 
     # new object table
     obj <- get_idd_class(idd_env, setnames(l$object, "name", "class_name")$class_name, underscore = TRUE)
@@ -1682,9 +1698,9 @@ add_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .all = FALSE
 }
 # }}}
 # set_idf_object {{{
-set_idf_object <- function (idd_env, idf_env, ..., .default = TRUE) {
+set_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .env = parent.frame()) {
     # .null in sep_value_dots controls whether list(field = NULL) is acceptable
-    l <- sep_value_dots(..., .empty = FALSE, .null = TRUE)
+    l <- sep_value_dots(..., .empty = FALSE, .null = TRUE, .env = .env)
 
     obj_val <- match_set_idf_data(idd_env, idf_env, l)
     obj <- obj_val$object
@@ -1770,17 +1786,49 @@ match_set_idf_data <- function (idd_env, idf_env, l) {
     # separate
     obj_id_in <- l$object[!is.na(object_id)]
     set(obj_id_in, NULL, "object_name", NULL)
-    obj_nm_in <- l$object[is.na(object_id)]
-    set(obj_nm_in, NULL, "object_id", NULL)
+
+    # handle when trying to match whole class
+    if (nrow(l_cls <- l$dot[J(TRUE), on = "class", nomatch = 0L])) {
+        set(l_cls, NULL, "object_rleid", unlist(l_cls$object_rleid))
+        obj_nm_in <- l$object[is.na(object_id)][!l_cls, on = c("rleid", "object_rleid")]
+        set(obj_nm_in, NULL, "object_id", NULL)
+        cls_nm_in <- l$object[is.na(object_id)][!obj_nm_in, on = c("rleid", "object_rleid")]
+        set(cls_nm_in, NULL, "object_id", NULL)
+    } else {
+        obj_nm_in <- l$object[is.na(object_id)]
+        set(obj_nm_in, NULL, "object_id", NULL)
+        cls_nm_in <- obj_nm_in[0L]
+    }
 
     # get object data
     obj_id <- get_idf_object(idd_env, idf_env, object = obj_id_in$object_id)
     set(obj_id, NULL, names(obj_id_in), obj_id_in)
     obj_nm <- get_idf_object(idd_env, idf_env, object = obj_nm_in$object_name, ignore_case = TRUE)
-    set(obj_nm, NULL, names(obj_nm_in), obj_nm_in)
+    set(obj_nm, NULL, setdiff(names(obj_nm_in), "object_name"), obj_nm_in[, -"object_name"])
+
+    if (!nrow(cls_nm_in)) {
+        cls_nm <- obj_nm[0L]
+        # make sure each object can be matched in value table
+        l$value[obj_id, on = c("rleid", "object_rleid"), `:=`(object_id = i.object_id)]
+        l$value[obj_nm, on = c("rleid", "object_rleid"), `:=`(object_id = i.object_id)]
+    } else {
+        # get all objects in class
+        cls_nm <- get_idf_object(idd_env, idf_env, class = cls_nm_in$object_name, underscore = TRUE)
+        # make sure each object can be matched in object table
+        cls_nm_in[, new_rleid := .GRP, by = c("rleid", "object_rleid")]
+        cls_nm <- cls_nm[cls_nm_in[, -c("object_name")], on = c(rleid = "new_rleid")][
+            , `:=`(rleid = i.rleid, i.rleid = NULL, class_name_us = NULL)][
+            , object_rleid := seq_len(.N), by = "rleid"]
+
+        # make sure each object can be matched in value table
+        l$value[obj_id, on = c("rleid", "object_rleid"), `:=`(sgl_object_id = i.object_id)]
+        l$value[obj_nm, on = c("rleid", "object_rleid"), `:=`(sgl_object_id = i.object_id)]
+        l$value <- cls_nm[, list(rleid, object_id)][l$value, on = "rleid", allow.cartesian = TRUE][
+            !is.na(sgl_object_id), object_id := sgl_object_id]
+    }
 
     # combine
-    obj <- rbindlist(list(obj_id, obj_nm))
+    obj <- rbindlist(list(obj_id, obj_nm, cls_nm), use.names = TRUE)
 
     # update comment
     # NOTE: have to use `:=` format here as comment is a list
@@ -1794,7 +1842,7 @@ match_set_idf_data <- function (idd_env, idf_env, l) {
     set(obj, NULL, "new_rleid", rleid(obj$rleid, obj$object_rleid))
 
     # new value table
-    val <- l$value[obj[, -c("comment")], on = c("rleid", "object_rleid"), nomatch = 0L ]
+    val <- l$value[obj[, -c("comment")], on = c("rleid", "object_id"), nomatch = 0L]
 
     # clean old rleid
     set(obj, NULL, c("rleid", "object_rleid"), NULL)

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -487,6 +487,12 @@ Similar to \code{$add()}, a special element \code{.comment} in each list will be
 as the \strong{new} comments for modified object, overwriting the old ones. Names
 in list element are treated as field names.
 
+There is a special syntax \code{class := list(field = value)} in \code{$set()} has been
+added. Note the use of \code{:=} instead of \code{=}. The main difference is that,
+unlike \code{=}, the left hand side of \code{:=} should be a valid class name in
+current \code{Idf} object.  It will set the field of all objects in specified
+class to specified value.
+
 \strong{Note}:
 \itemize{
 \item You can delete a field by assigning \code{NULL} to it, e.g. \code{list(fld = NULL)} means to delete the value of field \code{fld}. If \code{.default} is FALSE,
@@ -524,13 +530,8 @@ possible. Default: \code{TRUE}.
 \item Delete field value: \code{model$set(Object_Name = list(Field_1 = NULL), .default = FALSE)}.
 \item Assign default field value: \code{model$set(Object_Name = list(Field_1 = NULL), .default = TRUE)}.
 \item Variable input: \code{a <- list(Object_Name = list(Field_1 = val1)); model$set(a, .default = TRUE)}.
-\item Set all values of field \code{fld} in a class \code{cls}:
-}\preformatted{ids <- model$object_id("cls", simplify = TRUE)
-val <- rep(list(list(fld = val)), times = length(ids))
-names(val) <- paste0("..", ids)
-model$set(val)
+\item Set all values of field \code{fld} in a class \code{cls}: \code{model$set(cls := list(fld = val))}.
 }
-
 }
 
 \subsection{Deleting Existing Objects}{\preformatted{model$del(..., .ref_by = FALSE, .ref_to = FALSE, .recursive = FALSE, .force = FALSE)

--- a/tests/testthat/test_impl-idf.R
+++ b/tests/testthat/test_impl-idf.R
@@ -581,6 +581,17 @@ test_that("VALUE DOTS", {
             defaulted = rep(FALSE, 4L)
         )
     )
+
+    # whole-class support
+    expect_silent(l <- sep_value_dots(cls1 := list(fld1 = 1, fld2 = 2)))
+    expect_equivalent(l$object,
+        data.table(rleid = 1L, object_rleid = 1L, name = "cls1", empty = FALSE, comment = list())
+    )
+    expect_equivalent(l$value,
+        data.table(rleid = 1L, object_rleid = 1L, field_name = paste0("fld", 1L:2L),
+            value_chr = c("1", "2"), value_num = c(1, 2), defaulted = rep(FALSE, 2L)
+        )
+    )
 })
 # }}}
 
@@ -744,6 +755,17 @@ test_that("Set", {
     expect_equal(nrow(set_idf_object(idd_env, idf_env,
         ..8 = list(name = "name", start_year = NULL), .default = FALSE)$value),
         11L)
+
+    # can set whole class
+    expect_silent({mat <- set_idf_object(idd_env, idf_env,
+        Material_NoMass := list(roughness = "smooth", thermal_absorptance = 0.8))})
+    expect_equivalent(mat$object,
+        data.table(object_id = c(12L, 13L), class_id = 56L, comment = list(),
+            object_name = c("R13LAYER", "R31LAYER"), object_name_lower = c("r13layer", "r31layer")
+        )
+    )
+    expect_equivalent(mat$value[field_id == 7091, value_chr], c("smooth", "smooth"))
+    expect_equivalent(mat$value[field_id == 7093, value_chr], c("0.8", "0.8"))
 })
 # }}}
 


### PR DESCRIPTION
A new syntax `class := list(field = value)` in `$set()` has been added. Note
  the use of `:=` instead of `=`. The main difference is that, unlike `=`, the
  left hand side of `:=` should be a valid class name in current `Idf` object.
  It will set the field of all objects in specified class to specified value.