### PR TITLE
Reuse input epw when only one is supplied in GroupEplusJob

### DIFF
--- a/R/group.R
+++ b/R/group.R
@@ -776,6 +776,7 @@ get_epgroup_input <- function (idfs, epws) {
 
     # check length
     if (!is.null(epws)) {
+        if (length(epws) == 1L) epws <- replicate(length(idfs), epws[[1L]]$clone())
         assert(have_same_len(idfs, epws))
         nm_epw <- tools::file_path_sans_ext(basename(vcapply(epws, function (epw) epw$path())))
         setattr(epws, "names", make.unique(nm_epw, "_"))

--- a/R/group.R
+++ b/R/group.R
@@ -304,8 +304,10 @@ NULL
 #' @examples
 #' if (is_avail_eplus(8.8)) {
 #'     dir <- eplus_config(8.8)$dir
-#'     path_idfs <- list.files(file.path(dir, "ExampleFiles"), "\\.idf")[1:5]
-#'     path_epws <- list.files(file.path(dir, "WeatherData"), "\\.epw")[1:5]
+#'     path_idfs <- list.files(file.path(dir, "ExampleFiles"), "\\.idf",
+#'         full.names = TRUE)[1:5]
+#'     path_epws <- list.files(file.path(dir, "WeatherData"), "\\.epw",
+#'         full.names = TRUE)[1:5]
 #'
 #'     # create from local files
 #'     group <- group_job(path_idfs, path_epws)

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -355,11 +355,15 @@ sep_value_dots <- function (..., .empty = !in_final_mode(), .scalar = TRUE, .nul
             dt_unnmd <- flatten(dt[!dot_nmd])
             dt_multi <- dt[len_nm > 1L & dot_nmd][, {
                 len <- each_length(object_rleid)
+                object_rleid <- unlist(object_rleid)
+                dot_nm <- unlist(lapply(dot_nm, function (x) if (is.numeric(x)) paste0("..", x) else x))
+                if (is.null(object_rleid)) object_rleid <- integer()
+                if (is.null(dot_nm)) dot_nm <- character()
                 list(rleid = rep(rleid, len),
-                     object_rleid = unlist(object_rleid),
+                     object_rleid = object_rleid,
                      dep = rep(dep, len),
                      dot = rep(dot, len),
-                     dot_nm = unlist(lapply(dot_nm, function (x) if (is.numeric(x)) paste0("..", x) else x))
+                     dot_nm = dot_nm
                 )
             }]
 

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -1624,8 +1624,8 @@ add_idf_object <- function (idd_env, idf_env, ..., .default = TRUE, .all = FALSE
 
     # new object table
     obj <- get_idd_class(idd_env, setnames(l$object, "name", "class_name")$class_name, underscore = TRUE)
-    set(obj, NULL, c("object_rleid", "comment", "empty"),
-        l$object[obj$rleid, .SD, .SDcols = c("object_rleid", "comment", "empty")]
+    set(obj, NULL, c("rleid", "object_rleid", "comment", "empty"),
+        l$object[obj$rleid, .SD, .SDcols = c("rleid", "object_rleid", "comment", "empty")]
     )
 
     # stop if cannot add objects in specified classes

--- a/man/group_job.Rd
+++ b/man/group_job.Rd
@@ -27,8 +27,10 @@ For details on \code{EplusGroupJob}, please see \link{EplusGroupJob} class.
 \examples{
 if (is_avail_eplus(8.8)) {
     dir <- eplus_config(8.8)$dir
-    path_idfs <- list.files(file.path(dir, "ExampleFiles"), "\\\\.idf")[1:5]
-    path_epws <- list.files(file.path(dir, "WeatherData"), "\\\\.epw")[1:5]
+    path_idfs <- list.files(file.path(dir, "ExampleFiles"), "\\\\.idf",
+        full.names = TRUE)[1:5]
+    path_epws <- list.files(file.path(dir, "WeatherData"), "\\\\.epw",
+        full.names = TRUE)[1:5]
 
     # create from local files
     group <- group_job(path_idfs, path_epws)

--- a/tests/testthat/test_group.R
+++ b/tests/testthat/test_group.R
@@ -12,6 +12,7 @@ test_that("Group methods", {
         "\\.epw", full.names = TRUE)[1:5]
 
     expect_error(group_job(empty_idf(8.8)), class = "error_idf_not_local")
+    expect_silent(group_job(path_idfs, path_epws[1L]))
     expect_silent(grp <- group_job(path_idfs, NULL))
     expect_equal(grp$status(),
         list(run_before = FALSE, alive = FALSE, terminated = NA,


### PR DESCRIPTION
## Pull request overview

* Closes #144
* Reuse input epw when only one is supplied in GroupEplusJob.