### PR TITLE
Handle case when no weather are provided in `$save()` in ParametricJob.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -108,6 +108,8 @@
 * `param_job()` now preserve parametric model names from argument `.names` in
   `$apply_measure()` instead of calling `make.name()` to convert them into valid
   R names (#115).
+* `$save()` works if weather was not given during initialization for
+  `ParametricJob` (#120).
 
 # eplusr 0.10.3
 

--- a/R/param.R
+++ b/R/param.R
@@ -857,7 +857,11 @@ param_save <- function (self, private, dir = NULL, separate = TRUE, copy_externa
     uuid <- vcapply(private$m_param, function (idf) ._get_private(idf)$m_log$uuid)
 
     path_idf <- normalizePath(private$m_idf$path(), mustWork = TRUE)
-    path_epw <- normalizePath(private$m_epw$path(), mustWork = TRUE)
+    if (is.null(private$m_epw)) {
+        path_epw <- NULL
+    } else {
+        path_epw <- normalizePath(private$m_epw$path(), mustWork = TRUE)
+    }
 
     if (is.null(dir))
         dir <- dirname(path_idf)
@@ -888,7 +892,11 @@ param_save <- function (self, private, dir = NULL, separate = TRUE, copy_externa
     # save model
     path_param <- apply2_chr(private$m_param, path_param, function (x, y) x$save(y, overwrite = TRUE, copy_external = copy_external))
     # copy weather
-    path_weather <- copy_run_files(path_epw, unique(dirname(path_param)))
+    if (!is.null(path_epw)) {
+        path_epw <- copy_run_files(path_epw, unique(dirname(path_param)))
+    } else {
+        path_epw <- NA_character_
+    }
 
     # assign original uuid in case it is updated when saving
     # if not assign original here, the model modification checkings in `$run()`
@@ -898,7 +906,7 @@ param_save <- function (self, private, dir = NULL, separate = TRUE, copy_externa
         log$uuid <- uuid[[i]]
     }
 
-    data.table::data.table(model = path_param, weather = path_weather)
+    data.table::data.table(model = path_param, weather = path_epw)
 }
 # }}}
 # param_kill {{{

--- a/tests/testthat/test_param.R
+++ b/tests/testthat/test_param.R
@@ -84,6 +84,20 @@ test_that("Parametric methods", {
             weather = normalizePath(file.path(tempdir(), basename(param$weather()$path())))
         )
     )
+    # can save when no weather are provided
+    expect_silent(paths <- {
+        empty <- empty_idf()
+        empty$save(tempfile(fileext = ".idf"))
+        par <- param_job(empty, NULL)
+        par$apply_measure(function (idf, x) idf, 1:2, .names = 1:2)
+        par$save()
+    })
+    expect_equal(paths,
+        data.table::data.table(
+            model = normalizePath(file.path(tempdir(), 1:2, paste0(1:2, ".idf"))),
+            weather = NA_character_
+        )
+    )
     # }}}
 
     # Run and Status {{{


### PR DESCRIPTION
## Pull request overview

* Fixes #120
* Only save weather file if applicable in `Parametric$save()`