### PR TITLE
Retain the original column order in `EplusSql$tabular_data()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 * Now `group_job()` supports single IDF input with multiple EPW inputs (#185).
 
+## Bug fixes
+
+* Now `EplusSql$tabular_data()` keeps the original column order when `wide` is
+  `TRUE` (#186).
+
 # eplusr 0.11.0
 
 ## New features

--- a/R/impl-sql.R
+++ b/R/impl-sql.R
@@ -401,7 +401,10 @@ wide_tabular_data <- function (dt, string_value = TRUE) {
     }
 
     # clean
-    data.table::set(dt, NULL, "row_index", NULL)
+    set(dt, NULL, "row_index", NULL)
+
+    # column order
+    setcolorder(dt, c(setdiff(names(dt), cols), cols))
 
     # coerece type
     if (!string_value && length(cols_num)) {

--- a/tests/testthat/test_group.R
+++ b/tests/testthat/test_group.R
@@ -113,9 +113,9 @@ test_that("Group methods", {
             report_for = "character",
             table_name = "character",
             row_name = "character",
-            `Energy Per Conditioned Building Area [MJ/m2]` = "numeric",
+            `Total Energy [GJ]` = "numeric",
             `Energy Per Total Building Area [MJ/m2]` = "numeric",
-            `Total Energy [GJ]` = "numeric"
+            `Energy Per Conditioned Building Area [MJ/m2]` = "numeric"
         )
     )
     # }}}

--- a/tests/testthat/test_sql.R
+++ b/tests/testthat/test_sql.R
@@ -83,9 +83,9 @@ test_that("Sql methods", {
             report_for = "character",
             table_name = "character",
             row_name = "character",
-            `Energy Per Conditioned Building Area [MJ/m2]` = "numeric",
+            `Total Energy [GJ]` = "numeric",
             `Energy Per Total Building Area [MJ/m2]` = "numeric",
-            `Total Energy [GJ]` = "numeric"
+            `Energy Per Conditioned Building Area [MJ/m2]` = "numeric"
         )
     )
 


### PR DESCRIPTION
## Pull request view

* Fixes #186

Previously when `wide` is `TRUE`, `EplusSql$tabular_data()` will reorder the dcasted columns alphabetically.

```r
job$tabular_data(table_name = "Site and Source Energy", wide = TRUE)
#> $`AnnualBuildingUtilityPerformanceSummary.Entire Facility.Site and Source Energy`
#>                 case                             report_name      report_for
#> 1: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#> 2: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#> 3: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#> 4: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#>                table_name            row_name
#> 1: Site and Source Energy   Total Site Energy
#> 2: Site and Source Energy     Net Site Energy
#> 3: Site and Source Energy Total Source Energy
#> 4: Site and Source Energy   Net Source Energy
#>    Energy Per Conditioned Building Area [MJ/m2]
#> 1:                                             
#> 2:                                             
#> 3:                                             
#> 4:                                             
#>    Energy Per Total Building Area [MJ/m2] Total Energy [GJ]
#> 1:                                      0                 0
#> 2:                                      0                 0
#> 3:                                      0                 0
#> 4:                                      0                 0
```

This PR makes sure that the original column order is retained:

``` r
job$tabular_data(table_name = "Site and Source Energy", wide = TRUE)
#> $`AnnualBuildingUtilityPerformanceSummary.Entire Facility.Site and Source Energy`
#>                 case                             report_name      report_for
#> 1: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#> 2: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#> 3: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#> 4: 1ZoneUncontrolled AnnualBuildingUtilityPerformanceSummary Entire Facility
#>                table_name            row_name
#> 1: Site and Source Energy   Total Site Energy
#> 2: Site and Source Energy     Net Site Energy
#> 3: Site and Source Energy Total Source Energy
#> 4: Site and Source Energy   Net Source Energy
#>    Energy Per Conditioned Building Area [MJ/m2]
#> 1:                                             
#> 2:                                             
#> 3:                                             
#> 4:                                             
#>    Energy Per Total Building Area [MJ/m2] Total Energy [GJ]
#> 1:                                      0                 0
#> 2:                                      0                 0
#> 3:                                      0                 0
#> 4:                                      0                 0
```
