### PR TITLE
Do not manually change encoding of input string

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -111,12 +111,6 @@ read_lines <- function(input, trim = TRUE, ...) {
     if (!nrow(dt)) return(data.table(string = character(0L), line = integer(0L)))
     set(dt, j = "line", value = seq_along(dt[["string"]]))
 
-    # fix encoding issue in older versions of IDD files
-    dt[!stringi::stri_enc_isutf8(string), string := tryCatch(
-        stringi::stri_encode(string, "windows-1252", "UTF-8"),
-        error = function (e) string
-    )]
-
     if (trim) set(dt, j = "string", value = stri_trim_both(dt[["string"]]))
     setcolorder(dt, c("line", "string"))
 


### PR DESCRIPTION
## Pull request overview

Previously, `read_lines()` will try to assume that all invalid `UTF-8` strings are encoded in `windows-1252` and re-encoded to `UTF-8`.

This introduces some wired characters in `transition()` and `version_updater()`. This PR removes encoding handling in `read_lines()`.