### PR TITLE
Change `group_ext` input from integers to choices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,12 +11,12 @@
   `/usr/local` ([NREL/EnergyPlus#7256](https://github.com/NREL/EnergyPlus/issues/7256))
   (#193).
 * A new parameter `group_ext` has been added in `Idf$to_table()` and
-  `IdfObject$to_table()`, with default value being `0L`.
-  If `1L`, values from extensible fields will be grouped by the
+  `IdfObject$to_table()`, with default value being `"none"`.
+  If `"group"`, values from extensible fields will be grouped by the
   extensible group they belong to. For example, coordinate
   values of each vertex in class `BuildingSurface:Detailed` will
-  be put into a list. If `2L`, values from extensible fields
-  will be grouped by the extensible field indice they belong to.
+  be put into a list. If `"index"`, values from extensible fields
+  will be grouped by the extensible field indices they belong to.
   For example, coordinate values of all x coordinates will be
   put into a list (#74).
 

--- a/R/idf.R
+++ b/R/idf.R
@@ -1945,21 +1945,21 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #' * `index`: Integer type. Field indexes.
         #' * `field`: Character type. Field names.
         #' * `value`: Character type if `string_value` is `TRUE` or list type if
-        #'   `string_value` is `FALSE` or `group_ext` > `0`. Field values.
+        #'   `string_value` is `FALSE` or `group_ext` is not `"none"`. Field values.
         #'
-        #' Note that when `group_ext` > `0`, `index` and `field` values will not
-        #' match the original field indices and names. In this case, `index`
-        #' will only indicate the indices of sequences. For `field` column,
-        #' specifically:
+        #' Note that when `group_ext` is not `"none"`, `index` and `field`
+        #' values will not match the original field indices and names. In this
+        #' case, `index` will only indicate the indices of sequences. For
+        #' `field` column, specifically:
         #'
-        #' * When `group_ext` is `1L`, each field name in a extensible group
+        #' * When `group_ext` is `"group"`, each field name in a extensible group
         #'   will be abbreviated using [abbreviate()] with `minlength` being
         #'   `10L` and all abbreviated names will be separated by `|` and
         #'   combined together. For example, field names in the extensible group
         #'   (`Vertex 1 X-coordinate`, `Vertex 1 Y-coordinate`, `Vertex 1
         #'   Z-coordinate`) in class `BuildiBuildingSurface:Detailed` will be
         #'   merged into one name `Vrtx1X-crd|Vrtx1Y-crd|Vrtx1Z-crd`.
-        #' * When `group_ext` is `2L`, the extensible group indicator in field
+        #' * When `group_ext` is `"index"`, the extensible group indicator in field
         #'   names will be removed. Take the same example as above, the
         #'   resulting field names will be `Vertex X-coordinate`, `Vertex
         #'   Y-coordinate`, and `Vertex Z-coordinate`.
@@ -1992,18 +1992,20 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #' @param all If `TRUE`, all available fields defined in IDD for the
         #'        class that objects belong to will be returned. Default:
         #'        `FALSE`.
-        #' @param group_ext If greater than `0L`, `value` column in returned
+        #' @param group_ext Should be one of `"none"`, `"group"` or `"index"`.
+        #'        If not `"none"`, `value` column in returned
         #'        [data.table::data.table()] will be converted into a list.
-        #'        If `1L`, values from extensible fields will be grouped by the
+        #'        If `"group"`, values from extensible fields will be grouped by the
         #'        extensible group they belong to. For example, coordinate
         #'        values of each vertex in class `BuildingSurface:Detailed` will
-        #'        be put into a list. If `2L`, values from extensible fields
+        #'        be put into a list. If `"index"`, values from extensible fields
         #'        will be grouped by the extensible field indice they belong to.
         #'        For example, coordinate values of all x coordinates will be
-        #'        put into a list. If `0L`, nothing special will be done.
-        #'        Default: `0L`.
+        #'        put into a list. If `"none"`, nothing special will be done.
+        #'        Default: `"none"`.
         #'
-        #' @return A [data.table][data.table::data.table()] with 6 columns.
+        #' @return A [data.table][data.table::data.table()] with 6 columns (if
+        #' `wide` is `FALSE`) or at least 6 columns (if `wide` is `TRUE`).
         #'
         #' @examples
         #' \dontrun{
@@ -2035,27 +2037,27 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #' idf$to_table(class = "OtherEquipment", wide = TRUE, string_value = FALSE)
         #'
         #' # group extensible by extensible group number
-        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = 1)
+        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = "group")
         #'
         #' # group extensible by extensible group number and convert into a wide table
-        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = 1, wide = TRUE)
+        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = "group", wide = TRUE)
         #'
         #' # group extensible by extensible field index
