### PR TITLE
Support one-line-formatted IDF version with trailing comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -121,6 +121,8 @@
   (#110).
 * Now `leading` and `sep_at` argument work as expected in `Idf$to_string()` (#160).
 * Now `Idf$to_table()` matches object names case-insensitively (#157).
+* One-line-formatted `Version` object with trailing comments can be successfully
+  parsed, e.g. `Version, 8.6; !- ABC` (#170).
 
 ## Minor changes
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -321,7 +321,7 @@ get_idf_ver <- function (idf_dt, empty_removed = TRUE) {
     reg_ver <- "(\\d+\\.\\d+(?:\\.\\d+)*)"
     set(ver_line_spe, NULL, "version",
         stri_match_first_regex(
-            ver_line_spe$string, paste0("Version\\s*,\\s*", reg_ver, "\\s*;\\s*!.*$"),
+            ver_line_spe$string, paste0("Version\\s*,\\s*", reg_ver, "\\s*;(?:\\s*!.*)*$"),
             opts_regex = stringi::stri_opts_regex(case_insensitive = TRUE)
         )[, 2L]
     )

--- a/R/parse.R
+++ b/R/parse.R
@@ -321,7 +321,7 @@ get_idf_ver <- function (idf_dt, empty_removed = TRUE) {
     reg_ver <- "(\\d+\\.\\d+(?:\\.\\d+)*)"
     set(ver_line_spe, NULL, "version",
         stri_match_first_regex(
-            ver_line_spe$string, paste0("Version\\s*,\\s*", reg_ver, "\\s*;$"),
+            ver_line_spe$string, paste0("Version\\s*,\\s*", reg_ver, "\\s*;\\s*!.*$"),
             opts_regex = stringi::stri_opts_regex(case_insensitive = TRUE)
         )[, 2L]
     )

--- a/tests/testthat/test_parse.R
+++ b/tests/testthat/test_parse.R
@@ -261,6 +261,23 @@ test_that("parse_idd_file()", {
 
 # parse_idf_file() {{{
 test_that("parse_idf_file()", {
+    # get version {{{
+    # Normal formatted
+    expect_equal(
+        get_idf_ver(data.table(string = c("Version,", "8.6;"), line = 1:2)),
+        numeric_version(8.6)
+    )
+    # One line formatted
+    expect_equal(
+        get_idf_ver(data.table(string = "Version, 8.6;", line = 1)),
+        numeric_version(8.6)
+    )
+    expect_equal(
+        get_idf_ver(data.table(string = "Version, 8.6; !- Version", line = 1)),
+        numeric_version(8.6)
+    )
+    # }}}
+
     expect_warning(idf_parsed <- parse_idf_file(text("idf"), 8.8),
         "Missing version field in input IDF"
     )


### PR DESCRIPTION
## Pull request overview

* Fixes #170 

Previously, in order to speed up IDF version parsing, `get_idf_ver()` assumes that there are no trailing comments after semicolon `;` in version object if it is formatted in one line, e.g. `Version, 8.6;` which is the default behavior of IDF Editor. However, some third-party software, such as DesignBuilder, a trailing comment `!- Version Identifier` is added. This leads to parse errors in `parse_idf_file()`. This PR fixes this.