### PR TITLE
Not overwrite year column when adding/setting new epw data

### DIFF
--- a/R/impl-epw.R
+++ b/R/impl-epw.R
@@ -2840,7 +2840,6 @@ check_epw_new_data <- function (epw_data, epw_header, data, target_period, other
     )
 
     # update datetime components
-    set(data, NULL, "year", as.integer(lubridate::year(data$datetime)))
     set(data, NULL, c("month", "day", "hour", "minute"),
         create_epw_datetime_components(start, end, interval, leapyear = leapyear)[, -"year"]
     )

--- a/R/impl-epw.R
+++ b/R/impl-epw.R
@@ -1705,7 +1705,7 @@ match_epw_data_period <- function (epw_data, data_period, interval, leapyear, wa
     abnormal <- find_epw_data_abnormal_line(data, offset = from - 1L, warning,
         period_name = paste0("#", data_period$index, " ", surround(data_period$name),
             " (", 60/interval, " mins interval)"
-        )
+        ), from = from
     )
 
     # update datetime and minute column {{{
@@ -1844,7 +1844,7 @@ match_epw_data_datetime <- function (epw_data, index, name, start, end, interval
 }
 # }}}
 # find_epw_data_abnormal_line {{{
-find_epw_data_abnormal_line <- function (epw_data, offset = 0L, warning = FALSE, period_name = NULL) {
+find_epw_data_abnormal_line <- function (epw_data, offset = 0L, warning = FALSE, period_name = NULL, from = 0L) {
     # data period name for reporting
     nm <- if (is.null(period_name)) "." else paste0(" for data period ", period_name, ".")
 
@@ -1975,7 +1975,7 @@ find_epw_data_na_line <- function (epw_data, offset = 0L, warning = FALSE, perio
                 paste0("NA found in data", nm),
                 data = add_epw_raw_string(.SD[ln_na]),
                 num = length(unlist(na, use.names = FALSE)),
-                post = paste0("At ", combine_date(year[ln_na], month[ln_na], day[ln_miss], hour[ln_miss]), ": ", mes_miss),
+                post = paste0("At ", combine_date(year[ln_na], month[ln_na], day[ln_na], hour[ln_na]), ": ", mes_na),
                 stop = FALSE
             )
         }
@@ -2722,8 +2722,8 @@ set_epw_data <- function (epw_data, epw_header, data, realyear = FALSE,
 # }}}
 # check_epw_new_data {{{
 check_epw_new_data <- function (epw_data, epw_header, data, target_period, other_periods,
-                                  reset = FALSE, realyear = FALSE, name = NULL,
-                                  start_day_of_week = NULL, warning = TRUE) {
+                                reset = FALSE, realyear = FALSE, name = NULL,
+                                start_day_of_week = NULL, warning = TRUE) {
     # get current data period and other periods
     p <- epw_header$period$period[target_period]
     p_other <- epw_header$period$period[other_periods]
@@ -2737,7 +2737,7 @@ check_epw_new_data <- function (epw_data, epw_header, data, target_period, other
     # check datetime column type first, then others
     assert(inherits(data$datetime, "POSIXct"),
         msg = paste0("Column `datetime` of input data should be `POSIXct` class, not ",
-            surround(class(data$datetime)[[1L]]), "class."
+            surround(class(data$datetime)[[1L]]), " class."
         )
     )
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -236,7 +236,7 @@ validate_on_level <- function (idd_env, idf_env, dt_object = NULL, dt_value = NU
 # @param dt_object A data.table that contains object data to validate. If
 #        `NULL`, the object data from `idf_env` will be used, which means to
 #        validate the whole IDF.
-# @param dt_object A data.table that contains value data to validate. If
+# @param dt_value A data.table that contains value data to validate. If
 #        `NULL`, the value data from `idf_env` will be used, which means to
 #        validate the whole IDF.
 # @param required_object Whether to check if required objects are missing. This

--- a/tests/testthat/test_epw.R
+++ b/tests/testthat/test_epw.R
@@ -154,8 +154,11 @@ test_that("Epw class", {
     expect_silent(epw$purge())
 
     epw <- read_epw(path_epw)
+    # keep input year values
+    y <- epw$data()$year
     # can change weather data
     expect_silent(epw$set(epw$data(), warning = FALSE))
+    expect_equal(epw$data()$year, y)
     expect_error(epw$add(epw$data(), warning = FALSE), class = "error_epw_data_overlap")
     expect_error(epw$add(epw$data(start_year = 2016L), realyear = TRUE, warning = FALSE), class = "error_invalid_epw_data_date")
     expect_silent(epw$add(epw$data(start_year = 2018L), realyear = TRUE, warning = FALSE))


### PR DESCRIPTION
## Pull request overview

Previously, `year` column will overwritten by `datetime` year value.

https://github.com/hongyuanjia/eplusr/blob/3b5db0d8192cfae9934fa76f94c23d85ed48a9a3/R/impl-epw.R#L2843
``` r
library(eplusr)
epw <- read_epw("~/.local/EnergyPlus-8-8-0/WeatherData/USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")

data <- epw$data()
summary(data$year)
#>    Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
#>    1976    1994    1996    1993    1998    2004

epw$set(data)
#> Warning: EPW PARSING WARNING.
#> ════════════════════════════════════════════════════════════════════════════════
#> [Warning Type]: Missing data found for data period #1 `Data` (60 mins interval).
#> [Total Number]: 6500
#> ── Location ────────────────────────────────────────────────────────────────────
#> Line 208: 2017,1,9,16,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9,...
#> Line 225: 2017,1,10,9,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9,...
#> Line 226: 2017,1,10,10,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9...
#> Line 227: 2017,1,10,11,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9...
#> Line 228: 2017,1,10,12,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9...
#> Line 229: 2017,1,10,13,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9...
#> Line 230: 2017,1,10,14,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9...
#> Line 231: 2017,1,10,15,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9?9*9*9?9*9*9...
#> Line 745: 2017,2,1,1,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9?9?9?9*_*9*9*9*9*9,7...
#> Line 746: 2017,2,1,2,0,?9?9?9?9E0?9?9?9?9?9?9?9?9?9?9?9*9?9?9*_*9*9*9*9*9,7...
#> ...[truncated. First 10 are shown.]
#> ── Detail ──────────────────────────────────────────────────────────────────────
#> At 2017/1/9 16:XX: liquid precip depth is missing
#> At 2017/1/10 09:XX: liquid precip depth is missing
#> At 2017/1/10 10:XX: liquid precip depth is missing
#> At 2017/1/10 11:XX: liquid precip depth is missing
#> At 2017/1/10 12:XX: liquid precip depth is missing
#> At 2017/1/10 13:XX: liquid precip depth is missing
#> At 2017/1/10 14:XX: liquid precip depth is missing
#> At 2017/1/10 15:XX: liquid precip depth is missing
#> At 2017/2/1 01:XX: liquid precip depth is missing
#> At 2017/2/1 02:XX: liquid precip depth is missing
#> ...[truncated. First 10 are shown.]
#> ════════════════════════════════════════════════════════════════════════════════
#> ── Info ────────────────────────────────────────────────────────────────────────
#> Data period #1 has been replaced with input data.
#>      Name StartDayOfWeek StartDay EndDay
#>  1:  Data         Sunday     1/ 1  12/31

summary(epw$data()$year)
#>    Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
#>    2017    2017    2017    2017    2017    2018
```

<sup>Created on 2020-01-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This PR fixes it.