-        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2)
+        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index")
         #'
         #' # group extensible by extensible field index and convert into a wide table
-        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2, wide = TRUE)
+        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index", wide = TRUE)
         #'
         #' # when grouping extensible, 'string_value' and 'unit' still take effect
-        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2,
+        #' idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index",
         #'     wide = TRUE, string_value = FALSE, unit = TRUE
         #' )
         #' }
         #'
         to_table = function (which = NULL, class = NULL, string_value = TRUE,
-                             unit = FALSE, wide = FALSE, align = FALSE, all = FALSE, group_ext = 0L)
+                             unit = FALSE, wide = FALSE, align = FALSE, all = FALSE, group_ext = c("none", "group", "index"))
             idf_to_table(self, private, which = which, class = class,
-                string_value = string_value, unit = unit, wide = wide, align = align, all = all, group_ext = group_ext),
+                string_value = string_value, unit = unit, wide = wide, align = align, all = all, group_ext = match.arg(group_ext)),
         # }}}
 
         # is_unsaved {{{
@@ -2880,7 +2882,7 @@ idf_string <- function (self, private, ...) {
 }
 # }}}
 # idf_to_table {{{
-idf_to_table <- function (self, private, which = NULL, class = NULL, string_value = TRUE, unit = FALSE, wide = FALSE, align = FALSE, all = FALSE, group_ext = 0L) {
+idf_to_table <- function (self, private, which = NULL, class = NULL, string_value = TRUE, unit = FALSE, wide = FALSE, align = FALSE, all = FALSE, group_ext = c("none", "group", "index")) {
     get_idf_table(private$idd_env(), private$idf_env(), class, which, string_value, unit, wide, align, all, group_ext)
 }
 # }}}

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -662,19 +662,19 @@ idf$to_table(class = "Construction", wide = TRUE)
 idf$to_table(class = "OtherEquipment", wide = TRUE, string_value = FALSE)
 
 # group extensible by extensible group number
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 1)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "group")
 
 # group extensible by extensible group number and convert into a wide table
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 1, wide = TRUE)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "group", wide = TRUE)
 
 # group extensible by extensible field index
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index")
 
 # group extensible by extensible field index and convert into a wide table
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2, wide = TRUE)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index", wide = TRUE)
 
 # when grouping extensible, 'string_value' and 'unit' still take effect
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2,
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index",
     wide = TRUE, string_value = FALSE, unit = TRUE
 )
 }
@@ -3236,7 +3236,7 @@ Format \code{Idf} as a data.frame
   wide = FALSE,
   align = FALSE,
   all = FALSE,
-  group_ext = 0L
+  group_ext = c("none", "group", "index")
 )}\if{html}{\out{</div>}}
 }
 
@@ -3278,16 +3278,17 @@ Default: \code{FALSE}.}
 class that objects belong to will be returned. Default:
 \code{FALSE}.}
 
-\item{\code{group_ext}}{If greater than \code{0L}, \code{value} column in returned
+\item{\code{group_ext}}{Should be one of \code{"none"}, \code{"group"} or \code{"index"}.
+If not \code{"none"}, \code{value} column in returned
 \code{\link[data.table:data.table]{data.table::data.table()}} will be converted into a list.
-If \code{1L}, values from extensible fields will be grouped by the
+If \code{"group"}, values from extensible fields will be grouped by the
 extensible group they belong to. For example, coordinate
 values of each vertex in class \code{BuildingSurface:Detailed} will
-be put into a list. If \code{2L}, values from extensible fields
+be put into a list. If \code{"index"}, values from extensible fields
 will be grouped by the extensible field indice they belong to.
 For example, coordinate values of all x coordinates will be
-put into a list. If \code{0L}, nothing special will be done.
-Default: \code{0L}.}
+put into a list. If \code{"none"}, nothing special will be done.
+Default: \code{"none"}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -3302,28 +3303,29 @@ The returned \link[data.table:data.table]{data.table} has 6 columns:
 \item \code{index}: Integer type. Field indexes.
 \item \code{field}: Character type. Field names.
 \item \code{value}: Character type if \code{string_value} is \code{TRUE} or list type if
-\code{string_value} is \code{FALSE} or \code{group_ext} > \code{0}. Field values.
+\code{string_value} is \code{FALSE} or \code{group_ext} is not \code{"none"}. Field values.
 }
 
