### PR TITLE
Add `.empty` parameter in setting methods in `Idf` and `IdfObject`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,9 @@
   `group_job()`. `EplusGroupJob` provides a wrapper of `run_multi()` to group
   multiple EnergyPlus simulations together for running and collecting different
   EnergyPlus outputs (#117).
+* A new parameter named `.empty` has been added in `$set()`, `$insert()`,
+  `$load()`, `$update()`, `$paste()` methods in `Idf` class and `$set()` method
+  in `IdfObject` class (#133).
 
 ## Bug fixes
 

--- a/R/idf.R
+++ b/R/idf.R
@@ -61,13 +61,13 @@ NULL
 #' model[[ClassName]]
 #' model$dup(...)
 #' model$add(..., .default = TRUE, .all = FALSE)
-#' model$set(..., .default = TRUE)
+#' model$set(..., .default = TRUE, .empty = FALSE)
 #' model$del(..., .ref_by = FALSE, .ref_to = FALSE, .recursive = FALSE, .force = FALSE)
-#' model$insert(..., .unique = TRUE)
-#' model$load(..., .unique = TRUE, .default = TRUE)
-#' model$update(..., .default = TRUE)
+#' model$insert(..., .unique = TRUE, .empty = FALSE)
+#' model$load(..., .unique = TRUE, .default = TRUE, .empty = FALSE)
+#' model$update(..., .default = TRUE, .empty = FALSE)
 #' model$rename(...)
-#' model$paste(in_ip = FALSE, ver = NULL, unique = TRUE)
+#' model$paste(in_ip = FALSE, ver = NULL, unique = TRUE, empty = FALSE)
 #' model$search_value(pattern, class = NULL, ignore.case = FALSE, perl = FALSE,
 #'                    fixed = FALSE, useBytes = FALSE)
 #' model$replace_value(pattern, class = NULL, replacement, ignore.case = FALSE,
@@ -489,7 +489,7 @@ NULL
 #' \subsection{Set Values of Existing Objects}{
 #'
 #' ```
-#' model$set(..., .default = TRUE)
+#' model$set(..., .default = TRUE, .empty = FALSE)
 #' ```
 #'
 #' `$set()` takes new field value definitions in list format, sets new
@@ -520,6 +520,9 @@ NULL
 #'   the number minimum fields required for that class, it will be deleted.
 #'   Otherwise it will be left as blank. If `.default` is `TRUE`, that field
 #'   will be filled with default value if applicable and left as blank if not.
+#' * By default, trailing empty fields that are not required will be removed and
+#'   only minimum required fields are kept. You can keep the trailing empty
+#'   fields by setting `.empty` to `TRUE`.
 #' * New fields that currently do not exist in that object can also be set. They
 #'   will be automatically added on the fly.
 #' * Field name matching is **case-insensitive**. For convenience,
@@ -539,6 +542,7 @@ NULL
 #'   new comments of modified object, overwriting existing ones.
 #' * `.default`: If `TRUE`, default values are used for those blank fields if
 #'    possible. Default: `TRUE`.
+#' * `.empty`: If `TRUE`, trailing empty fields are kept. Default: `FALSE`.
 #'
 #' **Usage**:
 #'
@@ -642,7 +646,7 @@ NULL
 #' \subsection{Insert Objects}{
 #'
 #' ```
-#' model$insert(..., .unique = TRUE)
+#' model$insert(..., .unique = TRUE, .empty = FALSE)
 #' ```
 #'
 #' `$insert()` takes [IdfObject]s or lists of [IdfObject]s as input, inserts
@@ -652,6 +656,9 @@ NULL
 #'
 #' * You cannot insert an [IdfObject] which comes from a different version than
 #'   current `Idf` object.
+#' * By default, trailing empty fields that are not required will be removed and
+#'   only minimum required fields are kept. You can keep the trailing empty
+#'   fields by setting `.empty` to `TRUE`.
 #' * If input [IdfObject] has the same name as one [IdfObject] in current `Idf`
 #'   object but field values are not equal, an error may be issued if current
 #'   validation level includes conflicted-name checking. For what kind of
@@ -664,6 +671,7 @@ NULL
 #' * `.unique`: If there are duplications in input [IdfObject]s or there is same
 #'   object in current `Idf` object, duplications in input are removed. Default:
 #'   `TRUE`.
+#' * `.empty`: If `TRUE`, trailing empty fields are kept. Default: `FALSE`.
 #'
 #' **Usage**:
 #'
@@ -676,7 +684,7 @@ NULL
 #' \subsection{Load Objects from characters or data.frames}{
 #'
 #' ```
-#' model$load(..., .unique = TRUE, .default = TRUE)
+#' model$load(..., .unique = TRUE, .default = TRUE, .empty = FALSE)
 #' ```
 #'
 #' `$load()` is similar to `$insert()` except it takes directly character
@@ -724,6 +732,9 @@ NULL
 #' * `$load()` assume all definitions are from the same version as current `Idf`
 #'   object. If input definition is from different version, parsing error may
 #'   occur.
+#' * By default, trailing empty fields that are not required will be removed and
+#'   only minimum required fields are kept. You can keep the trailing empty
+#'   fields by setting `.empty` to `TRUE`.
 #'
 #' **Argument**:
 #'
@@ -733,6 +744,7 @@ NULL
 #'   object in current Idf, duplications in input are removed. Default: `TRUE`.
 #' * `.default`: If `TRUE`, default values are used for those blank fields if
 #'    possible. Default: `TRUE`.
+#' * `.empty`: If `TRUE`, trailing empty fields are kept. Default: `FALSE`.
 #'
 #' **Usage**:
 #'
@@ -767,7 +779,7 @@ NULL
 #' \subsection{Update Objects from characters or data.frames}{
 #'
 #' ```
-#' model$update(..., .unique = TRUE, .default = TRUE)
+#' model$update(..., .unique = TRUE, .default = TRUE, .empty = FALSE)
 #' ```
 #'
 #' `$update()` is similar to `$load()` except it update field values.  This
@@ -808,6 +820,9 @@ NULL
 #' * `$update()` assume all definitions are from the same version as current
 #'   `Idf` object. If input definition is from different version, parsing error
 #'   may occur.
+#' * By default, trailing empty fields that are not required will be removed and
+#'   only minimum required fields are kept. You can keep the trailing empty
+#'   fields by setting `.empty` to `TRUE`.
 #'
 #' **Argument**:
 #'
@@ -815,6 +830,7 @@ NULL
 #'   see above.
 #' * `.default`: If `TRUE`, default values are used for those blank fields if
 #'    possible. Default: `TRUE`.
+#' * `.empty`: If `TRUE`, trailing empty fields are kept. Default: `FALSE`.
 #'
 #' **Usage**:
 #'
@@ -838,7 +854,7 @@ NULL
 #' \subsection{Paste Objects from IDF Editor}{
 #'
 #' ```
-#' model$paste(in_ip = FALSE, ver = NULL, unique = TRUE)
+#' model$paste(in_ip = FALSE, ver = NULL, unique = TRUE, empty = FALSE)
 #' ```
 #'
 #' `$paste()` reads the contents (from clipboard) of copied objects from IDF
@@ -854,6 +870,9 @@ NULL
 #'   `$paste()`, or explicitly specify the version of file opened by IDF Editor
 #'   using `ver` parameter. Parsing error may occur if there is a version
 #'   mismatch.
+#' * By default, trailing empty fields that are not required will be removed and
+#'   only minimum required fields are kept. You can keep the trailing empty
+#'   fields by setting `empty` to `TRUE`.
 #'
 #' **Arguments**:
 #'
@@ -866,6 +885,7 @@ NULL
 #' * `unique`: If there are duplications in copied objects from IDF Editor or
 #'   there is same object in current Idf, duplications in input are removed.
 #'   Default: `TRUE`.
+#' * `empty`: If `TRUE`, trailing empty fields are kept. Default: `FALSE`.
 #'
 #' **Usage**:
 #'
@@ -1681,8 +1701,8 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         add = function (..., .default = TRUE, .all = FALSE)
             idf_add(self, private, ..., .default = .default, .all = .all),
 
-        set = function (..., .default = TRUE)
-            idf_set(self, private, ..., .default = .default),
+        set = function (..., .default = TRUE, .empty = FALSE)
+            idf_set(self, private, ..., .default = .default, .empty = .empty),
 
         del = function (..., .ref_by = FALSE, .ref_to = FALSE, .recursive = FALSE, .force = FALSE)
             idf_del(self, private, ..., .ref_by = .ref_by, .ref_to = .ref_to, .recursive = .recursive, .force = .force),
@@ -1690,17 +1710,17 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         rename = function (...)
             idf_rename(self, private, ...),
 
-        insert = function (..., .unique = TRUE)
-            idf_insert(self, private, ..., .unique = .unique),
+        insert = function (..., .unique = TRUE, .empty = FALSE)
+            idf_insert(self, private, ..., .unique = .unique, .empty = .empty),
 
-        load = function (..., .unique = TRUE, .default = TRUE)
-            idf_load(self, private, ..., .unique = .unique, .default = .default),
+        load = function (..., .unique = TRUE, .default = TRUE, .empty = FALSE)
+            idf_load(self, private, ..., .unique = .unique, .default = .default, .empty = .empty),
 
-        update = function (..., .default = TRUE)
-            idf_update(self, private, ..., .default = .default),
+        update = function (..., .default = TRUE, .empty = FALSE)
+            idf_update(self, private, ..., .default = .default, .empty = .empty),
 
-        paste = function (in_ip = FALSE, ver = NULL, unique = TRUE)
-            idf_paste(self, private, in_ip = in_ip, ver = ver, unique = unique),
+        paste = function (in_ip = FALSE, ver = NULL, unique = TRUE, empty = FALSE)
+            idf_paste(self, private, in_ip = in_ip, ver = ver, unique = unique, empty = empty),
 
         dup_object = function (object, new_name = NULL)
             idf_dup_object(self, private, object, new_name),
@@ -2126,8 +2146,8 @@ idf_add_object <- function (self, private, class, value = NULL, comment = NULL, 
 }
 # }}}
 # idf_set {{{
-idf_set <- function (self, private, ..., .default = TRUE, .env = parent.frame(2)) {
-    set <- set_idf_object(private$idd_env(), private$idf_env(), ..., .default = .default, .env = .env)
+idf_set <- function (self, private, ..., .default = TRUE, .empty = FALSE, .env = parent.frame(2)) {
+    set <- set_idf_object(private$idd_env(), private$idf_env(), ..., .default = .default, .empty = .empty, .env = .env)
     merge_idf_data(private$idf_env(), set, by_object = TRUE)
 
     # log
@@ -2186,8 +2206,8 @@ idf_rename <- function (self, private, ...) {
 }
 # }}}
 # idf_insert {{{
-idf_insert <- function (self, private, ..., .unique = TRUE) {
-    ins <- insert_idf_object(private$idd_env(), private$idf_env(), private$m_version, ..., .unique = .unique)
+idf_insert <- function (self, private, ..., .unique = TRUE, .empty = FALSE) {
+    ins <- insert_idf_object(private$idd_env(), private$idf_env(), private$m_version, ..., .unique = .unique, .empty = .empty)
 
     if (!nrow(ins$object)) {
         verbose_info("After deleting duplications, nothing to add.")
@@ -2243,9 +2263,9 @@ idf_replace_value <- function (self, private, pattern, replacement, class = NULL
 }
 # }}}
 # idf_paste {{{
-idf_paste <- function (self, private, in_ip = FALSE, ver = NULL, unique = TRUE) {
+idf_paste <- function (self, private, in_ip = FALSE, ver = NULL, unique = TRUE, empty = FALSE) {
     pas <- paste_idf_object(private$idd_env(), private$idf_env(),
-        version = private$m_version, in_ip = in_ip, unique = unique
+        version = private$m_version, in_ip = in_ip, unique = unique, empty = empty
     )
 
     if (!nrow(pas$object)) {
@@ -2264,9 +2284,9 @@ idf_paste <- function (self, private, in_ip = FALSE, ver = NULL, unique = TRUE) 
 }
 # }}}
 # idf_load {{{
-idf_load <- function (self, private, ..., .unique = TRUE, .default = TRUE) {
+idf_load <- function (self, private, ..., .unique = TRUE, .default = TRUE, .empty = FALSE) {
     l <- load_idf_object(private$idd_env(), private$idf_env(), private$m_version,
-        ..., .unique = .unique, .default = .default
+        ..., .unique = .unique, .default = .default, .empty = .empty
     )
 
     if (!nrow(l$object)) {
@@ -2285,9 +2305,9 @@ idf_load <- function (self, private, ..., .unique = TRUE, .default = TRUE) {
 }
 # }}}
 # idf_update {{{
-idf_update <- function (self, private, ..., .default = TRUE) {
+idf_update <- function (self, private, ..., .default = TRUE, .empty = FALSE) {
     l <- update_idf_object(private$idd_env(), private$idf_env(), private$m_version,
-        ..., .default = .default
+        ..., .default = .default, .empty = .empty
     )
 
     merge_idf_data(private$idf_env(), l, by_object = TRUE)

--- a/R/idf_object.R
+++ b/R/idf_object.R
@@ -25,7 +25,7 @@ NULL
 #' idfobj$value_possible(which = NULL, type = c("auto", "default", "choice", "range", "source"))
 #' idfobj$FieldName
 #' idfobj[[Field]]
-#' idfobj$set(..., .defaults = TRUE)
+#' idfobj$set(..., .defaults = TRUE. .empty = FALSE)
 #' idfobj$FieldName <- Value
 #' idfobj[[Field]] <- Value
 #' idfobj$value_relation(which = NULL, direction = c("all", "ref_to", "ref_by", "node"),
@@ -203,7 +203,7 @@ NULL
 #'
 #' @section Set Field Values:
 #' \preformatted{
-#' idfobj$set(..., .default = TRUE)
+#' idfobj$set(..., .default = TRUE, .empty = FALSE)
 #' idfobj$FieldName <- Value
 #' idfobj[[Field]] <- Value
 #' }
@@ -224,6 +224,9 @@ NULL
 #'   the number minimum fields required for that class, it will be deleted.
 #'   Otherwise it will be left as blank. If `.default` is `TRUE`, that field
 #'   will be filled with default value if applicable and left as blank if not.
+#' * By default, trailing empty fields that are not required will be removed and
+#'   only minimum required fields are kept. You can keep the trailing empty
+#'   fields by setting `.empty` to `TRUE`.
 #' * New fields that currently do not exist in that object can also be set. They
 #'   will be automatically added on the fly.
 #' * Field name matching is **case-insensitive**. For convenience,
@@ -250,6 +253,7 @@ NULL
 #'   ```
 #' * `.default`: If `TRUE`, default values are used for those blank fields if
 #'    possible. Default: `TRUE`.
+#' * `.empty`: If `TRUE`, trailing empty fields are kept. Default: `FALSE`.
 #' * `FieldName`: A single length character vector of one valid field name where
 #'     all characters except letters and numbers are replaced by underscores.
 #' * `Field`: A single length character vector of one valid field name or a
@@ -846,8 +850,8 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         get_value = function (which = NULL, all = FALSE, simplify = FALSE, unit = FALSE)
             idfobj_get_value(self, private, which, all, simplify, unit),
 
-        set = function (..., .default = TRUE)
-            idfobj_set(self, private, ..., .default = .default),
+        set = function (..., .default = TRUE, .empty = FALSE)
+            idfobj_set(self, private, ..., .default = .default, .empty = .empty),
 
         set_value = function (..., .default = TRUE)
             idfobj_set_value(self, private, ..., .default = .default),
@@ -1018,9 +1022,9 @@ idfobj_get_value <- function (self, private, which = NULL, all = FALSE, simplify
 }
 # }}}
 # idfobj_set {{{
-idfobj_set <- function (self, private, ..., .default = TRUE) {
+idfobj_set <- function (self, private, ..., .default = TRUE, .empty = FALSE) {
     set <- set_idfobj_value(private$idd_env(), private$idf_env(),
-        private$m_object_id, ..., .default = .default
+        private$m_object_id, ..., .default = .default, .empty = .empty
     )
     merge_idf_data(private$idf_env(), set, by_object = TRUE)
 

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -1736,9 +1736,9 @@ add_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .all = FALSE
 }
 # }}}
 # set_idf_object {{{
-set_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .env = parent.frame()) {
+set_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .empty = FALSE, .env = parent.frame()) {
     # .null in sep_value_dots controls whether list(field = NULL) is acceptable
-    l <- sep_value_dots(..., .empty = FALSE, .null = TRUE, .env = .env)
+    l <- sep_value_dots(..., .empty = .empty, .null = TRUE, .env = .env)
 
     obj_val <- match_set_idf_data(idd_env, idf_env, l)
     obj <- obj_val$object
@@ -1804,7 +1804,7 @@ set_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .env = paren
 
     # delete fields
     add_joined_cols(idd_env$class, val, "class_id", c("min_fields", "num_extensible"))
-    val <- remove_empty_fields(val)
+    if (!.empty) val <- remove_empty_fields(val)
 
     # validate
     assert_valid(idd_env, idf_env, obj, val, action = "set")
@@ -2154,7 +2154,7 @@ rename_idf_object <- function (idd_env, idf_env, ...) {
 }
 # }}}
 # insert_idf_object {{{
-insert_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE) {
+insert_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE, .empty = FALSE) {
     l <- sep_object_dots(...)
     ver <- version
     input <- l$data
@@ -2210,7 +2210,7 @@ insert_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE) {
 
     # remove empty fields
     add_class_property(idd_env, val, c("min_fields", "num_extensible"))
-    val <- remove_empty_fields(val)
+    if (!.empty) val <- remove_empty_fields(val)
 
     # remove duplicated objects
     if (.unique) {
@@ -2237,7 +2237,7 @@ insert_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE) {
 }
 # }}}
 # paste_idf_object {{{
-paste_idf_object <- function (idd_env, idf_env, version, in_ip = FALSE, unique = TRUE, default = TRUE) {
+paste_idf_object <- function (idd_env, idf_env, version, in_ip = FALSE, unique = TRUE, default = TRUE, empty = FALSE) {
     parsed <- read_idfeditor_copy(version, in_ip)
 
     # add class name
@@ -2254,7 +2254,7 @@ paste_idf_object <- function (idd_env, idf_env, version, in_ip = FALSE, unique =
     # delete empty fields
     add_joined_cols(idd_env$class, parsed$value, "class_id", c("min_fields", "num_extensible"))
     add_field_property(idd_env, parsed$value, "required_field")
-    parsed$value <- remove_empty_fields(parsed$value)
+    if (!empty) parsed$value <- remove_empty_fields(parsed$value)
 
     # add rleid for validation and message printing
     add_rleid(parsed$object)
@@ -2310,7 +2310,7 @@ paste_idf_object <- function (idd_env, idf_env, version, in_ip = FALSE, unique =
 }
 # }}}
 # load_idf_object {{{
-load_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE, .default = TRUE) {
+load_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE, .default = TRUE, .empty = FALSE) {
     l <- sep_definition_dots(..., .version = version)
 
     prop <- c("is_name", "required_field", "src_enum", "type_enum", "extensible_group")
@@ -2454,7 +2454,7 @@ load_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE, .de
 
     # delete fields
     add_joined_cols(idd_env$class, parsed$value, "class_id", c("min_fields", "num_extensible"))
-    parsed$value <- remove_empty_fields(parsed$value)
+    if (!.empty) parsed$value <- remove_empty_fields(parsed$value)
 
     # validate
     assert_valid(idd_env, idf_env, parsed$object, parsed$value, action = "add")
@@ -2482,7 +2482,7 @@ load_idf_object <- function (idd_env, idf_env, version, ..., .unique = TRUE, .de
 }
 # }}}
 # update_idf_object {{{
-update_idf_object <- function (idd_env, idf_env, version, ..., .default = TRUE) {
+update_idf_object <- function (idd_env, idf_env, version, ..., .default = TRUE, .empty = FALSE) {
     l <- sep_definition_dots(..., .version = version, .update = TRUE)
 
     prop <- c("is_name", "required_field", "src_enum", "type_enum", "extensible_group")
@@ -2709,7 +2709,7 @@ update_idf_object <- function (idd_env, idf_env, version, ..., .default = TRUE) 
 
     # delete fields
     add_joined_cols(idd_env$class, val, "class_id", c("min_fields", "num_extensible"))
-    val <- remove_empty_fields(val)
+    if (!.empty) val <- remove_empty_fields(val)
 
     # validate
     assert_valid(idd_env, idf_env, obj, val, action = "set")

--- a/R/impl-idfobj.R
+++ b/R/impl-idfobj.R
@@ -104,7 +104,7 @@ get_value_list <- function (dt_value, unit = FALSE) {
 }
 # }}}
 # set_idfobj_value {{{
-set_idfobj_value <- function (idd_env, idf_env, object, ..., .default = TRUE) {
+set_idfobj_value <- function (idd_env, idf_env, object, ..., .default = TRUE, .empty = FALSE) {
     nm <- if (is_count(object)) paste0("..", object) else object
 
     input <- list(...)
@@ -148,7 +148,7 @@ set_idfobj_value <- function (idd_env, idf_env, object, ..., .default = TRUE) {
 
     setattr(input, "names", nm)
 
-    set_idf_object(idd_env, idf_env, input, .default = .default)
+    set_idf_object(idd_env, idf_env, input, .default = .default, .empty = .empty)
 }
 # }}}
 # get_idfobj_possible {{{

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -63,13 +63,13 @@ model$ClassName
 model[[ClassName]]
 model$dup(...)
 model$add(..., .default = TRUE, .all = FALSE)
-model$set(..., .default = TRUE)
+model$set(..., .default = TRUE, .empty = FALSE)
 model$del(..., .ref_by = FALSE, .ref_to = FALSE, .recursive = FALSE, .force = FALSE)
-model$insert(..., .unique = TRUE)
-model$load(..., .unique = TRUE, .default = TRUE)
-model$update(..., .default = TRUE)
+model$insert(..., .unique = TRUE, .empty = FALSE)
+model$load(..., .unique = TRUE, .default = TRUE, .empty = FALSE)
+model$update(..., .default = TRUE, .empty = FALSE)
 model$rename(...)
-model$paste(in_ip = FALSE, ver = NULL, unique = TRUE)
+model$paste(in_ip = FALSE, ver = NULL, unique = TRUE, empty = FALSE)
 model$search_value(pattern, class = NULL, ignore.case = FALSE, perl = FALSE,
                    fixed = FALSE, useBytes = FALSE)
 model$replace_value(pattern, class = NULL, replacement, ignore.case = FALSE,
@@ -475,7 +475,7 @@ model$add(x)
 
 }
 
-\subsection{Set Values of Existing Objects}{\preformatted{model$set(..., .default = TRUE)
+\subsection{Set Values of Existing Objects}{\preformatted{model$set(..., .default = TRUE, .empty = FALSE)
 }
 
 \code{$set()} takes new field value definitions in list format, sets new
@@ -506,6 +506,9 @@ also \code{fld} is not a required field and the index of \code{fld} is larger th
 the number minimum fields required for that class, it will be deleted.
 Otherwise it will be left as blank. If \code{.default} is \code{TRUE}, that field
 will be filled with default value if applicable and left as blank if not.
+\item By default, trailing empty fields that are not required will be removed and
+only minimum required fields are kept. You can keep the trailing empty
+fields by setting \code{.empty} to \code{TRUE}.
 \item New fields that currently do not exist in that object can also be set. They
 will be automatically added on the fly.
 \item Field name matching is \strong{case-insensitive}. For convenience,
@@ -526,6 +529,7 @@ There is a special element \code{.comment} in each list, which will be used as
 new comments of modified object, overwriting existing ones.
 \item \code{.default}: If \code{TRUE}, default values are used for those blank fields if
 possible. Default: \code{TRUE}.
+\item \code{.empty}: If \code{TRUE}, trailing empty fields are kept. Default: \code{FALSE}.
 }
 
 \strong{Usage}:
@@ -621,7 +625,7 @@ model$rename(a, b)
 
 }
 
-\subsection{Insert Objects}{\preformatted{model$insert(..., .unique = TRUE)
+\subsection{Insert Objects}{\preformatted{model$insert(..., .unique = TRUE, .empty = FALSE)
 }
 
 \code{$insert()} takes \link{IdfObject}s or lists of \link{IdfObject}s as input, inserts
@@ -631,6 +635,9 @@ them into current Idf, and returns a list of inserted \link{IdfObject}s.
 \itemize{
 \item You cannot insert an \link{IdfObject} which comes from a different version than
 current \code{Idf} object.
+\item By default, trailing empty fields that are not required will be removed and
+only minimum required fields are kept. You can keep the trailing empty
+fields by setting \code{.empty} to \code{TRUE}.
 \item If input \link{IdfObject} has the same name as one \link{IdfObject} in current \code{Idf}
 object but field values are not equal, an error may be issued if current
 validation level includes conflicted-name checking. For what kind of
@@ -644,6 +651,7 @@ validation components to be performed during modifications, please see
 \item \code{.unique}: If there are duplications in input \link{IdfObject}s or there is same
 object in current \code{Idf} object, duplications in input are removed. Default:
 \code{TRUE}.
+\item \code{.empty}: If \code{TRUE}, trailing empty fields are kept. Default: \code{FALSE}.
 }
 
 \strong{Usage}:
@@ -655,7 +663,7 @@ object in current \code{Idf} object, duplications in input are removed. Default:
 }
 }
 
-\subsection{Load Objects from characters or data.frames}{\preformatted{model$load(..., .unique = TRUE, .default = TRUE)
+\subsection{Load Objects from characters or data.frames}{\preformatted{model$load(..., .unique = TRUE, .default = TRUE, .empty = FALSE)
 }
 
 \code{$load()} is similar to \code{$insert()} except it takes directly character
@@ -706,6 +714,9 @@ if there is any duplication in the \code{index} column.
 \item \code{$load()} assume all definitions are from the same version as current \code{Idf}
 object. If input definition is from different version, parsing error may
 occur.
+\item By default, trailing empty fields that are not required will be removed and
+only minimum required fields are kept. You can keep the trailing empty
+fields by setting \code{.empty} to \code{TRUE}.
 }
 
 \strong{Argument}:
@@ -716,6 +727,7 @@ see above.
 object in current Idf, duplications in input are removed. Default: \code{TRUE}.
 \item \code{.default}: If \code{TRUE}, default values are used for those blank fields if
 possible. Default: \code{TRUE}.
+\item \code{.empty}: If \code{TRUE}, trailing empty fields are kept. Default: \code{FALSE}.
 }
 
 \strong{Usage}:
@@ -743,7 +755,7 @@ model$load(dt)
 
 }
 
-\subsection{Update Objects from characters or data.frames}{\preformatted{model$update(..., .unique = TRUE, .default = TRUE)
+\subsection{Update Objects from characters or data.frames}{\preformatted{model$update(..., .unique = TRUE, .default = TRUE, .empty = FALSE)
 }
 
 \code{$update()} is similar to \code{$load()} except it update field values.  This
@@ -787,6 +799,9 @@ be performed during modifications, please see \code{\link[=level_checks]{level_c
 \item \code{$update()} assume all definitions are from the same version as current
 \code{Idf} object. If input definition is from different version, parsing error
 may occur.
+\item By default, trailing empty fields that are not required will be removed and
+only minimum required fields are kept. You can keep the trailing empty
+fields by setting \code{.empty} to \code{TRUE}.
 }
 
 \strong{Argument}:
@@ -795,6 +810,7 @@ may occur.
 see above.
 \item \code{.default}: If \code{TRUE}, default values are used for those blank fields if
 possible. Default: \code{TRUE}.
+\item \code{.empty}: If \code{TRUE}, trailing empty fields are kept. Default: \code{FALSE}.
 }
 
 \strong{Usage}:
@@ -811,7 +827,7 @@ model$update(dt)
 
 }
 
-\subsection{Paste Objects from IDF Editor}{\preformatted{model$paste(in_ip = FALSE, ver = NULL, unique = TRUE)
+\subsection{Paste Objects from IDF Editor}{\preformatted{model$paste(in_ip = FALSE, ver = NULL, unique = TRUE, empty = FALSE)
 }
 
 \code{$paste()} reads the contents (from clipboard) of copied objects from IDF
@@ -827,6 +843,9 @@ version than current IDF. Please check the version before running
 \code{$paste()}, or explicitly specify the version of file opened by IDF Editor
 using \code{ver} parameter. Parsing error may occur if there is a version
 mismatch.
+\item By default, trailing empty fields that are not required will be removed and
+only minimum required fields are kept. You can keep the trailing empty
+fields by setting \code{empty} to \code{TRUE}.
 }
 
 \strong{Arguments}:
@@ -840,6 +859,7 @@ Default: \code{NULL}.
 \item \code{unique}: If there are duplications in copied objects from IDF Editor or
 there is same object in current Idf, duplications in input are removed.
 Default: \code{TRUE}.
+\item \code{empty}: If \code{TRUE}, trailing empty fields are kept. Default: \code{FALSE}.
 }
 
 \strong{Usage}:

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -27,7 +27,7 @@ idfobj$value(which = NULL, all = FALSE, simplify = FALSE, unit = FALSE)
 idfobj$value_possible(which = NULL, type = c("auto", "default", "choice", "range", "source"))
 idfobj$FieldName
 idfobj[[Field]]
-idfobj$set(..., .defaults = TRUE)
+idfobj$set(..., .defaults = TRUE. .empty = FALSE)
 idfobj$FieldName <- Value
 idfobj[[Field]] <- Value
 idfobj$value_relation(which = NULL, direction = c("all", "ref_to", "ref_by", "node"),
@@ -214,7 +214,7 @@ returned. Should be one of or a combination of \code{"auto"}, \code{"default"},
 \section{Set Field Values}{
 
 \preformatted{
-idfobj$set(..., .default = TRUE)
+idfobj$set(..., .default = TRUE, .empty = FALSE)
 idfobj$FieldName <- Value
 idfobj[[Field]] <- Value
 }
@@ -233,6 +233,9 @@ also \code{fld} is not a required field and the index of \code{fld} is larger th
 the number minimum fields required for that class, it will be deleted.
 Otherwise it will be left as blank. If \code{.default} is \code{TRUE}, that field
 will be filled with default value if applicable and left as blank if not.
+\item By default, trailing empty fields that are not required will be removed and
+only minimum required fields are kept. You can keep the trailing empty
+fields by setting \code{.empty} to \code{TRUE}.
 \item New fields that currently do not exist in that object can also be set. They
 will be automatically added on the fly.
 \item Field name matching is \strong{case-insensitive}. For convenience,
@@ -258,6 +261,7 @@ list in format\preformatted{list(field1 = value1, field2 = value2)
 }
 \item \code{.default}: If \code{TRUE}, default values are used for those blank fields if
 possible. Default: \code{TRUE}.
+\item \code{.empty}: If \code{TRUE}, trailing empty fields are kept. Default: \code{FALSE}.
 \item \code{FieldName}: A single length character vector of one valid field name where
 all characters except letters and numbers are replaced by underscores.
 \item \code{Field}: A single length character vector of one valid field name or a

--- a/tests/testthat/test_idf.R
+++ b/tests/testthat/test_idf.R
@@ -266,6 +266,14 @@ test_that("Idf class", {
         ), .default = FALSE)
     )
     expect_equal(length(idf$RunPeriod$rp_test_4$value()), 11)
+    expect_silent(
+        idf$set(rp_test_4 = list(start_year = NULL), .default = FALSE, .empty = TRUE)
+    )
+    expect_equal(length(idf$RunPeriod$rp_test_4$value()), 14)
+    expect_silent(
+        idf$set(rp_test_4 = list(start_year = NULL), .default = FALSE, .empty = FALSE)
+    )
+    expect_equal(length(idf$RunPeriod$rp_test_4$value()), 11)
     # }}}
 
     # INSERT {{{


### PR DESCRIPTION
## Pull request overview

* Closes #133
* Add `.empty` parameter in setting methods in `Idf` and `IdfObject`.

``` r
idf <- empty_idf(9.0)
#> IDD v9.0.0 has not been parsed before.
#> Try to locate `Energy+.idd` in EnergyPlus v9.0.0 installation folder '/usr/local/EnergyPlus-9-0-0'.
#> IDD file found: '/usr/local/EnergyPlus-9-0-0/Energy+.idd'.
#> Start parsing...
#> Parsing completed.
eplusr_option(validate_level = "draft")
#> $validate_level
#> [1] "draft"
str_rp <- idf$definition("RunPeriod")$to_string(all = TRUE)
str_rp
#>  [1] "RunPeriod,"                                                                
#>  [2] "    ,                        !- Name"                                      
#>  [3] "    ,                        !- Begin Month"                               
#>  [4] "    ,                        !- Begin Day of Month"                        
#>  [5] "    ,                        !- Begin Year"                                
#>  [6] "    ,                        !- End Month"                                 
#>  [7] "    ,                        !- End Day of Month"                          
#>  [8] "    ,                        !- End Year"                                  
#>  [9] "    ,                        !- Day of Week for Start Day"                 
#> [10] "    ,                        !- Use Weather File Holidays and Special Days"
#> [11] "    ,                        !- Use Weather File Daylight Saving Period"   
#> [12] "    ,                        !- Apply Weekend Holiday Rule"                
#> [13] "    ,                        !- Use Weather File Rain Indicators"          
#> [14] "    ,                        !- Use Weather File Snow Indicators"          
#> [15] "    ;                        !- Treat Weather as Actual"
```

A new parameter named `.empty` has been added in `$set()`, `$insert()`,  `$load()`, `$update()`, `$paste()` methods in `Idf` class and `$set()` method in `IdfObject` class.

All trailing empty fields can be kept by setting `.empty` to TRUE

```r
idf$load(str_rp, .default = FALSE, .empty = TRUE)
# $<NA>
# <IdfObject: 'RunPeriod'> [ID:2]
# Class: <RunPeriod>
# ├─ 01: <"Blank">,  !- Name
# │─ 02: <Blank>,    !- Begin Month
# │─ 03: <Blank>,    !- Begin Day of Month
# │─ 04: <Blank>,    !- Begin Year
# │─ 05: <Blank>,    !- End Month
# │─ 06: <Blank>,    !- End Day of Month
# │─ 07: <Blank>,    !- End Year
# │─ 08: <"Blank">,  !- Day of Week for Start Day
# │─ 09: <"Blank">,  !- Use Weather File Holidays and Special Days
# │─ 10: <"Blank">,  !- Use Weather File Daylight Saving Period
# │─ 11: <"Blank">,  !- Apply Weekend Holiday Rule
# │─ 12: <"Blank">,  !- Use Weather File Rain Indicators
# │─ 13: <"Blank">,  !- Use Weather File Snow Indicators
# └─ 14: <"Blank">;  !- Treat Weather as Actual
# 
```