### PR TITLE
[feat] Add more options to handle class name references

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,7 +25,9 @@
 
 * The algorithm of object/field/value relation extraction has been completed
   refactored. Now it can correctly detect object recursive-reference and it's
-  faster. All relation-related methods now have an unified interface:
+  faster (#222, #223).
+
+  All relation-related methods now have an unified interface:
 
   ```r
   X$method(which, direction, object = NULL, class = NULL, group = NULL, depth = NULL, keep = FALSE)
@@ -46,6 +48,28 @@
 
   With this update, it is possible, for example, to directly know the structure
   of an air loop by using `idf$object_relation("AnAirLoop", depth = NULL)`
+
+  Moreover, a new argument `class_ref` can be specified in methods of
+  value-relation extraction. It can be used to specify how to handle
+  class-name-references. Class name references refer to references in like
+  field `Component 1 Object Type` in `Branch` objects. Their value refers to
+  other many class names of objects, instaed of refering to specific field
+  values. There are 3 options in total, i.e. `"none"`, `"both"` and `"all"`,
+  with `"both"` being the default.
+
+  * `"none"`: just ignore class-name-references. It is a reasonable
+    option, as for most cases, class-name-references always come along with
+    field value references. Ignoring class-name-references will not impact the
+    most part of the relation structure.
+  * `"both"`: only include class-name-references if this object
+    also reference field values of the same one. For example, if the value of
+    field `Component 1 Object Type` is `Coil:Heating:Water`, only the object
+    that is referenced in the next field `Component 1 Name` is treated as
+    referenced by `Component 1 Object Type`. This is the default option.
+  * `"all"`: include all class-name-references. For example, if the
+    value of field `Component 1 Object Type` is `Coil:Heating:Water`, all
+    objects in `Coil:Heating:Water` will be treated as referenced by that
+    field. This is the most aggressive option.
 
 ## Minor changes
 

--- a/R/format.R
+++ b/R/format.R
@@ -548,7 +548,11 @@ format_idf_relation <- function (ref, direction = c("ref_to", "ref_by")) {
         } else  {
             ref[[1L]] <- ref[[1L]][, by = c("class_id", "object_id"), {
                 if (.N == 1L) {
-                    list(src_value_chr = c(object_name[[1L]], stri_sub(src_value_chr[[1L]][-(1:2)], 3L)))
+                    list(src_value_chr = c(
+                        class_name[[1L]],
+                        add_pre(object_name[[1L]]),
+                        paste0("   ", stri_sub(src_value_chr[[1L]][-(1:2)], 3L))
+                    ))
                 } else {
                     # remove class and field prefix
                     src <- lapply(src_value_chr,
@@ -558,7 +562,11 @@ format_idf_relation <- function (ref, direction = c("ref_to", "ref_by")) {
                     src[[.N]] <- add_pre(src[[.N]])
                     src[-.N] <- lapply(src[-.N], add_pre, FALSE)
 
-                    list(src_value_chr = c(object_name[[1L]], unlist(src, FALSE, FALSE)))
+                    list(src_value_chr = c(
+                        class_name[[1L]],
+                        add_pre(object_name[[1L]]),
+                        paste0("   ", unlist(src, FALSE, FALSE))
+                    ))
                 }
             }]
         }

--- a/R/idf.R
+++ b/R/idf.R
@@ -778,6 +778,28 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #'        regardless they have any relations with other objects or not.
         #'        If `FALSE`, only fields in specified object that have
         #'        relations with other objects are returned. Default: `FALSE`.
+        #' @param class_ref Specify how to handle class-name-references. Class
+        #'        name references refer to references in field `Component 1
+        #'        Object Type` in `Branch` objects. Their value refers to other
+        #'        many class names of objects, instaed of refering to specific
+        #'        field values. There are 3 options in total, i.e. `"none"`,
+        #'        `"less"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'       option, as for most cases, class-name-references always come
+        #'       along with field value references. Ignoring
+        #'       class-name-references will not impact the most part of the
+        #'       relation structure.
+        #'     * `"both"`: only include class-name-references if this object
+        #'       also reference field values of the same one. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, only the object that is referenced in the
+        #'       next field `Component 1 Name` is treated as referenced by
+        #'       `Component 1 Object Type`. This is the default option.
+        #'     * `"all"`: include all class-name-references. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will
+        #'       be treated as referenced by that field. This is the most
+        #'       aggressive option.
         #'
         #' @return An `IdfRelation` object, which is a list of 3
         #' [data.table::data.table()]s named `ref_to`, `ref_by` and `node`.
@@ -793,9 +815,10 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #' }
         #'
         object_relation = function (which, direction = c("all", "ref_to", "ref_by", "node"),
-                                    object = NULL, class = NULL, group = NULL, depth = 0L, keep = FALSE)
+                                    object = NULL, class = NULL, group = NULL, depth = 0L,
+                                    keep = FALSE, class_ref = c("both", "none", "all"))
             idf_object_relation(self, private, which, match.arg(direction),
-                object = object, class = class, group = group, depth = depth, keep = keep),
+                object = object, class = class, group = group, depth = depth, keep = keep, class_ref = match.arg(class_ref)),
         # }}}
 
         # objects_in_relation {{{
@@ -850,6 +873,28 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #'        `mat` is referred by a construction named `const`, and `const`
         #'        is also referred by a surface named `surf`. If `NULL`,
         #'        all possible recursive relations are returned. Default: `0`.
