### PR TITLE
Improve column type detection in `EplusSql$tabular_data()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
 * A new method `Idf$last_job()` has been added to enable getting the last
   simulation job created using `Idf$run()` (#187).
 
+## Bug fixes
+
+* The algorithm of detecting numeric columns in `EplusSql$tabular_data()` has
+  been improved (#190).
+
 # eplusr 0.11.0
 
 ## New features

--- a/R/impl-sql.R
+++ b/R/impl-sql.R
@@ -356,8 +356,10 @@ get_sql_tabular_data <- function (sql, report_name = NULL, report_for = NULL,
     if (!string_value) {
         dt[!J(c("", " ")), on = "units", is_num := TRUE]
         # https://stackoverflow.com/questions/638565/parsing-scientific-notation-sensibly
-        dt[, is_num := any(stri_detect_regex(value, "^\\s*-?\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d+)?$")),
-            by = c("report_name", "report_for", "table_name", "column_name")]
+        dt[J(FALSE), on = "is_num",
+            is_num := any(stri_detect_regex(value, "^\\s*-?\\d+(?:\\.\\d*)?(?:[eE][+\\-]?\\d+)?$")),
+            by = c("report_name", "report_for", "table_name", "column_name")
+        ]
     }
 
     # add row index

--- a/tests/testthat/test_sql.R
+++ b/tests/testthat/test_sql.R
@@ -78,7 +78,7 @@ test_that("Sql methods", {
     expect_silent(tab <- sql$tabular_data(row_name = "Total Site Energy", wide = TRUE, case = NULL))
     expect_equal(names(tab), "AnnualBuildingUtilityPerformanceSummary.Entire Facility.Site and Source Energy")
     expect_equivalent(
-        read_idf(system.file("inst/extdata/1ZoneUncontrolled.idf", package = "eplusr"))$
+        read_idf(file.path(eplus_config(8.8)$dir, "ExampleFiles/1ZoneUncontrolled.idf"))$
             run(NULL, tempdir(), echo = FALSE)$
             tabular_data(table_name = "Site and Source Energy", wide = TRUE)[[1]][
             , lapply(.SD, class)],

--- a/tests/testthat/test_sql.R
+++ b/tests/testthat/test_sql.R
@@ -77,6 +77,22 @@ test_that("Sql methods", {
     # can convert to wide table
     expect_silent(tab <- sql$tabular_data(row_name = "Total Site Energy", wide = TRUE, case = NULL))
     expect_equal(names(tab), "AnnualBuildingUtilityPerformanceSummary.Entire Facility.Site and Source Energy")
+    expect_equivalent(
+        read_idf(system.file("inst/extdata/1ZoneUncontrolled.idf", package = "eplusr"))$
+            run(NULL, tempdir(), echo = FALSE)$
+            tabular_data(table_name = "Site and Source Energy", wide = TRUE)[[1]][
+            , lapply(.SD, class)],
+        data.table(
+            case = "character",
+            report_name = "character",
+            report_for = "character",
+            table_name = "character",
+            row_name = "character",
+            `Energy Per Conditioned Building Area [MJ/m2]` = "numeric",
+            `Energy Per Total Building Area [MJ/m2]` = "numeric",
+            `Total Energy [GJ]` = "numeric"
+        )
+    )
     expect_equivalent(tab[[1L]][, lapply(.SD, class)],
         data.table(
             report_name = "character",


### PR DESCRIPTION
## Pull request overview

* Fixes #190

Previously, the columns are numeric when

* it has one associated units **AND**
* it has one numeric values in string format

This PR changes the algorithm to

* it has one associated units **OR**
* it has one numeric values in string format

This will fixes the problem that empty columns with units were treated as character columns.