### PR TITLE
Keep the original rleid before matching value in `$add()`

### DIFF
--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -355,11 +355,15 @@ sep_value_dots <- function (..., .empty = !in_final_mode(), .scalar = TRUE, .nul
             dt_unnmd <- flatten(dt[!dot_nmd])
             dt_multi <- dt[len_nm > 1L & dot_nmd][, {
                 len <- each_length(object_rleid)
+                object_rleid <- unlist(object_rleid)
+                dot_nm <- unlist(lapply(dot_nm, function (x) if (is.numeric(x)) paste0("..", x) else x))
+                if (is.null(object_rleid)) object_rleid <- integer()
+                if (is.null(dot_nm)) dot_nm <- character()
                 list(rleid = rep(rleid, len),
-                     object_rleid = unlist(object_rleid),
+                     object_rleid = object_rleid,
                      dep = rep(dep, len),
                      dot = rep(dot, len),
-                     dot_nm = unlist(lapply(dot_nm, function (x) if (is.numeric(x)) paste0("..", x) else x))
+                     dot_nm = dot_nm
                 )
             }]
 

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -1624,8 +1624,8 @@ add_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .all = FALSE
 
     # new object table
     obj <- get_idd_class(idd_env, setnames(l$object, "name", "class_name")$class_name, underscore = TRUE)
-    set(obj, NULL, c("object_rleid", "comment", "empty"),
-        l$object[obj$rleid, .SD, .SDcols = c("object_rleid", "comment", "empty")]
+    set(obj, NULL, c("rleid", "object_rleid", "comment", "empty"),
+        l$object[obj$rleid, .SD, .SDcols = c("rleid", "object_rleid", "comment", "empty")]
     )
 
     # stop if cannot add objects in specified classes


### PR DESCRIPTION
## Pull request overview

* Fixes #141
* Keep the original rleid before matching value in `$add()`, otherwise object value matching could be wrong.