+        #' @param class_ref Specify how to handle class-name-references. Class
+        #'        name references refer to references in field `Component 1
+        #'        Object Type` in `Branch` objects. Their value refers to other
+        #'        many class names of objects, instaed of refering to specific
+        #'        field values. There are 3 options in total, i.e. `"none"`,
+        #'        `"less"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'       option, as for most cases, class-name-references always come
+        #'       along with field value references. Ignoring
+        #'       class-name-references will not impact the most part of the
+        #'       relation structure.
+        #'     * `"both"`: only include class-name-references if this object
+        #'       also reference field values of the same one. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, only the object that is referenced in the
+        #'       next field `Component 1 Name` is treated as referenced by
+        #'       `Component 1 Object Type`. This is the default option.
+        #'     * `"all"`: include all class-name-references. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will
+        #'       be treated as referenced by that field. This is the most
+        #'       aggressive option.
         #'
         #' @return An named list of [IdfObject] objects.
         #'
@@ -863,9 +908,10 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #' }
         #'
         objects_in_relation = function (which, direction = c("ref_to", "ref_by", "node"),
-                                        object = NULL, class = NULL, group = NULL, depth = 0L)
+                                        object = NULL, class = NULL, group = NULL, depth = 0L,
+                                        class_ref = c("both", "none", "all"))
             idf_objects_in_relation(self, private, which, match.arg(direction),
-                object = object, class = class, group = group, depth = depth),
+                object = object, class = class, group = group, depth = depth, class_ref = match.arg(class_ref)),
         # }}}
 
         # search_object {{{
