### PR TITLE
Make `autocomplete` option work for `Idd` and `Idf`

### DIFF
--- a/R/idd.R
+++ b/R/idd.R
@@ -567,6 +567,23 @@ idd_print <- function (self, private) {
 # }}}
 
 #' @export
+# [[.Idd {{{
+`[[.Idd` <- function (x, i) {
+    if (i %chin% ls(x)) return(NextMethod())
+
+    private <- ._get_private(x)
+
+    cls_id <- chmatch(i, private$m_idd_env$class$class_name)
+
+    # skip if not a valid IDD class name
+    if (is.na(cls_id)) return(NextMethod())
+
+    cls_nm <- private$m_idd_env$class$class_name[cls_id]
+    .subset2(x, "object")(cls_nm)
+}
+# }}}
+
+#' @export
 # $.Idd {{{
 `$.Idd` <- function (x, i) {
     if (i %chin% ls(x)) return(NextMethod())

--- a/R/idd.R
+++ b/R/idd.R
@@ -354,6 +354,8 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE, lock_objects = FALSE,
 
 # add_idd_class_bindings {{{
 add_idd_class_bindings <- function (idd) {
+    if (!.options$autocomplete) return(idd)
+
     # get all classes in current version IDD
     env <- .subset2(idd, ".__enclos_env__")
     self <- .subset2(env, "self")

--- a/R/idf.R
+++ b/R/idf.R
@@ -2609,6 +2609,8 @@ read_idf <- function (path, idd = NULL) {
 
 # add_idf_class_bindings {{{
 add_idf_class_bindings <- function (idf, class_id = NULL, update = FALSE) {
+    if (!.options$autocomplete) return(idf)
+
     # get all classes in current version IDD
     env <- .subset2(idf, ".__enclos_env__")
     self <- .subset2(env, "self")

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,1 @@
-comment: false
+comment: true

--- a/tests/testthat/test_idd.R
+++ b/tests/testthat/test_idd.R
@@ -143,7 +143,7 @@ test_that("Idd class", {
 
     # can get single object using S3 method
     expect_equal(idd$TestSlash, idd$object("TestSlash"))
-    expect_equal(idd[["TestSlash"]], idd$object("TestSlash"))
+    if (.options$autocomplete) expect_equal(idd[["TestSlash"]], idd$object("TestSlash"))
 
     expect_is(idd$object("TestSlash"), "IddObject")
     expect_is(idd$objects_in_group("TestGroup1")[[1L]], "IddObject")

--- a/tests/testthat/test_idd.R
+++ b/tests/testthat/test_idd.R
@@ -46,6 +46,7 @@ test_that("can read IDD", {
 
 # Idd class {{{
 test_that("Idd class", {
+    .options$autocomplete <- TRUE
     # can create an Idd object from string
     expect_silent(idd <- use_idd(text("idd", "9.9.9")))
 
@@ -143,7 +144,7 @@ test_that("Idd class", {
 
     # can get single object using S3 method
     expect_equal(idd$TestSlash, idd$object("TestSlash"))
-    if (.options$autocomplete) expect_equal(idd[["TestSlash"]], idd$object("TestSlash"))
+    expect_equal(idd[["TestSlash"]], idd$object("TestSlash"))
 
     expect_is(idd$object("TestSlash"), "IddObject")
     expect_is(idd$objects_in_group("TestGroup1")[[1L]], "IddObject")

--- a/tests/testthat/test_idf.R
+++ b/tests/testthat/test_idf.R
@@ -406,7 +406,7 @@ test_that("Idf class", {
     idf <- read_idf(example())
 
     # UNIQUE-OBJECT CLASS {{{
-    expect_true("SimulationControl" %in% names(idf))
+    if (.options$autocomplete) expect_true("SimulationControl" %in% names(idf))
 
     # get data.frame input
     tbl <- idf$SimulationControl$to_table()
@@ -431,11 +431,11 @@ test_that("Idf class", {
     expect_true(idf$is_valid_class("SimulationControl"))
     expect_silent(idf$SimulationControl <- NULL)
     expect_silent(idf$SimulationControl <- str)
-    expect_true("SimulationControl" %in% names(idf))
+    if (.options$autocomplete) expect_true("SimulationControl" %in% names(idf))
     # }}}
 
     # NORMAL CLASS {{{
-    expect_true("Material" %in% names(idf))
+    if (.options$autocomplete) expect_true("Material" %in% names(idf))
 
     # get data.frame input
     tbl <- idf$to_table(class = "Material")

--- a/tests/testthat/test_idf.R
+++ b/tests/testthat/test_idf.R
@@ -403,10 +403,11 @@ test_that("Idf class", {
     # }}}
 
     # ACTIVE BINDINGS {{{
+    .options$autocomplete <- TRUE
     idf <- read_idf(example())
 
     # UNIQUE-OBJECT CLASS {{{
-    if (.options$autocomplete) expect_true("SimulationControl" %in% names(idf))
+    expect_true("SimulationControl" %in% names(idf))
 
     # get data.frame input
     tbl <- idf$SimulationControl$to_table()
@@ -431,11 +432,11 @@ test_that("Idf class", {
     expect_true(idf$is_valid_class("SimulationControl"))
     expect_silent(idf$SimulationControl <- NULL)
     expect_silent(idf$SimulationControl <- str)
-    if (.options$autocomplete) expect_true("SimulationControl" %in% names(idf))
+    expect_true("SimulationControl" %in% names(idf))
     # }}}
 
     # NORMAL CLASS {{{
-    if (.options$autocomplete) expect_true("Material" %in% names(idf))
+    expect_true("Material" %in% names(idf))
 
     # get data.frame input
     tbl <- idf$to_table(class = "Material")

--- a/tests/testthat/test_options.R
+++ b/tests/testthat/test_options.R
@@ -17,7 +17,7 @@ test_that("eplusr_option()", {
     expect_equal(eplusr_option(autocomplete = TRUE), list(autocomplete = TRUE))
 
     expect_equal(eplusr_option(),
-        list(autocomplete = interactive(),
+        list(autocomplete = TRUE,
              num_parallel = 8L,
              save_format = "asis",
              validate_level = "final",

--- a/tests/testthat/test_options.R
+++ b/tests/testthat/test_options.R
@@ -14,6 +14,7 @@ test_that("eplusr_option()", {
     expect_equal(eplusr_option(save_format = "asis"), list(save_format = "asis"))
     expect_equal(eplusr_option(num_parallel = 8L), list(num_parallel = 8L))
     expect_equal(eplusr_option(verbose_info = TRUE), list(verbose_info = TRUE))
+    expect_equal(eplusr_option(autocomplete = TRUE), list(autocomplete = TRUE))
 
     expect_equal(eplusr_option(),
         list(autocomplete = interactive(),


### PR DESCRIPTION
Previously, `autocomplete` only works for `IdfObject`. This PR make sure it works for `Idd` and `Idf` class.