### PR TITLE
Fix `group_job()` error when input contains non-saved `Idf`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,8 @@
 * Fix EnergyPlus installation on macOS (#193).
 * Fix parallel simulations on macOS (#194).
 * Now `eplus_config()` will always return the expanded EnergyPlus path (#196).
+* Now `group_job()` will return more informative error messages when input
+  contains `Idf` objects that havn't been saved (#204).
 
 # eplusr 0.11.0
 

--- a/R/group.R
+++ b/R/group.R
@@ -1105,18 +1105,21 @@ get_epgroup_input <- function (idfs, epws) {
     if (is_idf(idfs)) {
         idfs <- list(get_init_idf(idfs))
     } else {
-        idfs <- tryCatch(lapply(idfs, get_init_idf),
-            error_idf_not_local = function (e) e,
-            error_idf_path_not_exist = function (e) e,
-            error_idf_not_saved = function (e) e
-        )
+        init_idf <- function (...) {
+            tryCatch(get_init_idf(...),
+                error_idf_not_local = function (e) e,
+                error_idf_path_not_exist = function (e) e,
+                error_idf_not_saved = function (e) e
+            )
+        }
+        idfs <- lapply(idfs, init_idf)
     }
 
     if (any(!vlapply(idfs, is_idf))) {
         for (err in c("error_idf_not_local", "error_idf_path_not_exist", "error_idf_not_saved")) {
             if (any(invld <- vlapply(idfs, inherits, err))) {
-                abort(err, paste0(conditionMessage(idfs[[which(invld)[[1L]]]]),
-                    " Invalid input index: ", collapse(which(invld))
+                abort(err, paste0("Invalid input index: ", collapse(which(invld)), " --> ",
+                    conditionMessage(idfs[[which(invld)[[1L]]]])
                 ))
             }
         }

--- a/tests/testthat/test_group.R
+++ b/tests/testthat/test_group.R
@@ -12,6 +12,17 @@ test_that("Group methods", {
         "\\.epw", full.names = TRUE)[1:5]
 
     expect_error(group_job(empty_idf(8.8)), class = "error_idf_not_local")
+    # can stop if input model is not saved after modification
+    expect_error(
+        group_job(
+            list(
+                {idf <- read_idf(path_idfs[[1]]); idf$RunPeriod <- NULL; idf},
+                path_idfs[1]
+            ),
+            NULL
+        ),
+        class = "error_idf_not_saved"
+    )
     expect_silent(group_job(path_idfs, path_epws[1L]))
     expect_silent(group_job(path_idfs[1], path_epws))
     expect_silent(grp <- group_job(path_idfs, NULL))


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #204


[Fail to run group job when specifying custom output directory](https://app.gitkraken.com/glo/board/5b4ef08d98db050f002036ba/card/5e40e2d6a326a20010886248)