### PR TITLE
Add `case`, `wide` and `string_value` par in `EplusSql$tabular_data()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,6 +101,17 @@
   Please see `?install_eplus` for details.
 * All documentation in R6 classes have been update thanks to roxyten2 R6 support (#156).
 * Deprecated methods in each class have all been remove (#156).
+* New parameter `case` has been added in
+  `EplusSql$tabular_data()`. Similar like `case` paramter in
+  `EplusSql$report_data()`, it lets you to add a `case` column to indicate the
+  case of simulation. This brings some changes in the returned results of
+  `EplusSql$tabular_data()`. Compared to previous version, there will always be
+  a `case` column, unless `case` parameter is set to `NULL` (#182).
+* New parameter `wide` and `string_value` have been added in
+  `EplusSql$tabular_data()` and `EplusGroupJob$tabular_data()`. When `wide` is
+  `TRUE`, each table will be converted into the similar format as it is shown in
+  EnergyPlus HTML output file. And when `string_value` is `FALSE`, values in
+  possible numeric columns are converted into numbers (#182).
 
 ## Bug fixes
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -233,7 +233,7 @@ str(results)
 all(weekdays(results$datetime) == results$day_type)
 
 # get tabular data
-job$tabular_data(table_name = "site and source energy", row_name = "total site energy")
+job$tabular_data(table_name = "site and source energy", row_name = "total site energy", wide = TRUE)
 ```
 
 ```{r del_job, include = FALSE}

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ idf <- read_idf(system.file("extdata/1ZoneUncontrolled.idf", package = "eplusr")
 # print idf
 idf
 #> ── EnergPlus Input Data File ───────────────────────────────────────────────────
-#>  * Path: '/tmp/RtmprrcDIJ/temp_libpath2117415c8234/eplusr/extdata/1ZoneUnco...
+#>  * Path: '/tmp/RtmpKBABCZ/temp_libpath32e07f6ab0f9/eplusr/extdata/1ZoneUnco...
 #>  * Version: '8.8.0'
 #> 
 #> Group: <Simulation Parameters>
@@ -372,12 +372,12 @@ weekdays(weather$datetime)
 # run simulation
 job <- idf$run(epw)
 #> Adding an object in class `Output:SQLite` and setting its `Option Type` to `SimpleAndTabular` in order to create SQLite output file.
-#> Replace the existing IDF located at /tmp/RtmprrcDIJ/model.idf.
+#> Replace the existing IDF located at /tmp/RtmpKBABCZ/model.idf.
 #> ExpandObjects Started.
 #> No expanded file generated.
 #> ExpandObjects Finished. Time:     0.000
 #> EnergyPlus Starting
-#> EnergyPlus, Version 8.8.0-7c3bbe4830, YMD=2020.01.19 18:03
+#> EnergyPlus, Version 8.8.0-7c3bbe4830, YMD=2020.01.20 02:50
 #> Processing Data Dictionary
 #> Processing Input File
 #> Initializing Simulation
@@ -411,7 +411,7 @@ job <- idf$run(epw)
 job$errors()
 #> ══ EnergyPlus Error File ═══════════════════════════════════════════════════════
 #>   * EnergyPlus version: 8.8.0 (7c3bbe4830)
-#>   * Simulation started: 2020-01-19 18:03:00
+#>   * Simulation started: 2020-01-20 02:50:00
 #>   * Terminated: FALSE
 #>   * Successful: TRUE
 #>   * Warning[W]: 2
@@ -462,19 +462,16 @@ all(weekdays(results$datetime) == results$day_type)
 #> [1] TRUE
 
 # get tabular data
-job$tabular_data(table_name = "site and source energy", row_name = "total site energy")
-#>    index                             report_name      report_for
-#> 1:     1 AnnualBuildingUtilityPerformanceSummary Entire Facility
-#> 2:     5 AnnualBuildingUtilityPerformanceSummary Entire Facility
-#> 3:     9 AnnualBuildingUtilityPerformanceSummary Entire Facility
-#>                table_name                          column_name
-#> 1: Site and Source Energy                         Total Energy
-#> 2: Site and Source Energy       Energy Per Total Building Area
-#> 3: Site and Source Energy Energy Per Conditioned Building Area
-#>             row_name units        value
-#> 1: Total Site Energy    GJ        89.81
-#> 2: Total Site Energy MJ/m2       386.67
-#> 3: Total Site Energy MJ/m2
+job$tabular_data(table_name = "site and source energy", row_name = "total site energy", wide = TRUE)
+#> $`AnnualBuildingUtilityPerformanceSummary.Entire Facility.Site and Source Energy`
+#>     case                             report_name      report_for
+#> 1: model AnnualBuildingUtilityPerformanceSummary Entire Facility
+#>                table_name          row_name
+#> 1: Site and Source Energy Total Site Energy
+#>    Energy Per Conditioned Building Area [MJ/m2]
+#> 1:                                             
+#>    Energy Per Total Building Area [MJ/m2] Total Energy [GJ]
+#> 1:                                 386.67             89.81
 ```
 
 ## Acknowledgement

