### PR TITLE
[feat] Add `Idf$duplicated()` and `Idf$unique()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,8 +23,8 @@
 * New methods `Idf$duplicatd()` and `Idf$unique()` have been added. They can be
   used to detect and remove duplicated objects, respectively. Here duplicated
   objects refer to objects whose field values are the same except the names.
-  Object comments are ignored during comprison. These two methods can be useful
-  when doing model cleaning (#227).
+  Object comments are ignored during comparison. These two methods can be
+  useful when doing model cleaning (#227).
 
 ## Major changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,8 @@
 * `Idf$to_table()` gains a new parameter `force`. The default value is `FALSE`. If
   `TRUE`, you can convert object data from any classes into a wide data.table.
   This may be useful when you know that target classes have the exact same
-  fields, e.g.  `Ceiling:Adiabatic` and `Floor:Adiabatic`.
-* A new method `Idf$purge()` has been added. It can be used to delete any
+  fields, e.g.  `Ceiling:Adiabatic` and `Floor:Adiabatic` (#202).
+* A new method `Idf$purge()` has been added (#223). It can be used to delete any
   resource objects that are not referenced by other objects. Here resource
   objects indicate all objects that can be referenced by other objects, e.g. all
   schedules. `$purge()` will ignore any inputs that are not resources. If inputs
@@ -17,9 +17,14 @@
   `Idf$purge()` makes it quite straightforward to perform IDF cleaning. Actions
   like removing all materials, constructions and schedules can be easily
   achieved via
-  ```
+  ```r
   Idf$purge(class = c("Material", "Construction"), group = "Schedules")
   ```