@@ -2751,7 +2797,7 @@ idf_objects_in_group <- function (self, private, group) {
 idf_object_relation <- function (self, private, which,
                                  direction = c("all", "ref_to", "ref_by", "node"),
                                  object = NULL, class = NULL, group = NULL,
-                                 depth = 0L, keep = FALSE) {
+                                 depth = 0L, keep = FALSE, class_ref = c("both", "none", "all")) {
     assert(is_scalar(which))
 
     obj <- get_idf_object(private$idd_env(), private$idf_env(),
@@ -2760,21 +2806,22 @@ idf_object_relation <- function (self, private, which,
 
     get_idfobj_relation(private$idd_env(), private$idf_env(),
         object_id = obj$object_id, name = TRUE, direction = direction,
-        keep_all = keep, depth = depth,
+        keep_all = keep, depth = depth, class_ref = class_ref,
         object = object, class = class, group = group
     )
 }
 # }}}
 # idf_objects_in_relation {{{
 idf_objects_in_relation <- function (self, private, which, direction = c("ref_to", "ref_by", "node"),
-                                     object = NULL, class = NULL, group = NULL, depth = 0L) {
+                                     object = NULL, class = NULL, group = NULL, depth = 0L,
+                                     class_ref = c("both", "none", "all")) {
     assert(is_scalar(which))
     direction <- match.arg(direction)
 
     obj <- get_idf_object(private$idd_env(), private$idf_env(), object = which, ignore_case = TRUE)
     rel <- get_idfobj_relation(private$idd_env(), private$idf_env(), obj$object_id,
         name = FALSE, depth = depth, direction = direction,
-        object = object, class = class, group = group
+        object = object, class = class, group = group, class_ref = class_ref
     )
 
     id_self <- obj$object_id
@@ -3119,7 +3166,7 @@ idf_run <- function (self, private, epw, dir = NULL, wait = TRUE,
     # recreate job if the model has been changed since last ran
     } else if (
         normalizePath(private$m_path, mustWork = FALSE) !=
-        normalizePath(private$m_log$job$path("idf"), mustWork = FALSE)){
+        normalizePath(private$m_log$job$path("idf"), mustWork = FALSE)) {
         private$m_log$job <- EplusJob$new(self, epw)
     }
 

--- a/R/idf.R
+++ b/R/idf.R
@@ -779,12 +779,12 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #'        If `FALSE`, only fields in specified object that have
         #'        relations with other objects are returned. Default: `FALSE`.
         #' @param class_ref Specify how to handle class-name-references. Class
-        #'        name references refer to references in field `Component 1
+        #'        name references refer to references in like field `Component 1
         #'        Object Type` in `Branch` objects. Their value refers to other
         #'        many class names of objects, instaed of refering to specific
         #'        field values. There are 3 options in total, i.e. `"none"`,
-        #'        `"less"` and `"all"`, with `"both"` being the default.
-        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'        `"both"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonable
         #'       option, as for most cases, class-name-references always come
         #'       along with field value references. Ignoring
         #'       class-name-references will not impact the most part of the
@@ -874,12 +874,12 @@ Idf <- R6::R6Class(classname = "Idf", lock_objects = FALSE,
         #'        is also referred by a surface named `surf`. If `NULL`,
         #'        all possible recursive relations are returned. Default: `0`.
         #' @param class_ref Specify how to handle class-name-references. Class
-        #'        name references refer to references in field `Component 1
+        #'        name references refer to references in like field `Component 1
         #'        Object Type` in `Branch` objects. Their value refers to other
         #'        many class names of objects, instaed of refering to specific
         #'        field values. There are 3 options in total, i.e. `"none"`,
-        #'        `"less"` and `"all"`, with `"both"` being the default.
-        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'        `"both"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonable
         #'       option, as for most cases, class-name-references always come
         #'       along with field value references. Ignoring
         #'       class-name-references will not impact the most part of the

--- a/R/idf_object.R
+++ b/R/idf_object.R
@@ -775,6 +775,29 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        fields in input that have relations with other objects are
         #'        returned. Default: `FALSE`.
         #'
+        #' @param class_ref Specify how to handle class-name-references. Class
+        #'        name references refer to references in field `Component 1
+        #'        Object Type` in `Branch` objects. Their value refers to other
+        #'        many class names of objects, instaed of refering to specific
+        #'        field values. There are 3 options in total, i.e. `"none"`,
+        #'        `"less"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'       option, as for most cases, class-name-references always come
+        #'       along with field value references. Ignoring
+        #'       class-name-references will not impact the most part of the
+        #'       relation structure.
+        #'     * `"both"`: only include class-name-references if this object
+        #'       also reference field values of the same one. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, only the object that is referenced in the
+        #'       next field `Component 1 Name` is treated as referenced by
+        #'       `Component 1 Object Type`. This is the default option.
+        #'     * `"all"`: include all class-name-references. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will
+        #'       be treated as referenced by that field. This is the most
+        #'       aggressive option.
+        #'
         #' @return An `IdfRelation` object, which is a list of 3
         #' [data.table::data.table()]s named `ref_to`, `ref_by` and `node`.
         #' Each [data.table::data.table()] contains 24 columns.
@@ -789,9 +812,11 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #' }
         #'
         value_relation = function (which = NULL, direction = c("all", "ref_to", "ref_by", "node"),
-                                   object = NULL, class = NULL, group = NULL, depth = 0L, keep = FALSE)
+                                   object = NULL, class = NULL, group = NULL, depth = 0L, keep = FALSE,
+                                   class_ref = c("both", "none", "all"))
             idfobj_value_relation(self, private, which, match.arg(direction),
-                                  object = object, class = class, group = group, depth = depth, keep = keep),
+                                  object = object, class = class, group = group,
+                                  depth = depth, keep = keep, class_ref = match.arg(class_ref)),
         # }}}
 
         # ref_to_object {{{
@@ -824,6 +849,29 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        is also referred by a surface named `surf`. If `NULL`,
         #'        all possible recursive relations are returned. Default: `0`.
         #'
+        #' @param class_ref Specify how to handle class-name-references. Class
+        #'        name references refer to references in field `Component 1
+        #'        Object Type` in `Branch` objects. Their value refers to other
+        #'        many class names of objects, instaed of refering to specific
+        #'        field values. There are 3 options in total, i.e. `"none"`,
+        #'        `"less"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'       option, as for most cases, class-name-references always come
+        #'       along with field value references. Ignoring
+        #'       class-name-references will not impact the most part of the
+        #'       relation structure.
+        #'     * `"both"`: only include class-name-references if this object
+        #'       also reference field values of the same one. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, only the object that is referenced in the
+        #'       next field `Component 1 Name` is treated as referenced by
+        #'       `Component 1 Object Type`. This is the default option.
+        #'     * `"all"`: include all class-name-references. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will
+        #'       be treated as referenced by that field. This is the most
+        #'       aggressive option.
+        #'
         #' @return A named list of `IdfObject` objects.
         #'
         #' @examples
@@ -832,8 +880,8 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #' mat$ref_to_object() # not referencing other objects
         #' }
         #'
-        ref_to_object = function (which = NULL, object = NULL, class = NULL, group = NULL, depth = 0L)
-            idfobj_ref_to_object(self, private, which, object = NULL, class = class, group = group, depth = depth),
+        ref_to_object = function (which = NULL, object = NULL, class = NULL, group = NULL, depth = 0L, class_ref = c("both", "none", "all"))
+            idfobj_ref_to_object(self, private, which, object = NULL, class = class, group = group, depth = depth, class_ref = match.arg(class_ref)),
         # }}}
 
         # ref_by_object {{{
@@ -866,6 +914,29 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        is also referred by a surface named `surf`. If `NULL`,
         #'        all possible recursive relations are returned. Default: `0`.
         #'
+        #' @param class_ref Specify how to handle class-name-references. Class
+        #'        name references refer to references in field `Component 1
+        #'        Object Type` in `Branch` objects. Their value refers to other
+        #'        many class names of objects, instaed of refering to specific
+        #'        field values. There are 3 options in total, i.e. `"none"`,
+        #'        `"less"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'       option, as for most cases, class-name-references always come
+        #'       along with field value references. Ignoring
+        #'       class-name-references will not impact the most part of the
+        #'       relation structure.
+        #'     * `"both"`: only include class-name-references if this object
+        #'       also reference field values of the same one. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, only the object that is referenced in the
+        #'       next field `Component 1 Name` is treated as referenced by
+        #'       `Component 1 Object Type`. This is the default option.
+        #'     * `"all"`: include all class-name-references. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will
+        #'       be treated as referenced by that field. This is the most
+        #'       aggressive option.
+        #'
         #' @return A named list of `IdfObject` objects.
         #'
         #' @examples
@@ -874,8 +945,8 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #' mat$ref_by_object() # referenced by construction "FLOOR"
         #' }
         #'
-        ref_by_object = function (which = NULL, object = NULL, class = NULL, group = NULL, depth = 0L)
-            idfobj_ref_by_object(self, private, which, object = object, class = class, group = group, depth = depth),
+        ref_by_object = function (which = NULL, object = NULL, class = NULL, group = NULL, depth = 0L, class_ref = c("both", "none", "all"))
+            idfobj_ref_by_object(self, private, which, object = object, class = class, group = group, depth = depth, class_ref = match.arg(class_ref)),
         # }}}
 
         # ref_to_node {{{
@@ -952,6 +1023,29 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        `mat` is referred by a construction named `const`, and `const`
         #'        is also referred by a surface named `surf`. Default: `FALSE`.
         #'
+        #' @param class_ref Specify how to handle class-name-references. Class
+        #'        name references refer to references in field `Component 1
+        #'        Object Type` in `Branch` objects. Their value refers to other
+        #'        many class names of objects, instaed of refering to specific
+        #'        field values. There are 3 options in total, i.e. `"none"`,
+        #'        `"less"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'       option, as for most cases, class-name-references always come
+        #'       along with field value references. Ignoring
+        #'       class-name-references will not impact the most part of the
+        #'       relation structure.
+        #'     * `"both"`: only include class-name-references if this object
+        #'       also reference field values of the same one. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, only the object that is referenced in the
+        #'       next field `Component 1 Name` is treated as referenced by
+        #'       `Component 1 Object Type`. This is the default option.
+        #'     * `"all"`: include all class-name-references. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will
+        #'       be treated as referenced by that field. This is the most
+        #'       aggressive option.
+        #'
         #' @return A logical vector with the same length as specified field.
         #'
         #' @examples
@@ -959,8 +1053,8 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #' mat$has_ref_to()
         #' }
         #'
-        has_ref_to = function (which = NULL, object = NULL, class = NULL, group = NULL, recursive = FALSE)
-            idfobj_has_ref_to(self, private, which, object = object, class = class, group = group, recursive = recursive),
+        has_ref_to = function (which = NULL, object = NULL, class = NULL, group = NULL, recursive = FALSE, class_ref = c("both", "none", "all"))
+            idfobj_has_ref_to(self, private, which, object = object, class = class, group = group, recursive = recursive, class_ref = match.arg(class_ref)),
         # }}}
 
         # has_ref_by {{{
@@ -992,6 +1086,29 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        `mat` is referred by a construction named `const`, and `const`
         #'        is also referred by a surface named `surf`. Default: `FALSE`.
         #'
+        #' @param class_ref Specify how to handle class-name-references. Class
+        #'        name references refer to references in field `Component 1
+        #'        Object Type` in `Branch` objects. Their value refers to other
+        #'        many class names of objects, instaed of refering to specific
+        #'        field values. There are 3 options in total, i.e. `"none"`,
+        #'        `"less"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'       option, as for most cases, class-name-references always come
+        #'       along with field value references. Ignoring
+        #'       class-name-references will not impact the most part of the
+        #'       relation structure.
+        #'     * `"both"`: only include class-name-references if this object
+        #'       also reference field values of the same one. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, only the object that is referenced in the
+        #'       next field `Component 1 Name` is treated as referenced by
+        #'       `Component 1 Object Type`. This is the default option.
+        #'     * `"all"`: include all class-name-references. For example, if the
+        #'       value of field `Component 1 Object Type` is
+        #'       `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will
+        #'       be treated as referenced by that field. This is the most
+        #'       aggressive option.
+        #'
         #' @return A logical vector with the same length as specified field.
         #'
         #' @examples
@@ -999,8 +1116,8 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #' mat$has_ref_by()
         #' }
         #'
-        has_ref_by = function (which = NULL, object = NULL, class = NULL, group = NULL, recursive = FALSE)
-            idfobj_has_ref_by(self, private, which, object = object, class = class, group = group, recursive = recursive),
+        has_ref_by = function (which = NULL, object = NULL, class = NULL, group = NULL, recursive = FALSE, class_ref = c("both", "none", "all"))
+            idfobj_has_ref_by(self, private, which, object = object, class = class, group = group, recursive = recursive, class_ref = match.arg(class_ref)),
         # }}}
 
         # has_ref_node {{{
@@ -1562,7 +1679,8 @@ idfobj_is_valid <- function (self, private, level = eplusr_option("validate_leve
 # idfobj_value_relation {{{
 idfobj_value_relation <- function (self, private, which = NULL,
                                    direction = c("all", "ref_to", "ref_by", "node"),
-                                   object = object, class = NULL, group = NULL, depth = 0L, keep = FALSE) {
+                                   object = object, class = NULL, group = NULL, depth = 0L,
+                                   keep = FALSE, class_ref = c("both", "none", "all")) {
     direction <- match.arg(direction)
 
     val <- get_idf_value(private$idd_env(), private$idf_env(),
@@ -1571,18 +1689,20 @@ idfobj_value_relation <- function (self, private, which = NULL,
 
     get_idfobj_relation(private$idd_env(), private$idf_env(), object_id = NULL,
         value_id = val$value_id, name = TRUE, direction = direction, object = object,
-        class = class, group = group, depth = depth, keep_all = keep)
+        class = class, group = group, depth = depth, keep_all = keep, class_ref = match.arg(class_ref))
 }
 # }}}
 # idfobj_ref_to_object {{{
-idfobj_ref_to_object <- function (self, private, which = NULL, object = NULL, class = NULL, group = NULL, depth = 0L) {
+idfobj_ref_to_object <- function (self, private, which = NULL, object = NULL,
+                                  class = NULL, group = NULL, depth = 0L,
+                                  class_ref = c("both", "none", "all")) {
     val <- get_idf_value(private$idd_env(), private$idf_env(),
         object = private$m_object_id, field = which
     )
 
     # exclude invalid references
     rel <- get_idf_relation(private$idd_env(), private$idf_env(),
-        value_id = val$value_id, direction = "ref_to",
+        value_id = val$value_id, direction = "ref_to", class_ref = match.arg(class_ref),
         object = object, class = class, group = group, depth = depth
     )[!is.na(src_value_id)]
 
@@ -1611,14 +1731,16 @@ idfobj_ref_to_object <- function (self, private, which = NULL, object = NULL, cl
 }
 # }}}
 # idfobj_ref_by_object {{{
-idfobj_ref_by_object <- function (self, private, which = NULL, object = NULL, class = NULL, group = NULL, depth = 0L) {
+idfobj_ref_by_object <- function (self, private, which = NULL, object = NULL,
+                                  class = NULL, group = NULL, depth = 0L,
+                                  class_ref = c("both", "none", "all")) {
     val <- get_idf_value(private$idd_env(), private$idf_env(),
         object = private$m_object_id, field = which
     )
 
     # exclude invalid references
     rel <- get_idf_relation(private$idd_env(), private$idf_env(),
-        value_id = val$value_id, direction = "ref_by",
+        value_id = val$value_id, direction = "ref_by", class_ref = match.arg(class_ref),
         object = object, class = class, group = group, depth = depth
     )[!is.na(value_id)]
 
@@ -1684,13 +1806,15 @@ idfobj_ref_to_node <- function (self, private, which = NULL, object = NULL, clas
 }
 # }}}
 # idfobj_has_ref {{{
-idfobj_has_ref <- function (self, private, which = NULL, object = NULL, class = NULL, group = NULL, type = c("all", "ref_to", "ref_by", "node"), recursive = FALSE) {
+idfobj_has_ref <- function (self, private, which = NULL, object = NULL,
+                            class = NULL, group = NULL, type = c("all", "ref_to", "ref_by", "node"),
+                            recursive = FALSE, class_ref = c("both", "none", "all")) {
     depth <- if (recursive) NULL else 0L
     type <- match.arg(type)
     if (is.null(which)) {
         rel <- get_idfobj_relation(private$idd_env(), private$idf_env(), private$m_object_id,
             NULL, FALSE, direction = type, object = object, class = class, group = group, depth = depth,
-            keep_all = TRUE)
+            keep_all = TRUE, class_ref = match.arg(class_ref))
     } else {
         val <- get_idf_value(private$idd_env(), private$idf_env(),
             object = private$m_object_id, field = which
@@ -1698,7 +1822,8 @@ idfobj_has_ref <- function (self, private, which = NULL, object = NULL, class = 
 
         rel <- get_idfobj_relation(private$idd_env(), private$idf_env(),
             value_id = val$value_id, direction = type, object = object,
-            class = class, group = group, depth = depth, keep_all = TRUE)
+            class = class, group = group, depth = depth, keep_all = TRUE,
+            class_ref = match.arg(class_ref))
     }
 
     if (type == "all") {
@@ -1715,13 +1840,19 @@ idfobj_has_ref <- function (self, private, which = NULL, object = NULL, class = 
 }
 # }}}
 # idfobj_has_ref_to {{{
-idfobj_has_ref_to <- function (self, private, which = NULL, object = NULL, class = NULL, group = NULL, recursive = FALSE) {
-    idfobj_has_ref(self, private, which, object = object, class = class, group = group, recursive = recursive, type = "ref_to")
+idfobj_has_ref_to <- function (self, private, which = NULL, object = NULL,
+                               class = NULL, group = NULL, recursive = FALSE,
+                               class_ref = c("both", "none", "all")) {
+    idfobj_has_ref(self, private, which, object = object, class = class, group = group,
+        recursive = recursive, type = "ref_to", class_ref = match.arg(class_ref))
 }
 # }}}
 # idfobj_has_ref_by {{{
-idfobj_has_ref_by <- function (self, private, which = NULL, object = NULL, class = NULL, group = NULL, recursive = FALSE) {
-    idfobj_has_ref(self, private, which, object = object, class = class, group = group, recursive = recursive, type = "ref_by")
+idfobj_has_ref_by <- function (self, private, which = NULL, object = NULL,
+                               class = NULL, group = NULL, recursive = FALSE,
+                               class_ref = c("both", "none", "all")) {
+    idfobj_has_ref(self, private, which, object = object, class = class, group = group,
+        recursive = recursive, type = "ref_by", class_ref = match.arg(class_ref))
 }
 # }}}
 # idfobj_has_ref_node {{{

--- a/R/idf_object.R
+++ b/R/idf_object.R
@@ -776,12 +776,12 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        returned. Default: `FALSE`.
         #'
         #' @param class_ref Specify how to handle class-name-references. Class
-        #'        name references refer to references in field `Component 1
+        #'        name references refer to references in like field `Component 1
         #'        Object Type` in `Branch` objects. Their value refers to other
         #'        many class names of objects, instaed of refering to specific
         #'        field values. There are 3 options in total, i.e. `"none"`,
-        #'        `"less"` and `"all"`, with `"both"` being the default.
-        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'        `"both"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonable
         #'       option, as for most cases, class-name-references always come
         #'       along with field value references. Ignoring
         #'       class-name-references will not impact the most part of the
@@ -850,12 +850,12 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        all possible recursive relations are returned. Default: `0`.
         #'
         #' @param class_ref Specify how to handle class-name-references. Class
-        #'        name references refer to references in field `Component 1
+        #'        name references refer to references in like field `Component 1
         #'        Object Type` in `Branch` objects. Their value refers to other
         #'        many class names of objects, instaed of refering to specific
         #'        field values. There are 3 options in total, i.e. `"none"`,
-        #'        `"less"` and `"all"`, with `"both"` being the default.
-        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'        `"both"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonable
         #'       option, as for most cases, class-name-references always come
         #'       along with field value references. Ignoring
         #'       class-name-references will not impact the most part of the
@@ -915,12 +915,12 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        all possible recursive relations are returned. Default: `0`.
         #'
         #' @param class_ref Specify how to handle class-name-references. Class
-        #'        name references refer to references in field `Component 1
+        #'        name references refer to references in like field `Component 1
         #'        Object Type` in `Branch` objects. Their value refers to other
         #'        many class names of objects, instaed of refering to specific
         #'        field values. There are 3 options in total, i.e. `"none"`,
-        #'        `"less"` and `"all"`, with `"both"` being the default.
-        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'        `"both"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonable
         #'       option, as for most cases, class-name-references always come
         #'       along with field value references. Ignoring
         #'       class-name-references will not impact the most part of the
@@ -1024,12 +1024,12 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        is also referred by a surface named `surf`. Default: `FALSE`.
         #'
         #' @param class_ref Specify how to handle class-name-references. Class
-        #'        name references refer to references in field `Component 1
+        #'        name references refer to references in like field `Component 1
         #'        Object Type` in `Branch` objects. Their value refers to other
         #'        many class names of objects, instaed of refering to specific
         #'        field values. There are 3 options in total, i.e. `"none"`,
-        #'        `"less"` and `"all"`, with `"both"` being the default.
-        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'        `"both"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonable
         #'       option, as for most cases, class-name-references always come
         #'       along with field value references. Ignoring
         #'       class-name-references will not impact the most part of the
@@ -1087,12 +1087,12 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #'        is also referred by a surface named `surf`. Default: `FALSE`.
         #'
         #' @param class_ref Specify how to handle class-name-references. Class
-        #'        name references refer to references in field `Component 1
+        #'        name references refer to references in like field `Component 1
         #'        Object Type` in `Branch` objects. Their value refers to other
         #'        many class names of objects, instaed of refering to specific
         #'        field values. There are 3 options in total, i.e. `"none"`,
-        #'        `"less"` and `"all"`, with `"both"` being the default.
-        #'     * `"none"`: just ignore class-name-references. It is a reasonal
+        #'        `"both"` and `"all"`, with `"both"` being the default.
+        #'     * `"none"`: just ignore class-name-references. It is a reasonable
         #'       option, as for most cases, class-name-references always come
         #'       along with field value references. Ignoring
         #'       class-name-references will not impact the most part of the

--- a/R/impl-idfobj.R
+++ b/R/impl-idfobj.R
@@ -233,7 +233,7 @@ get_idfobj_possible <- function (idd_env, idf_env, object, field,
 get_idfobj_relation <- function (idd_env, idf_env, object_id = NULL, value_id = NULL,
                                  name = TRUE, direction = c("ref_to", "ref_by", "node", "all"),
                                  object = NULL, class = NULL, group = NULL,
-                                 keep_all = FALSE, depth = 0L) {
+                                 keep_all = FALSE, depth = 0L, class_ref = c("both", "none", "all")) {
     all_dir <- c("ref_to", "ref_by", "node", "all")
     direction <- all_dir[sort(chmatch(direction, all_dir))]
     assert(no_na(direction), msg = paste0("`direction` should be one or some of ", collapse(all_dir)))
@@ -245,14 +245,14 @@ get_idfobj_relation <- function (idd_env, idf_env, object_id = NULL, value_id = 
     if ("ref_to" %in% direction) {
         rel$ref_to <- get_idf_relation(idd_env, idf_env, object_id = object_id, value_id,
             depth = depth, name = name, direction = "ref_to", keep_all = keep_all,
-            object = object, class = class, group = group
+            object = object, class = class, group = group, class_ref = match.arg(class_ref)
         )
     }
 
     if ("ref_by" %in% direction) {
         rel$ref_by <- get_idf_relation(idd_env, idf_env, object_id = object_id, value_id,
             depth = depth, name = name, direction = "ref_by", keep_all = keep_all,
-            object = object, class = class, group = group
+            object = object, class = class, group = group, class_ref = match.arg(class_ref)
         )
     }
 
@@ -262,7 +262,6 @@ get_idfobj_relation <- function (idd_env, idf_env, object_id = NULL, value_id = 
             object = object, class = class, group = group
         )
     }
-
 
     setattr(rel, "class", c("IdfRelation", class(rel)))
 

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -1775,7 +1775,8 @@ Extract the relationship between object field values.
   class = NULL,
   group = NULL,
   depth = 0L,
-  keep = FALSE
+  keep = FALSE,
+  class_ref = c("both", "none", "all")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1807,6 +1808,28 @@ all possible recursive relations are returned. Default: \code{0}.}
 regardless they have any relations with other objects or not.
 If \code{FALSE}, only fields in specified object that have
 relations with other objects are returned. Default: \code{FALSE}.}
+
+\item{\code{class_ref}}{Specify how to handle class-name-references. Class
+name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+many class names of objects, instaed of refering to specific
+field values. There are 3 options in total, i.e. \code{"none"},
+\code{"less"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonal
+option, as for most cases, class-name-references always come
+along with field value references. Ignoring
+class-name-references will not impact the most part of the
+relation structure.
+* \code{"both"}: only include class-name-references if this object
+also reference field values of the same one. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, only the object that is referenced in the
+next field \verb{Component 1 Name} is treated as referenced by
+\verb{Component 1 Object Type}. This is the default option.
+* \code{"all"}: include all class-name-references. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, all objects in \code{Coil:Heating:Water} will
+be treated as referenced by that field. This is the most
+aggressive option.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1874,7 +1897,8 @@ Extract multiple \link{IdfObject} objects referencing each others.
   object = NULL,
   class = NULL,
   group = NULL,
-  depth = 0L
+  depth = 0L,
+  class_ref = c("both", "none", "all")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1907,6 +1931,28 @@ simple example of recursive reference: one material named
 \code{mat} is referred by a construction named \code{const}, and \code{const}
 is also referred by a surface named \code{surf}. If \code{NULL},
 all possible recursive relations are returned. Default: \code{0}.}
+
+\item{\code{class_ref}}{Specify how to handle class-name-references. Class
+name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+many class names of objects, instaed of refering to specific
+field values. There are 3 options in total, i.e. \code{"none"},
+\code{"less"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonal
+option, as for most cases, class-name-references always come
+along with field value references. Ignoring
+class-name-references will not impact the most part of the
+relation structure.
+* \code{"both"}: only include class-name-references if this object
+also reference field values of the same one. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, only the object that is referenced in the
+next field \verb{Component 1 Name} is treated as referenced by
+\verb{Component 1 Object Type}. This is the default option.
+* \code{"all"}: include all class-name-references. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, all objects in \code{Coil:Heating:Water} will
+be treated as referenced by that field. This is the most
+aggressive option.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -1810,11 +1810,11 @@ If \code{FALSE}, only fields in specified object that have
 relations with other objects are returned. Default: \code{FALSE}.}
 
 \item{\code{class_ref}}{Specify how to handle class-name-references. Class
-name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+name references refer to references in like field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
 many class names of objects, instaed of refering to specific
 field values. There are 3 options in total, i.e. \code{"none"},
-\code{"less"} and \code{"all"}, with \code{"both"} being the default.
-* \code{"none"}: just ignore class-name-references. It is a reasonal
+\code{"both"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonable
 option, as for most cases, class-name-references always come
 along with field value references. Ignoring
 class-name-references will not impact the most part of the
@@ -1933,11 +1933,11 @@ is also referred by a surface named \code{surf}. If \code{NULL},
 all possible recursive relations are returned. Default: \code{0}.}
 
 \item{\code{class_ref}}{Specify how to handle class-name-references. Class
-name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+name references refer to references in like field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
 many class names of objects, instaed of refering to specific
 field values. There are 3 options in total, i.e. \code{"none"},
-\code{"less"} and \code{"all"}, with \code{"both"} being the default.
-* \code{"none"}: just ignore class-name-references. It is a reasonal
+\code{"both"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonable
 option, as for most cases, class-name-references always come
 along with field value references. Ignoring
 class-name-references will not impact the most part of the

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -1257,7 +1257,8 @@ Get value relations
   class = NULL,
   group = NULL,
   depth = 0L,
-  keep = FALSE
+  keep = FALSE,
+  class_ref = c("both", "none", "all")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1289,6 +1290,28 @@ all possible recursive relations are returned. Default: \code{0}.}
 have any relations with other objects or not. If \code{FALSE}, only
 fields in input that have relations with other objects are
 returned. Default: \code{FALSE}.}
+
+\item{\code{class_ref}}{Specify how to handle class-name-references. Class
+name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+many class names of objects, instaed of refering to specific
+field values. There are 3 options in total, i.e. \code{"none"},
+\code{"less"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonal
+option, as for most cases, class-name-references always come
+along with field value references. Ignoring
+class-name-references will not impact the most part of the
+relation structure.
+* \code{"both"}: only include class-name-references if this object
+also reference field values of the same one. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, only the object that is referenced in the
+next field \verb{Component 1 Name} is treated as referenced by
+\verb{Component 1 Object Type}. This is the default option.
+* \code{"all"}: include all class-name-references. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, all objects in \code{Coil:Heating:Water} will
+be treated as referenced by that field. This is the most
+aggressive option.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1356,7 +1379,8 @@ Extract multiple \code{IdfObject} objects referred by specified field values
   object = NULL,
   class = NULL,
   group = NULL,
-  depth = 0L
+  depth = 0L,
+  class_ref = c("both", "none", "all")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1380,6 +1404,28 @@ simple example of recursive reference: one material named
 \code{mat} is referred by a construction named \code{const}, and \code{const}
 is also referred by a surface named \code{surf}. If \code{NULL},
 all possible recursive relations are returned. Default: \code{0}.}
+
+\item{\code{class_ref}}{Specify how to handle class-name-references. Class
+name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+many class names of objects, instaed of refering to specific
+field values. There are 3 options in total, i.e. \code{"none"},
+\code{"less"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonal
+option, as for most cases, class-name-references always come
+along with field value references. Ignoring
+class-name-references will not impact the most part of the
+relation structure.
+* \code{"both"}: only include class-name-references if this object
+also reference field values of the same one. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, only the object that is referenced in the
+next field \verb{Component 1 Name} is treated as referenced by
+\verb{Component 1 Object Type}. This is the default option.
+* \code{"all"}: include all class-name-references. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, all objects in \code{Coil:Heating:Water} will
+be treated as referenced by that field. This is the most
+aggressive option.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1418,7 +1464,8 @@ Extract multiple \code{IdfObject} objects referring to specified field values
   object = NULL,
   class = NULL,
   group = NULL,
-  depth = 0L
+  depth = 0L,
+  class_ref = c("both", "none", "all")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1442,6 +1489,28 @@ simple example of recursive reference: one material named
 \code{mat} is referred by a construction named \code{const}, and \code{const}
 is also referred by a surface named \code{surf}. If \code{NULL},
 all possible recursive relations are returned. Default: \code{0}.}
+
+\item{\code{class_ref}}{Specify how to handle class-name-references. Class
+name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+many class names of objects, instaed of refering to specific
+field values. There are 3 options in total, i.e. \code{"none"},
+\code{"less"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonal
+option, as for most cases, class-name-references always come
+along with field value references. Ignoring
+class-name-references will not impact the most part of the
+relation structure.
+* \code{"both"}: only include class-name-references if this object
+also reference field values of the same one. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, only the object that is referenced in the
+next field \verb{Component 1 Name} is treated as referenced by
+\verb{Component 1 Object Type}. This is the default option.
+* \code{"all"}: include all class-name-references. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, all objects in \code{Coil:Heating:Water} will
+be treated as referenced by that field. This is the most
+aggressive option.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1545,7 +1614,8 @@ Check if object field values refer to others
   object = NULL,
   class = NULL,
   group = NULL,
-  recursive = FALSE
+  recursive = FALSE,
+  class_ref = c("both", "none", "all")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1568,6 +1638,28 @@ relations. Default: \code{NULL}.}
 simple example of recursive reference: one material named
 \code{mat} is referred by a construction named \code{const}, and \code{const}
 is also referred by a surface named \code{surf}. Default: \code{FALSE}.}
+
+\item{\code{class_ref}}{Specify how to handle class-name-references. Class
+name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+many class names of objects, instaed of refering to specific
+field values. There are 3 options in total, i.e. \code{"none"},
+\code{"less"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonal
+option, as for most cases, class-name-references always come
+along with field value references. Ignoring
+class-name-references will not impact the most part of the
+relation structure.
+* \code{"both"}: only include class-name-references if this object
+also reference field values of the same one. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, only the object that is referenced in the
+next field \verb{Component 1 Name} is treated as referenced by
+\verb{Component 1 Object Type}. This is the default option.
+* \code{"all"}: include all class-name-references. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, all objects in \code{Coil:Heating:Water} will
+be treated as referenced by that field. This is the most
+aggressive option.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1605,7 +1697,8 @@ Check if object field values are referred by others
   object = NULL,
   class = NULL,
   group = NULL,
-  recursive = FALSE
+  recursive = FALSE,
+  class_ref = c("both", "none", "all")
 )}\if{html}{\out{</div>}}
 }
 
@@ -1628,6 +1721,28 @@ relations. Default: \code{NULL}.}
 simple example of recursive reference: one material named
 \code{mat} is referred by a construction named \code{const}, and \code{const}
 is also referred by a surface named \code{surf}. Default: \code{FALSE}.}
+
+\item{\code{class_ref}}{Specify how to handle class-name-references. Class
+name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+many class names of objects, instaed of refering to specific
+field values. There are 3 options in total, i.e. \code{"none"},
+\code{"less"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonal
+option, as for most cases, class-name-references always come
+along with field value references. Ignoring
+class-name-references will not impact the most part of the
+relation structure.
+* \code{"both"}: only include class-name-references if this object
+also reference field values of the same one. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, only the object that is referenced in the
+next field \verb{Component 1 Name} is treated as referenced by
+\verb{Component 1 Object Type}. This is the default option.
+* \code{"all"}: include all class-name-references. For example, if the
+value of field \verb{Component 1 Object Type} is
+\code{Coil:Heating:Water}, all objects in \code{Coil:Heating:Water} will
+be treated as referenced by that field. This is the most
+aggressive option.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -1292,11 +1292,11 @@ fields in input that have relations with other objects are
 returned. Default: \code{FALSE}.}
 
 \item{\code{class_ref}}{Specify how to handle class-name-references. Class
-name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+name references refer to references in like field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
 many class names of objects, instaed of refering to specific
 field values. There are 3 options in total, i.e. \code{"none"},
-\code{"less"} and \code{"all"}, with \code{"both"} being the default.
-* \code{"none"}: just ignore class-name-references. It is a reasonal
+\code{"both"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonable
 option, as for most cases, class-name-references always come
 along with field value references. Ignoring
 class-name-references will not impact the most part of the
@@ -1406,11 +1406,11 @@ is also referred by a surface named \code{surf}. If \code{NULL},
 all possible recursive relations are returned. Default: \code{0}.}
 
 \item{\code{class_ref}}{Specify how to handle class-name-references. Class
-name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+name references refer to references in like field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
 many class names of objects, instaed of refering to specific
 field values. There are 3 options in total, i.e. \code{"none"},
-\code{"less"} and \code{"all"}, with \code{"both"} being the default.
-* \code{"none"}: just ignore class-name-references. It is a reasonal
+\code{"both"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonable
 option, as for most cases, class-name-references always come
 along with field value references. Ignoring
 class-name-references will not impact the most part of the
@@ -1491,11 +1491,11 @@ is also referred by a surface named \code{surf}. If \code{NULL},
 all possible recursive relations are returned. Default: \code{0}.}
 
 \item{\code{class_ref}}{Specify how to handle class-name-references. Class
-name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+name references refer to references in like field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
 many class names of objects, instaed of refering to specific
 field values. There are 3 options in total, i.e. \code{"none"},
-\code{"less"} and \code{"all"}, with \code{"both"} being the default.
-* \code{"none"}: just ignore class-name-references. It is a reasonal
+\code{"both"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonable
 option, as for most cases, class-name-references always come
 along with field value references. Ignoring
 class-name-references will not impact the most part of the
@@ -1640,11 +1640,11 @@ simple example of recursive reference: one material named
 is also referred by a surface named \code{surf}. Default: \code{FALSE}.}
 
 \item{\code{class_ref}}{Specify how to handle class-name-references. Class
-name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+name references refer to references in like field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
 many class names of objects, instaed of refering to specific
 field values. There are 3 options in total, i.e. \code{"none"},
-\code{"less"} and \code{"all"}, with \code{"both"} being the default.
-* \code{"none"}: just ignore class-name-references. It is a reasonal
+\code{"both"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonable
 option, as for most cases, class-name-references always come
 along with field value references. Ignoring
 class-name-references will not impact the most part of the
@@ -1723,11 +1723,11 @@ simple example of recursive reference: one material named
 is also referred by a surface named \code{surf}. Default: \code{FALSE}.}
 
 \item{\code{class_ref}}{Specify how to handle class-name-references. Class
-name references refer to references in field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
+name references refer to references in like field \verb{Component 1 Object Type} in \code{Branch} objects. Their value refers to other
 many class names of objects, instaed of refering to specific
 field values. There are 3 options in total, i.e. \code{"none"},
-\code{"less"} and \code{"all"}, with \code{"both"} being the default.
-* \code{"none"}: just ignore class-name-references. It is a reasonal
+\code{"both"} and \code{"all"}, with \code{"both"} being the default.
+* \code{"none"}: just ignore class-name-references. It is a reasonable
 option, as for most cases, class-name-references always come
 along with field value references. Ignoring
 class-name-references will not impact the most part of the


### PR DESCRIPTION
Pull request overview
---------------------
 - Related to #221 and PR #222
 - Fix errors in relation extraction when `class` and `group` are specified
 - Make sure root class names are printed in relation objects
 - Add a new parameter in all `class_ref` relation method to specify how to handle class name references.

* `"none"`: just ignore class-name-references. It is a reasonable option, as for most cases, class-name-references always come along with field value references. Ignoring class-name-references will not impact the most part of the relation structure.
* `"both"`: only include class-name-references if this object also references field values of the same one. For example, if the value of field `Component 1 Object Type` is `Coil:Heating:Water`, only the object that is referenced in the next field `Component 1 Name` is treated as referenced by `Component 1 Object Type`. This is the default option.
* `"all"`: include all class-name-references. For example, if the value of field `Component 1 Object Type` is `Coil:Heating:Water`, all objects in `Coil:Heating:Water` will be treated as referenced by that field. This is the most aggressive option.

