### PR TITLE
Make sure standard output and error of EnergyPlus are read

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Now `EplusSql$tabular_data()` keeps the original column order when `wide` is
   `TRUE` (#186).
 * Fix EnergyPlus installation on macOS (#193).
+* Fix parallel simulations on macOS (#194).
 
 # eplusr 0.11.0
 

--- a/R/run.R
+++ b/R/run.R
@@ -742,8 +742,8 @@ energyplus <- function (eplus, model, weather, output_dir, output_prefix = NULL,
         p_stdout <- tempfile()
         p_stderr <- tempfile()
         post_fun <- function () {
-            stdout <- suppressWarnings(eplusr:::read_lines(p_stdout)$string)
-            stderr <- suppressWarnings(eplusr:::read_lines(p_stderr)$string)
+            stdout <- suppressWarnings(read_lines(p_stdout)$string)
+            stderr <- suppressWarnings(read_lines(p_stderr)$string)
             if (!length(stdout)) stdout <- character(0)
             if (!length(stderr)) stderr <- character(0)
             list(stdout = stdout, stderr = stderr, end_time = Sys.time())

--- a/man/run_model.Rd
+++ b/man/run_model.Rd
@@ -99,10 +99,12 @@ the simulation time
 \item \code{energyplus}: The path of EnergyPlus executable
 \item \code{stdout}: All standard output from EnergyPlus. Always being \code{NULL} if
 \code{wait} is \code{FALSE}, but you can manually get all standard output using
-\code{process$read_all_output_lines()}.
+\code{process$get_result()}, where \code{process} is the \link[processx:process]{processx::process}
+object stored in returned element \code{process}.
 \item \code{stderr}: All standard error from EnergyPlus. Always being \code{NULL} if
 \code{wait} is \code{FALSE}, but you can manually get all standard output using
-\code{process$read_all_output_lines()}.
+\code{process$get_result()}, where \code{process} is the \link[processx:process]{processx::process}
+object stored in returned element \code{process}.
 \item \code{process}: A \link[processx:process]{processx::process} object of current EnergyPlus simulation
 }
 


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #194
 - Previously, when running EnergyPlus simulations in the background, standard output and standard error are piped into R using connections. However, as said in #194, the connections have a buffer, which can fill up, and if R does not read out the output, the process will stop until R reads the connection and the buffer is freed.

In this PR, when running simulations with `wait` being `FALSE`, all standard output and standard error are saved into temp file and will be read using post process function specified during `processx::process` initialization.