-Note that when \code{group_ext} > \code{0}, \code{index} and \code{field} values will not
-match the original field indices and names. In this case, \code{index}
-will only indicate the indices of sequences. For \code{field} column,
-specifically:
+Note that when \code{group_ext} is not \code{"none"}, \code{index} and \code{field}
+values will not match the original field indices and names. In this
+case, \code{index} will only indicate the indices of sequences. For
+\code{field} column, specifically:
 \itemize{
-\item When \code{group_ext} is \code{1L}, each field name in a extensible group
+\item When \code{group_ext} is \code{"group"}, each field name in a extensible group
 will be abbreviated using \code{\link[=abbreviate]{abbreviate()}} with \code{minlength} being
 \code{10L} and all abbreviated names will be separated by \code{|} and
 combined together. For example, field names in the extensible group
 (\verb{Vertex 1 X-coordinate}, \verb{Vertex 1 Y-coordinate}, \verb{Vertex 1 Z-coordinate}) in class \code{BuildiBuildingSurface:Detailed} will be
 merged into one name \code{Vrtx1X-crd|Vrtx1Y-crd|Vrtx1Z-crd}.
-\item When \code{group_ext} is \code{2L}, the extensible group indicator in field
+\item When \code{group_ext} is \code{"index"}, the extensible group indicator in field
 names will be removed. Take the same example as above, the
 resulting field names will be \verb{Vertex X-coordinate}, \verb{Vertex Y-coordinate}, and \verb{Vertex Z-coordinate}.
 }
 }
 
 \subsection{Returns}{
-A \link[data.table:data.table]{data.table} with 6 columns.
+A \link[data.table:data.table]{data.table} with 6 columns (if
+\code{wide} is \code{FALSE}) or at least 6 columns (if \code{wide} is \code{TRUE}).
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -3356,19 +3358,19 @@ idf$to_table(class = "Construction", wide = TRUE)
 idf$to_table(class = "OtherEquipment", wide = TRUE, string_value = FALSE)
 
 # group extensible by extensible group number
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 1)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "group")
 
 # group extensible by extensible group number and convert into a wide table
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 1, wide = TRUE)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "group", wide = TRUE)
 
 # group extensible by extensible field index
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index")
 
 # group extensible by extensible field index and convert into a wide table
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2, wide = TRUE)
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index", wide = TRUE)
 
 # when grouping extensible, 'string_value' and 'unit' still take effect
-idf$to_table(class = "BuildingSurface:Detailed", group_ext = 2,
+idf$to_table(class = "BuildingSurface:Detailed", group_ext = "index",
     wide = TRUE, string_value = FALSE, unit = TRUE
 )
 }

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -361,19 +361,19 @@ str(mat$to_table(wide = TRUE))
 
 # group extensible by extensible group number
 surf <- idf$BuildingSurface_Detailed[["Zn001:Roof001"]]
-surf$to_table(group_ext = 1)
+surf$to_table(group_ext = "group")
 
 # group extensible by extensible group number and convert into a wide table
-surf$to_table(group_ext = 1, wide = TRUE)
+surf$to_table(group_ext = "group", wide = TRUE)
 
 # group extensible by extensible field index
-surf$to_table(group_ext = 2)
+surf$to_table(group_ext = "index")
 
 # group extensible by extensible field index and convert into a wide table
-surf$to_table(group_ext = 2, wide = TRUE)
+surf$to_table(group_ext = "index", wide = TRUE)
 
 # when grouping extensible, 'string_value' and 'unit' still take effect
-surf$to_table(group_ext = 2, wide = TRUE, string_value = FALSE, unit = TRUE)
+surf$to_table(group_ext = "index", wide = TRUE, string_value = FALSE, unit = TRUE)
 }
 
 
@@ -1687,7 +1687,7 @@ Format \code{IdfObject} as a data.frame
   unit = TRUE,
   wide = FALSE,
   all = FALSE,
-  group_ext = 0L
+  group_ext = c("none", "group", "index")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1717,16 +1717,17 @@ Default: \code{FALSE}.}
 class that objects belong to will be returned. Default:
 \code{FALSE}.}
 