--- a/man/EplusGroupJob.Rd
+++ b/man/EplusGroupJob.Rd
@@ -202,6 +202,15 @@ str(group$tabular_data(c(1, 4),
     column_name = "Total Energy",
     row_name = "Total Site Energy"
 ))
+
+# get tabular data in wide format and coerce numeric values
+str(group$tabular_data(c(1, 4),
+    report_name = "AnnualBuildingUtilityPerformanceSummary",
+    table_name = "Site and Source Energy",
+    column_name = "Total Energy",
+    row_name = "Total Site Energy",
+    wide = TRUE, string_value = FALSE
+))
 }
 
 
@@ -1030,7 +1039,9 @@ Read tabular data
   report_for = NULL,
   table_name = NULL,
   column_name = NULL,
-  row_name = NULL
+  row_name = NULL,
+  wide = FALSE,
+  string_value = !wide
 )}\if{html}{\out{</div>}}
 }
 
@@ -1045,6 +1056,20 @@ parametric simulations are returned. Default: \code{NULL}.}
 a character vector for subsetting when querying the SQL
 database.  For the meaning of each argument, please see the
 description above.}
+
+\item{\code{wide}}{If \code{TRUE}, each table will be converted into the similar
+format as it is shown in EnergyPlus HTML output file. Default:
+\code{FALSE}.}
+
+\item{\code{string_value}}{Only applicable when \code{wide} is \code{TRUE}. If
+\code{string_value} is \code{FALSE}, instead of keeping all values as
+characters, values in possible numeric columns are converted
+into numbers. Default: the opposite of \code{wide}. Possible
+numeric columns indicate column that:
+\itemize{
+\item columns that have associated units
+\item columns that contents numbers
+}}
 }
 \if{html}{\out{</div>}}
 }
@@ -1063,7 +1088,7 @@ output from different simulations
 \item \code{column_name}: The name of the column that the record belongs to
 \item \code{row_name}: The name of the row that the record belongs to
 \item \code{units}: The units of the record
-\item \code{value}: The value of the record \strong{in string format}
+\item \code{value}: The value of the record \strong{in string format} by default
 }
 
 For convenience, input character arguments matching in
@@ -1071,7 +1096,10 @@ For convenience, input character arguments matching in
 }
 
 \subsection{Returns}{
-A \code{\link[data.table:data.table]{data.table::data.table()}} with 8 columns.
+A \code{\link[data.table:data.table]{data.table::data.table()}} with 9 columns (when \code{wide} is
+\code{FALSE}) or a named list of \code{\link[data.table:data.table]{data.table::data.table()}}s where the
+names are the combination of \code{report_name}, \code{report_for} and
+\code{table_name}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1085,6 +1113,15 @@ str(group$tabular_data(c(1, 4),
     table_name = "Site and Source Energy",
     column_name = "Total Energy",
     row_name = "Total Site Energy"
+))
+
+# get tabular data in wide format and coerce numeric values
+str(group$tabular_data(c(1, 4),
+    report_name = "AnnualBuildingUtilityPerformanceSummary",
+    table_name = "Site and Source Energy",
+    column_name = "Total Energy",
+    row_name = "Total Site Energy",
+    wide = TRUE, string_value = FALSE
 ))
 }
 

--- a/man/EplusJob.Rd
+++ b/man/EplusJob.Rd
@@ -246,6 +246,15 @@ str(job$tabular_data(
     column_name = "Total Energy",
     row_name = "Total Site Energy"
 ))