+* New methods `Idf$duplicatd()` and `Idf$unique()` have been added. They can be
+  used to detect and remove duplicated objects, respectively. Here duplicated
+  objects refer to objects whose field values are the same except the names.
+  Object comments are ignored during comprison. These two methods can be useful
+  when doing model cleaning (#227).
 
 ## Major changes
 

--- a/R/constants.R
+++ b/R/constants.R
@@ -114,7 +114,9 @@ utils::globalVariables(c(
     "sun_exposure_lower", "surface_type", "surface_type_int", "tilt_angle",
     "wind_exposure", "wind_exposure_lower", "y", "z", "zone", "zone_name",
     "cls", "i.class_name", "i.value_chr", "i.value_id", "i.value_num", "pointer",
-    "src_object_name", "i.field_id"
+    "src_object_name", "i.field_id", "i.field_index", "i.object_name",
+    "i.src_object_id", "i.src_value_chr", "i.src_value_id", "i.src_value_num",
+    "is_resource", "merged", "object_id_dup", "removed"
 ))
 # }}}
 # nocov end

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -492,6 +492,39 @@ idf$purge(group = "Schedules")
 
 
 ## ------------------------------------------------
+## Method `Idf$duplicated`
+## ------------------------------------------------
+
+\dontrun{
+# check if there are any duplications in the Idf
+idf$duplicated(class = "ScheduleTypeLimits")
+
+# check if there are any duplications in the schedule types
+idf$duplicated(class = "ScheduleTypeLimits")
+
+# check if there are any duplications in the schedule groups and
+# material class
+idf$duplicated(class = "Material", group = "Schedules")
+}
+
+
+## ------------------------------------------------
+## Method `Idf$unique`
+## ------------------------------------------------
+
+\dontrun{
+# remove duplications in the Idf
+idf$unique(class = "ScheduleTypeLimits")
+
+# remove duplications in the schedule types
+idf$unique(class = "ScheduleTypeLimits")
+
+# remove duplications in the schedule groups and material class
+idf$unique(class = "Material", group = "Schedules")
+}
+
+
+## ------------------------------------------------
 ## Method `Idf$rename`
 ## ------------------------------------------------
 
@@ -851,6 +884,8 @@ Hongyuan Jia
 \item \href{#method-set}{\code{Idf$set()}}
 \item \href{#method-del}{\code{Idf$del()}}
 \item \href{#method-purge}{\code{Idf$purge()}}
+\item \href{#method-duplicated}{\code{Idf$duplicated()}}
+\item \href{#method-unique}{\code{Idf$unique()}}
 \item \href{#method-rename}{\code{Idf$rename()}}
 \item \href{#method-insert}{\code{Idf$insert()}}
 \item \href{#method-load}{\code{Idf$load()}}
@@ -2455,7 +2490,7 @@ idf$del(ids)
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-purge"></a>}}
 \subsection{Method \code{purge()}}{
-purge resource objects that are not used
+Purge resource objects that are not used
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Idf$purge(object = NULL, class = NULL, group = NULL)}\if{html}{\out{</div>}}
 }
@@ -2502,6 +2537,130 @@ idf$purge(class = "ScheduleTypeLimits")
 
 # purge all unused schedule related objects
 idf$purge(group = "Schedules")
+}
+
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-duplicated"></a>}}
+\subsection{Method \code{duplicated()}}{
+Determine duplicated objects
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Idf$duplicated(object = NULL, class = NULL, group = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{object}}{an integer vector of object IDs or a character vector
+of object names in current \code{Idf} object. Default: \code{NULL}.}
+
+\item{\code{class}}{A character vector of valid class names in current \code{Idf}
+object. Default: \code{NULL}.}
+
+\item{\code{group}}{A character vector of valid group names in current \code{Idf}
+object. Default: \code{NULL}.
+
+If all \code{object}, \code{class} and \code{group} are \code{NULL}, duplication checking
+is performed on the whole \code{Idf}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\verb{$duplicated()} takes an integer vector of object IDs or a character
+vectors of object names, and returns a \code{\link[data.table:data.table]{data.table::data.table()}}
+to show whether input objects contain duplications or not.
+
+Here duplicated objects refer to objects whose field values are the
+same except the names. Object comments are just ignored during
+comparison.
+}
+
+\subsection{Returns}{
+A \code{\link[data.table:data.table]{data.table::data.table()}} of 4 columns:
+\itemize{
+\item \code{class}: Character. Names of classes that input objects belong to
+\item \code{id}: Integer. Input object IDs
+\item \code{name}: Character. Input object names
+\item \code{duplicated}: Logical. Whether this object is a duplication or not
+}
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+# check if there are any duplications in the Idf
+idf$duplicated(class = "ScheduleTypeLimits")
+
+# check if there are any duplications in the schedule types
+idf$duplicated(class = "ScheduleTypeLimits")
+
+# check if there are any duplications in the schedule groups and
+# material class
+idf$duplicated(class = "Material", group = "Schedules")
+}
+
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-unique"></a>}}
+\subsection{Method \code{unique()}}{
+Remove duplicated objects
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Idf$unique(object = NULL, class = NULL, group = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{object}}{an integer vector of object IDs or a character vector
+of object names in current \code{Idf} object. Default: \code{NULL}.}
+
+\item{\code{class}}{A character vector of valid class names in current \code{Idf}
+object. Default: \code{NULL}.}
+
+\item{\code{group}}{A character vector of valid group names in current \code{Idf}
+object. Default: \code{NULL}.
+
+If all \code{object}, \code{class} and \code{group} are \code{NULL}, duplication checking
+is performed on the whole \code{Idf}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\verb{$unique()} takes an integer vector of object IDs or a character
+vectors of object names, and remove duplicated objects.
+
+Here duplicated objects refer to objects whose field values are the
+same except the names. Object comments are just ignored during
+comparison.
+
+\verb{$unique()} will only keep the first unique object and remove all
+redundant objects. Value referencing the redundant objects will be
+redirected into the unique object.
+}
+
+\subsection{Returns}{
+The modified \code{Idf} object itself, invisibly.
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+# remove duplications in the Idf
+idf$unique(class = "ScheduleTypeLimits")
+
+# remove duplications in the schedule types
+idf$unique(class = "ScheduleTypeLimits")
+
+# remove duplications in the schedule groups and material class
+idf$unique(class = "Material", group = "Schedules")
 }
 
 }

--- a/tests/testthat/test_idf.R
+++ b/tests/testthat/test_idf.R
@@ -338,6 +338,28 @@ test_that("Idf class", {
     expect_equal(idf$purge(1:5, c("Material", "Construction"), idf$group_name())$is_valid_id(1:5), c(rep(FALSE, 4), TRUE))
     # }}}
 
+    # UNIQUE {{{
+    idf_1 <- read_idf(file.path(eplus_config(8.8)$dir, "ExampleFiles/5Zone_Transformer.idf"))
+    idf_1$unique(1, group = "Schedules")
+    expect_false(all(idf_1$is_valid_id(c(35, 38, 42))))
+    id <- idf_1$object_id(c("Material", "Output:Meter:MeterFileOnly"))
+    expect_silent(idf_1$unique(class = c("Material", "Output:Meter:MeterFileOnly")))
+    expect_equal(idf_1$object_id(c("Material", "Output:Meter:MeterFileOnly")), id)
+    # }}}
+
+    # DUPLICATED {{{
+    idf_1 <- read_idf(file.path(eplus_config(8.8)$dir, "ExampleFiles/5Zone_Transformer.idf"))
+    expect_silent(dup <- idf_1$duplicated())
+    expect_equal(nrow(dup), 322)
+    expect_equal(names(dup), c("class", "id", "name", "duplicated"))
+    expect_equal(dup$class, idf_1$class_name(sorted = FALSE))
+    expect_equal(dup$id, 1:322)
+    expect_equal(dup$name, idf_1$object_name(simplify = TRUE))
+    expect_equal(dup[duplicated == TRUE, id], c(35L, 38L, 42L, 77L, 78L, 152L, 154L, 156L, 158L))
+    expect_equal(idf_1$duplicated(class = "Schedule:Compact")[duplicated == TRUE, id], c(35L, 38L, 42L))
+    expect_equal(idf_1$duplicated(group = "Schedules")[duplicated == TRUE, id], c(35L, 38L, 42L))
+    # }}}
+
     # RENAME {{{
     idf <- read_idf(example())
     idf$rename(test = "C5 - 4 IN HW CONCRETE")

--- a/vignettes/eplusr.Rmd
+++ b/vignettes/eplusr.Rmd
@@ -252,6 +252,8 @@ them.
 |                     | `$set()`                 | Modify existing objects                           |
 |                     | `$del()`                 | Delete existing objects                           |
 |                     | `$purge()`               | Delete unused resource objects                    |
+|                     | `$duplicated()`          | Detect duplicated objects                         |
+|                     | `$unique()`              | Delete duplicated objects                         |
 |                     | `$rename()`              | Change object names                               |
 |                     | `$insert()`              | Add new objects from other `IdfObject`s           |
 |                     | `$load()`                | Add new objects from strings and data.frames      |
@@ -607,6 +609,8 @@ model$update(dt)
 
 ### Delete object
 
+#### `$del()`
+
 `$del()` will delete objects specified by object IDs or names.
 For example, in current model, there is a material named `"MAT-CLNG-1"` in class
 `Material:NoMass`. Let's see if it has been referred by other objects.
@@ -634,13 +638,28 @@ setting `.force` to `TRUE`.
 model$del("mat-clng-1", .force = TRUE)
 ```
 
-### Purge object
+#### `$purge()`
 
 `$purge()` will delete resource objects specified that are not used by any
 objects. Below we remove all schedules that are not currently used.
 
 ```{r purge}
 model$purge(group = "Schedules")
+```
+
+#### `$duplicated()` and `$unique()`
+
+`$duplicatd()` and `$unique()` can be used to detect and remove duplicated
+objects, respectively. Here duplicated objects refer to objects whose field
+values are the same except the names. Object comments are ignored during
+comparison. These two methods can be useful when doing model cleaning.
+
+```{r duplicated}
+model$duplicated(group = "Schedules")
+```
+
+```{r unique}
+model$unique(group = "Schedules")
 ```
 
 ### Paste from IDF Editor


### PR DESCRIPTION
Pull request overview
---------------------
 - Resolves partially #211

New methods `Idf$duplicatd()` and `Idf$unique()` have been added. They can be used to detect and remove duplicated objects, respectively. Here duplicated objects refer to objects whose field values are the same except the names. Object comments are ignored during comparison. These two methods can be useful when doing model cleaning
