### PR TITLE
Fix encoding error when parsing old IDD

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -120,7 +120,7 @@ read_lines <- function(input, trim = TRUE, ...) {
 
                 # fix encoding issue in older versions of IDD files
                 dt[!stringi::stri_enc_isutf8(string), string :=
-                    stringi::stri_encode(string, "windows-1252", "UTF-8"),
+                    stringi::stri_encode(string, "windows-1252", "UTF-8")
                 ]
 
                 set(dt, j = "string", value = stri_trim_both(dt[["string"]]))

--- a/R/utils.R
+++ b/R/utils.R
@@ -111,7 +111,23 @@ read_lines <- function(input, trim = TRUE, ...) {
     if (!nrow(dt)) return(data.table(string = character(0L), line = integer(0L)))
     set(dt, j = "line", value = seq_along(dt[["string"]]))
 
-    if (trim) set(dt, j = "string", value = stri_trim_both(dt[["string"]]))
+    if (trim) {
+        tryCatch(set(dt, j = "string", value = stri_trim_both(dt[["string"]])),
+            error = function (e) {
+                if (!grepl("invalid UTF-8 byte sequence detected", conditionMessage(e), fixed = TRUE)) {
+                    signalCondition(e)
+                }
+
+                # fix encoding issue in older versions of IDD files
+                dt[!stringi::stri_enc_isutf8(string), string :=
+                    stringi::stri_encode(string, "windows-1252", "UTF-8"),
+                ]
+
+                set(dt, j = "string", value = stri_trim_both(dt[["string"]]))
+            }
+        )
+    }
+
     setcolorder(dt, c("line", "string"))
 
     dt

--- a/tests/testthat/test_group.R
+++ b/tests/testthat/test_group.R
@@ -4,7 +4,7 @@ test_that("Group methods", {
     skip_on_cran()
     eplusr_option(verbose_info = FALSE)
 
-    if (!is_avail_eplus(8.8)) install_eplus(8.8)
+    if (!is_avail_eplus(8.8)) install_eplus(8.8, local = TRUE)
 
     path_idfs <- list.files(file.path(eplus_config(8.8)$dir, "ExampleFiles"),
         "\\.idf", full.names = TRUE)[1:5]

--- a/tests/testthat/test_idd.R
+++ b/tests/testthat/test_idd.R
@@ -43,7 +43,7 @@ test_that("can read IDD", {
     expect_true(is_avail_idd("9.9.9"))
 
     # can parse old IDD
-    expect_silent(use_idd(8.1, download = "auto"))
+    expect_warning(use_idd(8.1, download = "auto"))
 })
 # }}}
 

--- a/tests/testthat/test_idd.R
+++ b/tests/testthat/test_idd.R
@@ -41,6 +41,9 @@ test_that("can read IDD", {
 
     expect_silent(use_idd(text("idd", "9.9.9")))
     expect_true(is_avail_idd("9.9.9"))
+
+    # can parse old IDD
+    expect_silent(use_idd(8.1, download = "auto"))
 })
 # }}}
 

--- a/tests/testthat/test_job.R
+++ b/tests/testthat/test_job.R
@@ -3,7 +3,7 @@ context("Job methods")
 test_that("Job methods", {
     eplusr_option(verbose_info = FALSE)
     skip_on_cran()
-    if (!is_avail_eplus(8.8)) install_eplus(8.8)
+    if (!is_avail_eplus(8.8)) install_eplus(8.8, local = TRUE)
 
     example <- copy_example()
 

--- a/tests/testthat/test_param.R
+++ b/tests/testthat/test_param.R
@@ -4,7 +4,7 @@ test_that("Parametric methods", {
     skip_on_cran()
     eplusr_option(verbose_info = FALSE)
 
-    if (!is_avail_eplus(8.8)) install_eplus(8.8)
+    if (!is_avail_eplus(8.8)) install_eplus(8.8, local = TRUE)
 
     expect_error(param_job(empty_idf(8.8), NULL), class = "error_idf_not_local")
 

--- a/tests/testthat/test_rdd.R
+++ b/tests/testthat/test_rdd.R
@@ -2,7 +2,7 @@ context("Rdd")
 
 test_that("Rdd", {
     skip_on_cran()
-    if (!is_avail_eplus(8.8)) install_eplus(8.8)
+    if (!is_avail_eplus(8.8)) install_eplus(8.8, local = TRUE)
 
     idf <- read_idf(example())
     job <- idf$run(NULL, dir = tempdir(), echo = FALSE)

--- a/tests/testthat/test_sql.R
+++ b/tests/testthat/test_sql.R
@@ -2,7 +2,7 @@ context("Sql methods")
 
 test_that("Sql methods", {
     skip_on_cran()
-    if (!is_avail_eplus(8.8)) install_eplus(8.8)
+    if (!is_avail_eplus(8.8)) install_eplus(8.8, local = TRUE)
 
     example <- copy_example()
     idf <- read_idf(example$idf)


### PR DESCRIPTION
## Pull request overview

In old IDD, the IDD files were created on a `windows-1252` locale, which will cause errors when triming string.

``` r
idd <- eplusr::use_idd(8.1)
#> IDD v8.1.0 has not been parsed before.
#> Try to locate `Energy+.idd` in EnergyPlus v8.1.0 installation folder '/usr/local/EnergyPlus-8-1-0'.
#> Failed to locate `Energy+.idd` because EnergyPlus v8.1.0 is not available.
#> Try to locate `V8-1-0-Energy+.idd` in EnergyPlus v9.1.0 IDFVersionUpdater folder '~/.local/EnergyPlus-9-1-0/PreProcess/IDFVersionUpdater'. --> Succeeded
#> IDD file found: '/home/hongyuanjia/.local/EnergyPlus-9-1-0/PreProcess/IDFVersionUpdater/V8-1-0-Energy+.idd'.
#> Start parsing...
#> Error in stri_trim_both(dt[["string"]]): invalid UTF-8 byte sequence detected; try calling stri_enc_toutf8()
```

<sup>Created on 2020-01-16 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Example invalid characters are shown blow
```
 [1] "N13, \\field Young\x92s modulus"
 [2] "N14; \\field Poisson\x92s ratio"
 [3] "\\note and flat. Crown=0.0625x\x93Slat width\x94"
```

This PR fixes it.