-\item{\code{group_ext}}{If greater than \code{0L}, \code{value} column in returned
+\item{\code{group_ext}}{Should be one of \code{"none"}, \code{"group"} or \code{"index"}.
+If not \code{"none"}, \code{value} column in returned
 \code{\link[data.table:data.table]{data.table::data.table()}} will be converted into a list.
-If \code{1L}, values from extensible fields will be grouped by the
+If \code{"group"}, values from extensible fields will be grouped by the
 extensible group they belong to. For example, coordinate
 values of each vertex in class \code{BuildingSurface:Detailed} will
-be put into a list. If \code{2L}, values from extensible fields
+be put into a list. If \code{"index"}, values from extensible fields
 will be grouped by the extensible field indice they belong to.
 For example, coordinate values of all x coordinates will be
-put into a list. If \code{0L}, nothing special will be done.
-Default: \code{0L}.}
+put into a list. If \code{"none"}, nothing special will be done.
+Default: \code{"none"}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1734,34 +1735,35 @@ Default: \code{0L}.}
 \verb{$to_table()} returns a \link[data.table:data.table]{data.table} that
 contains core data of current \code{IdfObject}. It has 6 columns:
 \itemize{
-\item \code{id}: Integer type. Object ID.
-\item \code{name}: Character type. Object name.
+\item \code{id}: Integer type. Object IDs.
+\item \code{name}: Character type. Object names.
 \item \code{class}: Character type. Current class name.
 \item \code{index}: Integer type. Field indexes.
 \item \code{field}: Character type. Field names.
 \item \code{value}: Character type if \code{string_value} is \code{TRUE} or list type if
-\code{string_value} is \code{FALSE} or \code{group_ext} > \code{0}. Field values.
+\code{string_value} is \code{FALSE} or \code{group_ext} is not \code{"none"}. Field values.
 }
 
-Note that when \code{group_ext} > \code{0}, \code{index} and \code{field} values will not
-match the original field indices and names. In this case, \code{index}
-will only indicate the indices of sequences. For \code{field} column,
-specifically:
+Note that when \code{group_ext} is not \code{"none"}, \code{index} and \code{field}
+values will not match the original field indices and names. In this
+case, \code{index} will only indicate the indices of sequences. For
+\code{field} column, specifically:
 \itemize{
-\item When \code{group_ext} is \code{1L}, each field name in a extensible group
+\item When \code{group_ext} is \code{"group"}, each field name in a extensible group
 will be abbreviated using \code{\link[=abbreviate]{abbreviate()}} with \code{minlength} being
 \code{10L} and all abbreviated names will be separated by \code{|} and
 combined together. For example, field names in the extensible group
 (\verb{Vertex 1 X-coordinate}, \verb{Vertex 1 Y-coordinate}, \verb{Vertex 1 Z-coordinate}) in class \code{BuildiBuildingSurface:Detailed} will be
 merged into one name \code{Vrtx1X-crd|Vrtx1Y-crd|Vrtx1Z-crd}.
-\item When \code{group_ext} is \code{2L}, the extensible group indicator in field
+\item When \code{group_ext} is \code{"index"}, the extensible group indicator in field
 names will be removed. Take the same example as above, the
 resulting field names will be \verb{Vertex X-coordinate}, \verb{Vertex Y-coordinate}, and \verb{Vertex Z-coordinate}.
 }
 }
 
 \subsection{Returns}{
-A \link[data.table:data.table]{data.table} with 6 columns.
+A \link[data.table:data.table]{data.table} with 6 columns (if
+\code{wide} is \code{FALSE}) or at least 6 columns (if \code{wide} is \code{TRUE}).
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
@@ -1781,19 +1783,19 @@ str(mat$to_table(wide = TRUE))
 
 # group extensible by extensible group number
 surf <- idf$BuildingSurface_Detailed[["Zn001:Roof001"]]
-surf$to_table(group_ext = 1)
+surf$to_table(group_ext = "group")
 
 # group extensible by extensible group number and convert into a wide table
-surf$to_table(group_ext = 1, wide = TRUE)
+surf$to_table(group_ext = "group", wide = TRUE)
 
 # group extensible by extensible field index
-surf$to_table(group_ext = 2)
+surf$to_table(group_ext = "index")
 
 # group extensible by extensible field index and convert into a wide table
-surf$to_table(group_ext = 2, wide = TRUE)
+surf$to_table(group_ext = "index", wide = TRUE)
 
 # when grouping extensible, 'string_value' and 'unit' still take effect
-surf$to_table(group_ext = 2, wide = TRUE, string_value = FALSE, unit = TRUE)
+surf$to_table(group_ext = "index", wide = TRUE, string_value = FALSE, unit = TRUE)
 }
 
 }