+
+# get tabular data in wide format and coerce numeric values
+str(job$tabular_data(
+    report_name = "AnnualBuildingUtilityPerformanceSummary",
+    table_name = "Site and Source Energy",
+    column_name = "Total Energy",
+    row_name = "Total Site Energy",
+    wide = TRUE, string_value = FALSE
+))
 }
 
 
@@ -1075,7 +1084,9 @@ Read tabular data
   report_for = NULL,
   table_name = NULL,
   column_name = NULL,
-  row_name = NULL
+  row_name = NULL,
+  wide = FALSE,
+  string_value = !wide
 )}\if{html}{\out{</div>}}
 }
 
@@ -1086,6 +1097,20 @@ Read tabular data
 a character vector for subsetting when querying the SQL
 database.  For the meaning of each argument, please see the
 description above.}
+
+\item{\code{wide}}{If \code{TRUE}, each table will be converted into the similar
+format as it is shown in EnergyPlus HTML output file. Default:
+\code{FALSE}.}
+
+\item{\code{string_value}}{Only applicable when \code{wide} is \code{TRUE}. If
+\code{string_value} is \code{FALSE}, instead of keeping all values as
+characters, values in possible numeric columns are converted
+into numbers. Default: the opposite of \code{wide}. Possible
+numeric columns indicate column that:
+\itemize{
+\item columns that have associated units
+\item columns that contents numbers
+}}
 }
 \if{html}{\out{</div>}}
 }
@@ -1093,8 +1118,9 @@ description above.}
 \verb{$tabular_data()} extracts the tabular data in a
 \code{\link[data.table:data.table]{data.table::data.table()}} using report, table, column and row name
 specifications. The returned \code{\link[data.table:data.table]{data.table::data.table()}} has
-8 columns:
+9 columns:
 \itemize{
+\item \code{case}: Simulation case specified using \code{case} argument
 \item \code{index}: Tabular data index
 \item \code{report_name}: The name of the report that the record belongs to
 \item \code{report_for}: The \code{For} text that is associated with the record
@@ -1102,7 +1128,7 @@ specifications. The returned \code{\link[data.table:data.table]{data.table::data
 \item \code{column_name}: The name of the column that the record belongs to
 \item \code{row_name}: The name of the row that the record belongs to
 \item \code{units}: The units of the record
-\item \code{value}: The value of the record \strong{in string format}
+\item \code{value}: The value of the record \strong{in string format} by default
 }
 
 For convenience, input character arguments matching in
@@ -1110,7 +1136,10 @@ For convenience, input character arguments matching in
 }
 
 \subsection{Returns}{
-A \code{\link[data.table:data.table]{data.table::data.table()}} with 8 columns.
+A \code{\link[data.table:data.table]{data.table::data.table()}} with 8 columns (when \code{wide} is
+\code{FALSE}) or a named list of \code{\link[data.table:data.table]{data.table::data.table()}}s where the
+names are the combination of \code{report_name}, \code{report_for} and
+\code{table_name}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1124,6 +1153,15 @@ str(job$tabular_data(
     table_name = "Site and Source Energy",
     column_name = "Total Energy",
     row_name = "Total Site Energy"
+))
+
+# get tabular data in wide format and coerce numeric values
+str(job$tabular_data(
+    report_name = "AnnualBuildingUtilityPerformanceSummary",
+    table_name = "Site and Source Energy",
+    column_name = "Total Energy",
+    row_name = "Total Site Energy",
+    wide = TRUE, string_value = FALSE
 ))
 }
 

--- a/man/EplusSql.Rd
+++ b/man/EplusSql.Rd
@@ -159,6 +159,15 @@ str(sql$tabular_data(
     column_name = "Total Energy",
     row_name = "Total Site Energy"
 ))
+
+# get tabular data in wide format and coerce numeric values
+str(sql$tabular_data(
+    report_name = "AnnualBuildingUtilityPerformanceSummary",
+    table_name = "Site and Source Energy",
+    column_name = "Total Energy",
+    row_name = "Total Site Energy",
+    wide = TRUE, string_value = FALSE
+))
 }
 
 
@@ -449,9 +458,10 @@ restriction for each environment. Default: \code{NULL}.}
 \item{\code{tz}}{Time zone of date time in column \code{datetime}. Default:
 \code{"UTC"}.}
 
