### PR TITLE
Preserve .names input in `$apply_measure()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,9 @@
   distinguish different run period environment when no name is assigned.
 * `param_job()` now gives more informative error message if input `Idf` object
   and `Epw` object is not created from a local file (#112).
+* `param_job()` now preserve parametric model names from argument `.names` in
+  `$apply_measure()` instead of calling `make.name()` to convert them into valid
+  R names (#115).
 
 # eplusr 0.10.3
 

--- a/tests/testthat/test_param.R
+++ b/tests/testthat/test_param.R
@@ -58,6 +58,18 @@ test_that("Parametric methods", {
     # }}}
 
     # Save {{{
+    # can preserve name
+    param$apply_measure(set_infil_rate, seq(0, 4, by = 1), .names = 1:5)
+    expect_equal(names(param$models()), as.character(1:5))
+    expect_silent(paths <- param$save())
+    expect_equal(paths,
+        data.table::data.table(
+            model = normalizePath(file.path(tempdir(), 1:5, paste0(1:5, ".idf"))),
+            weather = normalizePath(file.path(tempdir(), 1:5, basename(param$weather()$path())))
+        )
+    )
+
+    param$apply_measure(set_infil_rate, seq(0, 4, by = 1), .names = NULL)
     expect_silent(paths <- param$save())
     expect_equal(paths,
         data.table::data.table(


### PR DESCRIPTION
This pull request tries to solve #115.

Using `make.name()` on `.names` in `$apply_measure()` will result in wired file names. In this pull request, changes are made:

* only first 100 characters are used
* `make.unique()` is called to make sure all file names are unique