--- a/man/eplusr-package.Rd
+++ b/man/eplusr-package.Rd
@@ -6,10 +6,10 @@
 \alias{eplusr-package}
 \title{eplusr: A Toolkit for Using EnergyPlus in R}
 \description{
-A rich toolkit of using the whole building simulation program
-    'EnergyPlus'(<https://energyplus.net>), which enables programmatic
-    navigation, modification of 'EnergyPlus' models and makes it less painful to
-    do parametric simulations and analysis.
+A rich toolkit of using the whole building
+    simulation program 'EnergyPlus'(<https://energyplus.net>), which
+    enables programmatic navigation, modification of 'EnergyPlus' models
+    and makes it less painful to do parametric simulations and analysis.
 }
 \details{
 eplusr provides a rich toolkit of using EnergyPlus directly in

--- a/tests/testthat/test_idf.R
+++ b/tests/testthat/test_idf.R
@@ -374,7 +374,7 @@ test_that("Idf class", {
         )
     )
     expect_equal(
-        idf$to_table(3, unit = TRUE, string_value = TRUE, group_ext = 1),
+        idf$to_table(3, unit = TRUE, string_value = TRUE, group_ext = "group"),
         data.table(id = 3L, name = "WALL-1PF", class = "BuildingSurface:Detailed",
             index = 1:15,
             field = c(
@@ -414,7 +414,7 @@ test_that("Idf class", {
         )
     )
     expect_equal(
-        idf$to_table(3, unit = TRUE, string_value = TRUE, group_ext = 2),
+        idf$to_table(3, unit = TRUE, string_value = TRUE, group_ext = "index"),
         data.table(id = 3L, name = "WALL-1PF", class = "BuildingSurface:Detailed",
             index = 1:13,
             field = c(
@@ -450,7 +450,7 @@ test_that("Idf class", {
         )
     )
     expect_equivalent(tolerance = 1e-5,
-        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = 1),
+        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = "group"),
         data.table(id = 3L, name = "WALL-1PF", class = "BuildingSurface:Detailed",
             index = 1:15,
             field = c(
@@ -490,7 +490,7 @@ test_that("Idf class", {
         )
     )
     expect_equivalent(tolerance = 1e-5,
-        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = 2),
+        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = "index"),
         data.table(id = 3L, name = "WALL-1PF", class = "BuildingSurface:Detailed",
             index = 1:13,
             field = c(
@@ -526,7 +526,7 @@ test_that("Idf class", {
         )
     )
     expect_equivalent(tolerance = 1e-5,
-        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = 1, wide = TRUE),
+        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = "group", wide = TRUE),
         data.table(id = 3L, name = "WALL-1PF", class = "BuildingSurface:Detailed",
             "Name" = "WALL-1PF",
             "Surface Type" = "WALL",
@@ -546,7 +546,7 @@ test_that("Idf class", {
         )
     )
     expect_equivalent(tolerance = 1e-5,
-        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = 2, wide = TRUE),
+        idf$to_table(3, unit = TRUE, string_value = FALSE, group_ext = "index", wide = TRUE),
         data.table(id = 3L, name = "WALL-1PF", class = "BuildingSurface:Detailed",
             "Name" = "WALL-1PF",
             "Surface Type" = "WALL",

--- a/tests/testthat/test_impl-idf.R
+++ b/tests/testthat/test_impl-idf.R
@@ -1081,7 +1081,7 @@ test_that("TO_TABLE", {
             "Visible Absorptance" = 0.65
         ), tolerance = 1e-5
     )
-    expect_equivalent(get_idf_table(idd_env, idf_env, "Material", string_value = FALSE, unit = TRUE, wide = TRUE, group_ext = 1),
+    expect_equivalent(get_idf_table(idd_env, idf_env, "Material", string_value = FALSE, unit = TRUE, wide = TRUE, group_ext = "group"),
         data.table(id = 14L, name = "C5 - 4 IN HW CONCRETE", class = "Material",
             "Name" = "C5 - 4 IN HW CONCRETE",
             "Roughness" = "MediumRough",


### PR DESCRIPTION
Pull request overview
---------------------
 - Tweak #74
 - Change `group_ext` input from integers to choices.

In #200, `group_ext` is set to integer input, which is not very intuitive to understand. This PR changes `group_ext` to choices `"none"`, `"group"` and `"index"`.
