### PR TITLE
[feat] Proceed parsing if type error occurs for non-important headers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,7 +81,10 @@
   other methods of `Epw` class. Some EPWs from sources other than
   energyplus.net sometimes fail to give all valid values for thse headers. Now
   `read_epw()` will return all failed-to-parse values as `NA`s. All parsing
-  warnings can be shown by setting `warning` in `read_epw()` to `TRUE`.
+  warnings can be shown by setting `warning` in `read_epw()` to `TRUE`. For
+  `HOLIDAYS/DAYLIGHT SAVINGS` and `DATA PERIODS`, `read_epw()` will still give
+  an error if any parsing errors are found. This is becasue values of those 2
+  headers are used to parsing the actual weather data.
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -77,14 +77,14 @@
     field. This is the most aggressive option.
 * `read_epw()` will proceed parsing if type error occurs for non-important
   headers, including `LOCATION`, `DESIGN CONDITIONS`, `TYPICAL/EXTREME PERIODS`
-  and `GROUND TEMPERATURES` (#235). These headers are not directly used in any
-  other methods of `Epw` class. Some EPWs from sources other than
-  energyplus.net sometimes fail to give all valid values for thse headers. Now
-  `read_epw()` will return all failed-to-parse values as `NA`s. All parsing
-  warnings can be shown by setting `warning` in `read_epw()` to `TRUE`. For
-  `HOLIDAYS/DAYLIGHT SAVINGS` and `DATA PERIODS`, `read_epw()` will still give
-  an error if any parsing errors are found. This is becasue values of those 2
-  headers are used to parsing the actual weather data.
+  and `GROUND TEMPERATURES` (#236). These headers are not directly used in any
+  other method of `Epw` class. Some EPWs from sources other than energyplus.net
+  sometimes fail to give all valid values for those headers. Now `read_epw()`
+  will return all failed-to-parse values as `NA`s. All parsing warnings can be
+  shown by setting `warning` in `read_epw()` to `TRUE`. For `HOLIDAYS/DAYLIGHT
+  SAVINGS` and `DATA PERIODS`, `read_epw()` will still give an error if any
+  parsing errors are found. This is because the values of those 2 headers are
+  used to parsing the actual weather data.
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,13 @@
     value of field `Component 1 Object Type` is `Coil:Heating:Water`, all
     objects in `Coil:Heating:Water` will be treated as referenced by that
     field. This is the most aggressive option.
+* `read_epw()` will proceed parsing if type error occurs for non-important
+  headers, including `LOCATION`, `DESIGN CONDITIONS`, `TYPICAL/EXTREME PERIODS`
+  and `GROUND TEMPERATURES` (#235). These headers are not directly used in any
+  other methods of `Epw` class. Some EPWs from sources other than
+  energyplus.net sometimes fail to give all valid values for thse headers. Now
+  `read_epw()` will return all failed-to-parse values as `NA`s. All parsing
+  warnings can be shown by setting `warning` in `read_epw()` to `TRUE`.
 
 ## Minor changes
 


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #228

`read_epw()` will proceed parsing if type error occurs for non-important headers, including `LOCATION`, `DESIGN CONDITIONS`, `TYPICAL/EXTREME PERIODS` and `GROUND TEMPERATURES`. These headers are not directly used in any other method of `Epw` class. Some EPWs from sources other than energyplus.net sometimes fail to give all valid values for those headers. Now `read_epw()` will return all failed-to-parse values as `NA`s. All parsing warnings can be shown by setting `warning` in `read_epw()` to `TRUE`. For `HOLIDAYS/DAYLIGHT SAVINGS` and `DATA PERIODS`, `read_epw()` will still give an error if any parsing errors are found. This is because the values of those 2 headers are used to parsing the actual weather data.


