### PR TITLE
Manual remove IDF class active bindings before cloning

### DIFF
--- a/R/idf.R
+++ b/R/idf.R
@@ -1706,6 +1706,18 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
 # set deep default value to `TRUE`
 formals(Idf$clone_method)$deep <- TRUE
 formals(Idf$public_methods$clone)$deep <- TRUE
+
+# Manually remove IDF clss active bindings before cloning. See #164
+b <- as.list(body(Idf$clone_method))
+b <- as.call(c(
+    list(b[[1]],
+         quote(enclosing <- .subset2(self, ".__enclos_env__")),
+         quote(rm(list = grep("^[A-Z]", names(enclosing$self), value = TRUE), envir = enclosing$self))
+    ),
+    b[-1]
+))
+body(Idf$clone_method) <- b
+body(Idf$public_methods$clone) <- b
 # }}}
 
 # idf_version {{{

--- a/tic.R
+++ b/tic.R
@@ -9,7 +9,12 @@ build_args <- c("--force")
 # https://github.com/travis-ci/travis-ci/issues/7875
 if (.Platform$OS.type == "windows" || Sys.getenv("TRAVIS_OS_NAME") == "osx") args <- c("--no-manual", args)
 
-do_package_checks(args = args, build_args = build_args)
+# test with specific R6 version
+# see #164
+get_stage("before_install") %>%
+    tic::add_code_step(remotes::install_github("r-lib/R6@rc-v2.4.1"))
+
+tic::do_package_checks(args = args, build_args = build_args)
 
 # pkgdown
 # make sure to clean site to rebuild everything


### PR DESCRIPTION
## Pull request overview

* Fixes #164.

It's a hack. Directly insert two lines into the default `$clone()` method. Most of the time, this should be fine, as these two lines have nothing to do with the actual behavior of `$clone()`, but just to remove custom active bindings.