### PR TITLE
[feat] Add `Idf$purge()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,20 @@
   `TRUE`, you can convert object data from any classes into a wide data.table.
   This may be useful when you know that target classes have the exact same
   fields, e.g.  `Ceiling:Adiabatic` and `Floor:Adiabatic`.
+* A new method `Idf$purge()` has been added. It can be used to delete any
+  resource objects that are not referenced by other objects. Here resource
+  objects indicate all objects that can be referenced by other objects, e.g. all
+  schedules. `$purge()` will ignore any inputs that are not resources. If inputs
+  contain objects from multiple classes, references among them are also taken
+  into account, which means purging is performed hierarchically. If both
+  materials and constructions are specified, the latter will be purged first,
+  because it is possible that input constructions reference input materials.
+  `Idf$purge()` makes it quite straightforward to perform IDF cleaning. Actions
+  like removing all materials, constructions and schedules can be easily
+  achieved via
+  ```
+  Idf$purge(class = c("Material", "Construction"), group = "Schedules")
+  ```
 
 ## Major changes
 

--- a/R/format.R
+++ b/R/format.R
@@ -435,7 +435,9 @@ format_idf_relation <- function (ref, direction = c("ref_to", "ref_by")) {
     switch_ref_src(ref, invert = TRUE)
 
     ref[!is.na(src_enum), by = c("src_enum", "value_chr"), pointer := {
-        if (.BY$src_enum == IDDFIELD_SOURCE$class) {
+        if (!length(src_enum)) {
+            prefix <- NA_character_
+        } else if (.BY$src_enum == IDDFIELD_SOURCE$class) {
             prefix <- switch(direction, ref_by = "b", ref_to = "p")
         } else {
             prefix <- switch(direction, ref_by = tc$u, ref_to = tc$d)

--- a/R/impl-idd.R
+++ b/R/impl-idd.R
@@ -661,7 +661,26 @@ add_class_name <- function (idd_env, dt) {
 # }}}
 # add_class_property {{{
 add_class_property <- function (idd_env, dt, property) {
+    add_group <- FALSE
+    if ("group_name" %in% property) {
+        if ("group_id" %in% property) {
+            add_id <- FALSE
+            property <- property[property != "group_name"]
+        } else {
+            property <- c(property[property != "group_name"], "group_id")
+            add_id <- TRUE
+        }
+        add_group <- TRUE
+    }
+
     add_joined_cols(idd_env$class, dt, "class_id", property)
+
+    if (add_group) {
+        add_joined_cols(idd_env$group, dt, "group_id", "group_name")
+        if (add_id) set(dt, NULL, "group_id", NULL)
+    }
+
+    dt
 }
 # }}}
 # add_field_property {{{

--- a/README.Rmd
+++ b/README.Rmd
@@ -189,6 +189,9 @@ idf$RunPeriod[[1]][c("Begin Month", "End Month")]
 # add new object
 idf$add(RunPeriod = list("run_period", 3, 1, 4, 1))
 
+# purge unused resource objects
+idf$purge(group = "Schedules")
+
 # get possible values for fields
 idf$Construction$FLOOR$value_possible("Outside Layer")
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 
 # eplusr <img src="man/figures/logo.svg" align="right" />
 
-[![Travis-CI Build Status](https://travis-ci.com/hongyuanjia/eplusr.svg?branch=master)](https://travis-ci.com/hongyuanjia/eplusr)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/hongyuanjia/eplusr?branch=master&svg=true)](https://ci.appveyor.com/project/hongyuanjia/eplusr)
+[![Travis-CI Build
+Status](https://travis-ci.com/hongyuanjia/eplusr.svg?branch=master)](https://travis-ci.com/hongyuanjia/eplusr)
+[![AppVeyor Build
+Status](https://ci.appveyor.com/api/projects/status/github/hongyuanjia/eplusr?branch=master&svg=true)](https://ci.appveyor.com/project/hongyuanjia/eplusr)
 [![codecov](https://codecov.io/gh/hongyuanjia/eplusr/branch/master/graph/badge.svg)](https://codecov.io/gh/hongyuanjia/eplusr)
 [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/eplusr)](https://cran.r-project.org/package=eplusr)
 [![CRAN
@@ -142,7 +144,7 @@ idf <- read_idf(system.file("extdata/1ZoneUncontrolled.idf", package = "eplusr")
 # print idf
 idf
 #> ── EnergPlus Input Data File ───────────────────────────────────────────────────
-#>  * Path: '/tmp/Rtmpc8OE8d/temp_libpath50206758a4f8/eplusr/extdata/1ZoneUnco...
+#>  * Path: '/tmp/RtmpiYeLsf/temp_libpathe5d7f4b4df7/eplusr/extdata/1ZoneUncon...
 #>  * Version: '8.8.0'
 #> 
 #> Group: <Simulation Parameters>
@@ -190,13 +192,13 @@ idf$object_relation("R13LAYER", "all")
 #> Target(s) does not refer to any other field.
 #> 
 #> ── Referred by Others ──────────────────────────────────────────────────────────
-#>   Class: <Material:NoMass>
-#>   └─ Object [ID:12] <R13LAYER>
-#>      └─ 1: "R13LAYER";    !- Name
-#>         ^~~~~~~~~~~~~~~~~~~~~~~~~
-#>         └─ Class: <Construction>
-#>            └─ Object [ID:15] <R13WALL>
-#>               └─ 2: "R13LAYER";    !- Outside Layer
+#>  Object [ID:12] <R13LAYER>
+#>   └─ 1: "R13LAYER";    !- Name
+#>      ^~~~~~~~~~~~~~~~~~~~~~~~~
+#>      └─ Class: <Construction>
+#>         └─ Object [ID:15] <R13WALL>
+#>            └─ 2: "R13LAYER";    !- Outside Layer
+#>  
 #> 
 #> ── Node Relation ───────────────────────────────────────────────────────────────
 #> Target(s) has no node or their nodes have no reference to other object.
@@ -225,6 +227,11 @@ idf$add(RunPeriod = list("run_period", 3, 1, 4, 1))
 #> │─ 09 : "No",             !- Apply Weekend Holiday Rule
 #> │─ 10 : "Yes",            !- Use Weather File Rain Indicators
 #> └─ 11 : "Yes";            !- Use Weather File Snow Indicators
+
+# purge unused resource objects
+idf$purge(group = "Schedules")
+#> Object(s) below have been purged:
+#>  #1| Object ID [19] (name 'Fraction') in class 'ScheduleTypeLimits'
 
 # get possible values for fields
 idf$Construction$FLOOR$value_possible("Outside Layer")
@@ -373,9 +380,9 @@ weekdays(weather$datetime)
 # run simulation
 job <- idf$run(epw)
 #> Adding an object in class `Output:SQLite` and setting its `Option Type` to `SimpleAndTabular` in order to create SQLite output file.
-#> Replace the existing IDF located at /tmp/Rtmpc8OE8d/model.idf.
+#> Replace the existing IDF located at /tmp/RtmpiYeLsf/model.idf.
 #> EnergyPlus Starting
-#> EnergyPlus, Version 8.8.0-7c3bbe4830, YMD=2020.03.03 15:36
+#> EnergyPlus, Version 8.8.0-7c3bbe4830, YMD=2020.03.15 04:31
 #> Processing Data Dictionary
 #> Processing Input File
 #> Initializing Simulation
@@ -410,7 +417,7 @@ job <- idf$run(epw)
 job$errors()
 #> ══ EnergyPlus Error File ═══════════════════════════════════════════════════════
 #>   * EnergyPlus version: 8.8.0 (7c3bbe4830)
-#>   * Simulation started: 2020-03-03 15:36:00
+#>   * Simulation started: 2020-03-15 04:31:00
 #>   * Terminated: FALSE
 #>   * Successful: TRUE
 #>   * Warning[W]: 2

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -476,6 +476,22 @@ idf$del(ids)
 
 
 ## ------------------------------------------------
+## Method `Idf$purge`
+## ------------------------------------------------
+
+\dontrun{
+# purge unused "Fraction" schedule type
+idf$purge("Fraction") # ScheduleTypeLimits
+
+# purge all unused schedule types
+idf$purge(class = "ScheduleTypeLimits")
+
+# purge all unused schedule related objects
+idf$purge(group = "Schedules")
+}
+
+
+## ------------------------------------------------
 ## Method `Idf$rename`
 ## ------------------------------------------------
 
@@ -834,6 +850,7 @@ Hongyuan Jia
 \item \href{#method-add}{\code{Idf$add()}}
 \item \href{#method-set}{\code{Idf$set()}}
 \item \href{#method-del}{\code{Idf$del()}}
+\item \href{#method-purge}{\code{Idf$purge()}}
 \item \href{#method-rename}{\code{Idf$rename()}}
 \item \href{#method-insert}{\code{Idf$insert()}}
 \item \href{#method-load}{\code{Idf$load()}}
@@ -2381,6 +2398,64 @@ idf$del("roof31", .ref_by = TRUE, .recursive = TRUE)
 # delete objects using variable inputs
 ids <- idf$object_id("Output:Variable", simplify = TRUE)
 idf$del(ids)
+}
+
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-purge"></a>}}
+\subsection{Method \code{purge()}}{
+purge resource objects that are not used
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Idf$purge(object = NULL, class = NULL, group = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{object}}{an integer vector of object IDs or a character vector
+of object names in current \code{Idf} object. Default: \code{NULL}.}
+
+\item{\code{class}}{A character vector of valid class names in current \code{Idf}
+object. Default: \code{NULL}.}
+
+\item{\code{group}}{A character vector of valid group names in current \code{Idf}
+object. Default: \code{NULL}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\verb{$purge()} takes an integer vector of object IDs or a character
+vectors of object names, and deletes resource objects specified that
+are not used by any objects.
+
+Here resource objects indicate all objects that can be referenced by
+other objects, e.g. all schedules. \verb{$purge()} will ignore any inputs
+that are not resources. If inputs contain objects from multiple
+classes, references among them are also taken into account, which
+means purging is performed hierarchically. If both materials and
+constructions are specified, the latter will be purged first, because
+it is possible that input constructions reference input materials.
+}
+
+\subsection{Returns}{
+The modified \code{Idf} object itself, invisibly.
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+# purge unused "Fraction" schedule type
+idf$purge("Fraction") # ScheduleTypeLimits
+
+# purge all unused schedule types
+idf$purge(class = "ScheduleTypeLimits")
+
+# purge all unused schedule related objects
+idf$purge(group = "Schedules")
 }
 
 }

--- a/vignettes/eplusr.Rmd
+++ b/vignettes/eplusr.Rmd
@@ -251,6 +251,7 @@ them.
 |                     | `$add()`                 | Add new objects                                   |
 |                     | `$set()`                 | Modify existing objects                           |
 |                     | `$del()`                 | Delete existing objects                           |
+|                     | `$purge()`               | Delete unused resource objects                    |
 |                     | `$rename()`              | Change object names                               |
 |                     | `$insert()`              | Add new objects from other `IdfObject`s           |
 |                     | `$load()`                | Add new objects from strings and data.frames      |
@@ -631,6 +632,15 @@ setting `.force` to `TRUE`.
 
 ```{r del_1}
 model$del("mat-clng-1", .force = TRUE)
+```
+
+### Purge object
+
+`$purge()` will delete resource objects specified that are not used by any
+objects. Below we remove all schedules that are not currently used.
+
+```{r purge}
+model$purge(group = "Schedules")
 ```
 
 ### Paste from IDF Editor


### PR DESCRIPTION
Pull request overview
---------------------
 - Resolves part of #178

A new method `Idf$purge()` has been added. It can be used to delete any resource objects that are not referenced by other objects. Here resource objects indicate all objects that can be referenced by other objects, e.g. all schedules. `$purge()` will ignore any inputs that are not resources. If inputs contain objects from multiple classes, references among them are also taken into account, which means purging is performed hierarchically. If both materials and constructions are specified, the latter will be purged first, because input constructions may reference input materials. `Idf$purge()` makes it quite straightforward to perform IDF cleaning. Actions like removing all materials, constructions, and schedules can be easily achieved via:
```
Idf$purge(class = c("Material", "Construction"), group = "Schedules")
```