-\item{\code{case}}{If not \code{NULL}, a character column will be added indicates
-the case of this simulation. If \code{"auto"}, the name of the IDF
-file without extension is used.}
+\item{\code{case}}{A single string used to add a character column \code{case} in
+the returned results to indicate the case of this simulation.
+If \code{NULL}, no column is added. If \code{"auto"}, the name of the
+IDF file without extension is used. Default: \code{"auto"}.}
 
 \item{\code{all}}{If \code{TRUE}, extra columns are also included in the returned
 \code{\link[data.table:data.table]{data.table::data.table()}}.}
@@ -638,7 +648,10 @@ Read tabular data
   report_for = NULL,
   table_name = NULL,
   column_name = NULL,
-  row_name = NULL
+  row_name = NULL,
+  case = "auto",
+  wide = FALSE,
+  string_value = !wide
 )}\if{html}{\out{</div>}}
 }
 
@@ -649,6 +662,25 @@ Read tabular data
 a character vector for subsetting when querying the SQL
 database.  For the meaning of each argument, please see the
 description above.}
+
+\item{\code{case}}{A single string used to add a character column \code{case} in
+the returned results to indicate the case of this simulation.
+If \code{NULL}, no column is added. If \code{"auto"}, the name of the
+IDF file without extension is used. Default: \code{"auto"}.}
+
+\item{\code{wide}}{If \code{TRUE}, each table will be converted into the similar
+format as it is shown in EnergyPlus HTML output file. Default:
+\code{FALSE}.}
+
+\item{\code{string_value}}{Only applicable when \code{wide} is \code{TRUE}. If
+\code{string_value} is \code{FALSE}, instead of keeping all values as
+characters, values in possible numeric columns are converted
+into numbers. Default: the opposite of \code{wide}. Possible
+numeric columns indicate column that:
+\itemize{
+\item columns that have associated units
+\item columns that contents numbers
+}}
 }
 \if{html}{\out{</div>}}
 }
@@ -656,8 +688,9 @@ description above.}
 \verb{$tabular_data()} extracts the tabular data in a
 \code{\link[data.table:data.table]{data.table::data.table()}} using report, table, column and row name
 specifications. The returned \code{\link[data.table:data.table]{data.table::data.table()}} has
