### PR TITLE
Make sure EnergyPlus path is expanded

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Now `EplusSql$tabular_data()` keeps the original column order when `wide` is
   `TRUE` (#186).
 * Fix EnergyPlus installation on macOS (#193).
+* Now `eplus_config()` will always return the expanded EnergyPlus path (#196).
 
 # eplusr 0.11.0
 

--- a/R/install.R
+++ b/R/install.R
@@ -567,7 +567,7 @@ use_eplus <- function (eplus) {
     }
 
     exe <- paste0("energyplus", if (is_windows()) ".exe" else "")
-    res <- list(version = ver, dir = eplus_dir, exe = exe)
+    res <- list(version = ver, dir = normalizePath(eplus_dir), exe = exe)
 
     ori <- .globals$eplus_config[[as.character(ver)]]
     .globals$eplus_config[[as.character(ver)]] <- res


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #196
 - With `local` parameter introduced `install_eplus()` in v0.11.0, `processx::run()` will fail with EnergyPlus path denoted in relative path.

This PR makes sure that `eplus_config()` will always return the expanded EnergyPlus folder.