### PR TITLE
Make sure valid file names are created before run in `ParametricJob` and `EplusGroupJob`.

### DIFF
--- a/R/group.R
+++ b/R/group.R
@@ -431,7 +431,7 @@ epgroup_run <- function (self, private, output_dir = NULL, wait = TRUE, force = 
 # }}}
 # epgroup_run_models {{{
 epgroup_run_models <- function (self, private, output_dir = NULL, wait = TRUE, force = FALSE, copy_external = FALSE, echo = wait) {
-    nms <- names(private$m_idfs)
+    nms <- make_filename(names(private$m_idfs))
     path_idf <- vcapply(private$m_idfs, function (idf) idf$path())
 
     if (is.null(private$m_epws)) {

--- a/R/param.R
+++ b/R/param.R
@@ -649,8 +649,7 @@ param_save <- function (self, private, dir = NULL, separate = TRUE, copy_externa
         )
     }
 
-    nms <- names(private$m_idfs)
-    filename <- make_filename(nms)
+    filename <- make_filename(names(private$m_idfs))
 
     if (separate) {
         path_param <- file.path(dir, filename, paste0(filename, ".idf"))


### PR DESCRIPTION
## Pull request overview

* Fixes #129
* Make sure valid file names are created before run in `ParametricJob` and `EplusGroupJob`.