### PR TITLE
Add `$parent()` method in `IddObject` and `IdfObject`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,8 @@
 * Now `read_epw()` support EPW files with non-integer timezones fail to load
   (#113). `$location()` in `Epw` class also support setting the timezone to
   non-integer one.
+* A new method `$parent()` has been added in `IddObject` and `IdfObject` class
+  to get parent `Idd` and `Idf` object, respectively (#76).
 
 ## Bug fixes
 

--- a/R/idd_object.R
+++ b/R/idd_object.R
@@ -19,6 +19,7 @@ NULL
 #' iddobj <- idd$object(class)
 #' iddobj <- idd_object(idd, class)
 #' iddobj$version()
+#' iddobj$parent()
 #' iddobj$group_name()
 #' iddobj$group_index()
 #' iddobj$class_name()
@@ -70,12 +71,15 @@ NULL
 #' iddobj <- idd$object(class)
 #' iddobj <- idd_object(idd, class)
 #' iddobj$version()
+#' iddobj$parent()
 #' ```
 #'
 #' An `IddObject` can be created from the parent [Idd] object, using
 #' `$object()`, [idd_object] and other equivalent.
 #'
 #' `$version()` returns the version of parent IDD current object belongs to.
+#'
+#' `$parent()` returns the parent Idd object.
 #'
 #' **Arguments**
 #'
@@ -614,6 +618,9 @@ IddObject <- R6::R6Class(classname = "IddObject", cloneable = FALSE,
         version = function ()
             iddobj_version(self, private),
 
+        parent = function ()
+            iddobj_parent(self, private),
+
         # CLASS PROPERTY GETTERS {{{
         group_name = function ()
             iddobj_group_name(self, private),
@@ -779,6 +786,11 @@ IddObject <- R6::R6Class(classname = "IddObject", cloneable = FALSE,
 # iddobj_version {{{
 iddobj_version <- function (self, private) {
     private$idd_priv()$m_version
+}
+# }}}
+# iddobj_parent {{{
+iddobj_parent <- function (self, private) {
+    private$m_parent
 }
 # }}}
 # iddobj_group_index {{{

--- a/R/idf_object.R
+++ b/R/idf_object.R
@@ -14,6 +14,7 @@ NULL
 #' idfobj <- model$object(which)
 #' idfobj <- idf_object(model, which, class = NULL)
 #' idfobj$version()
+#' idfobj$parent()
 #' idfobj$id()
 #' idfobj$name()
 #' idfobj$class_name()
@@ -50,6 +51,7 @@ NULL
 #' idfobj <- model$object(which)
 #' idfobj <- idf_object(model, which, class = NULL)
 #' idfobj$version()
+#' idfobj$parent()
 #' idfobj$id()
 #' idfobj$name()
 #' idfobj$group_name()
@@ -58,6 +60,8 @@ NULL
 #'
 #' `$version()` returns the version of parent [Idf] object in a
 #' [numeric_version][base::numeric_version()] format.
+#'
+#' `$parent()` returns the parent [Idf] object.
 #'
 #' `$id()` returns current `IdfObject` ID.
 #'
@@ -477,6 +481,9 @@ NULL
 #' # get object name
 #' mat$name()
 #'
+#' # get parent Idf object
+#' mat$parent()
+#'
 #' # NA will be returned if the class does not have name attribute. For example,
 #' # "Version" class
 #' idf$Version$name()
@@ -806,6 +813,9 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         version = function ()
             idfobj_version(self, private),
 
+        parent = function ()
+            idfobj_parent(self, private),
+
         id = function ()
             idfobj_id(self, private),
 
@@ -927,6 +937,11 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
 # idfobj_version {{{
 idfobj_version <- function (self, private) {
     private$m_parent$version()
+}
+# }}}
+# idfobj_parent {{{
+idfobj_parent <- function (self, private) {
+    private$m_parent
 }
 # }}}
 # idfobj_id {{{

--- a/man/IddObject.Rd
+++ b/man/IddObject.Rd
@@ -21,6 +21,7 @@ meaning of each property, please see the heading comments in the
 \preformatted{iddobj <- idd$object(class)
 iddobj <- idd_object(idd, class)
 iddobj$version()
+iddobj$parent()
 iddobj$group_name()
 iddobj$group_index()
 iddobj$class_name()
@@ -72,12 +73,15 @@ print(iddobj)
 \preformatted{iddobj <- idd$object(class)
 iddobj <- idd_object(idd, class)
 iddobj$version()
+iddobj$parent()
 }
 
 An \code{IddObject} can be created from the parent \link{Idd} object, using
 \code{$object()}, \link{idd_object} and other equivalent.
 
 \code{$version()} returns the version of parent IDD current object belongs to.
+
+\code{$parent()} returns the parent Idd object.
 
 \strong{Arguments}
 \itemize{

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -16,6 +16,7 @@ parent \link{Idf} object, using \code{$object()}, \code{$objects_in_class()} and
 idfobj <- model$object(which)
 idfobj <- idf_object(model, which, class = NULL)
 idfobj$version()
+idfobj$parent()
 idfobj$id()
 idfobj$name()
 idfobj$class_name()
@@ -51,6 +52,7 @@ print(iddobj)
 \preformatted{idfobj <- model$object(which)
 idfobj <- idf_object(model, which, class = NULL)
 idfobj$version()
+idfobj$parent()
 idfobj$id()
 idfobj$name()
 idfobj$group_name()
@@ -59,6 +61,8 @@ idfobj$class_name()
 
 \code{$version()} returns the version of parent \link{Idf} object in a
 \link[base:numeric_version]{numeric_version} format.
+
+\code{$parent()} returns the parent \link{Idf} object.
 
 \code{$id()} returns current \code{IdfObject} ID.
 
@@ -476,6 +480,9 @@ mat$id()
 
 # get object name
 mat$name()
+
+# get parent Idf object
+mat$parent()
 
 # NA will be returned if the class does not have name attribute. For example,
 # "Version" class

--- a/tests/testthat/test-idfobj.R
+++ b/tests/testthat/test-idfobj.R
@@ -9,6 +9,9 @@ test_that("IdfObject class", {
     con <- idf$Construction[["WALL-1"]]
 
     # Basic {{{
+    # get parent Idf
+    expect_is(ver$parent(), "Idf")
+
     # get group name
     expect_equal(con$group_name(), "Surface Construction Elements")
 

--- a/tests/testthat/test_iddobj.R
+++ b/tests/testthat/test_iddobj.R
@@ -8,6 +8,8 @@ test_that("IddObject class", {
 
     expect_error(idd_object(), class = "error_iddobject_missing_parent")
 
+    expect_is(slash$parent(), "Idd")
+
     # Group {{{
     # can use $group_name()
     expect_equal(slash$group_name(), "TestGroup2")


### PR DESCRIPTION
## Pull request overview

* Closes #76
* Add `$parent()` method in `IddObject` and `IdfObject` to get parent `Idd` and `Idf` object.