-8 columns:
+9 columns:
 \itemize{
+\item \code{case}: Simulation case specified using \code{case} argument
 \item \code{index}: Tabular data index
 \item \code{report_name}: The name of the report that the record belongs to
 \item \code{report_for}: The \code{For} text that is associated with the record
@@ -665,7 +698,7 @@ specifications. The returned \code{\link[data.table:data.table]{data.table::data
 \item \code{column_name}: The name of the column that the record belongs to
 \item \code{row_name}: The name of the row that the record belongs to
 \item \code{units}: The units of the record
-\item \code{value}: The value of the record \strong{in string format}
+\item \code{value}: The value of the record \strong{in string format} by default.
 }
 
 For convenience, input character arguments matching in
@@ -673,7 +706,10 @@ For convenience, input character arguments matching in
 }
 
 \subsection{Returns}{
-A \code{\link[data.table:data.table]{data.table::data.table()}} with 8 columns.
+A \code{\link[data.table:data.table]{data.table::data.table()}} with 9 columns (when \code{wide} is
+\code{FALSE}) or a named list of \code{\link[data.table:data.table]{data.table::data.table()}}s where the
+names are the combination of \code{report_name}, \code{report_for} and
+\code{table_name}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -687,6 +723,15 @@ str(sql$tabular_data(
     table_name = "Site and Source Energy",
     column_name = "Total Energy",
     row_name = "Total Site Energy"
+))
+
+# get tabular data in wide format and coerce numeric values
+str(sql$tabular_data(
+    report_name = "AnnualBuildingUtilityPerformanceSummary",
+    table_name = "Site and Source Energy",
+    column_name = "Total Energy",
+    row_name = "Total Site Energy",
+    wide = TRUE, string_value = FALSE
 ))
 }
 

--- a/tests/testthat/test_group.R
+++ b/tests/testthat/test_group.R
@@ -102,6 +102,21 @@ test_that("Group methods", {
     expect_equal(nrow(grp$tabular_data("1zoneevapcooler", table_name = "Site and Source Energy")), 12)
     expect_equal(nrow(grp$tabular_data("1zoneevapcooler" ,column_name = "Total Energy")), 4)
     expect_equal(nrow(grp$tabular_data("1zoneevapcooler", row_name = "Total Site Energy")), 3)
+    # can convert to wide table
+    expect_silent(tab <- grp$tabular_data("1zoneevapcooler", row_name = "Total Site Energy", wide = TRUE))
+    expect_equal(names(tab), "AnnualBuildingUtilityPerformanceSummary.Entire Facility.Site and Source Energy")
+    expect_equivalent(tab[[1L]][, lapply(.SD, class)],
+        data.table(
+            case = "character",
+            report_name = "character",
+            report_for = "character",
+            table_name = "character",
+            row_name = "character",
+            `Energy Per Conditioned Building Area [MJ/m2]` = "numeric",
+            `Energy Per Total Building Area [MJ/m2]` = "numeric",
+            `Total Energy [GJ]` = "numeric"
+        )
+    )
     # }}}
 
     # Report Data {{{

--- a/tests/testthat/test_sql.R
+++ b/tests/testthat/test_sql.R
@@ -74,6 +74,20 @@ test_that("Sql methods", {
     expect_equal(nrow(sql$tabular_data(table_name = "Site and Source Energy")), 12)
     expect_equal(nrow(sql$tabular_data(column_name = "Total Energy")), 4)
     expect_equal(nrow(sql$tabular_data(row_name = "Total Site Energy")), 3)
+    # can convert to wide table
+    expect_silent(tab <- sql$tabular_data(row_name = "Total Site Energy", wide = TRUE, case = NULL))
+    expect_equal(names(tab), "AnnualBuildingUtilityPerformanceSummary.Entire Facility.Site and Source Energy")
+    expect_equivalent(tab[[1L]][, lapply(.SD, class)],
+        data.table(
+            report_name = "character",
+            report_for = "character",
+            table_name = "character",
+            row_name = "character",
+            `Energy Per Conditioned Building Area [MJ/m2]` = "numeric",
+            `Energy Per Total Building Area [MJ/m2]` = "numeric",
+            `Total Energy [GJ]` = "numeric"
+        )
+    )
 
     skip_on_os("mac")
     # can get path

--- a/vignettes/eplusr.Rmd
+++ b/vignettes/eplusr.Rmd
@@ -805,8 +805,10 @@ Now let's get the total site energy per total building area. Note that the
 store not just numbers. We need to manually convert it.
 
 ```{r tab, eval = can_run}
-site_energy <- job$tabular_data(column_name = "energy per total building area", row_name = "total site energy")
-site_energy[, value := as.numeric(value)]
+site_energy <- job$tabular_data(
+    column_name = "energy per total building area", row_name = "total site energy",
+    wide = TRUE, string_value = FALSE
+)[[1]]
 str(site_energy)
 ```
 
@@ -897,9 +899,9 @@ After all simulations completed, let's see the variations of total energy.
 
 ```{r param_res, eval = can_run}
 tab <- param$tabular_data(
-  table_name = "Site and Source Energy",
-  column_name = "Total Energy",
-  row_name = "Total Site Energy"
+    table_name = "Site and Source Energy",
+    column_name = "Total Energy",
+    row_name = "Total Site Energy"
 )
 
 total_eng <- tab[, list(case, `Total Energy (GJ)` = as.numeric(value))]


### PR DESCRIPTION
## Pull request overview

* Closes #179 
* New parameter `case` has been added in `EplusSql$tabular_data()`. Similar like `case` parameter in `EplusSql$report_data()`, it lets you to add a `case` column to indicate the case of simulation. This brings some changes in the returned results of `EplusSql$tabular_data()`. Compared to previous version, there will always be a `case` column, unless `case` parameter is set to `NULL`.
* New parameter `wide` and `string_value` have been added in `EplusSql$tabular_data()` and `EplusGroupJob$tabular_data()`. When `wide` is `TRUE`, each table will be converted into the similar format as it is shown in EnergyPlus HTML output file. And when `string_value` is `FALSE`, values in possible numeric columns are converted into numbers.
