### PR TITLE
Add support to directly insert `Idf` objects in `Idf$insert()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@
   expression with temporary eplusr options (#240).
 * Now `Idf$insert()` can directly take an `Idf` object or a list of `Idf`
   objects ad input. And also `Version` objects in input will be directly
-  skipped instead of giving an error (#243, #244).
+  skipped instead of giving an error (#245).
 
 ## Major changes
 
@@ -107,6 +107,8 @@
 * Fix the bug in `install_eplus()` on Windows (#230)
 * Fix the error in `$<-.Idf` when input list of `IdfObject`s are all from the
   same `Idf` on the LHS (#238).
+* Now `Idf$insert()` and `Idf$load()` can now successfully remove duplicated
+  objects by comparing field values case-insensitively (#243)
 
 # eplusr 0.12.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,9 @@
 * Internal helper functions `with_option()`, `with_silent()`, `with_speed()`
   and `without_checking()` have been exported. They can be used to evaluate an
   expression with temporary eplusr options (#240).
+* Now `Idf$insert()` can directly take an `Idf` object or a list of `Idf`
+  objects ad input. And also `Version` objects in input will be directly
+  skipped instead of giving an error (#243, #244).
 
 ## Major changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,7 +31,7 @@
   and `without_checking()` have been exported. They can be used to evaluate an
   expression with temporary eplusr options (#240).
 * Now `Idf$insert()` can directly take an `Idf` object or a list of `Idf`
-  objects ad input. And also `Version` objects in input will be directly
+  objects as input. And also `Version` objects in input will be directly
   skipped instead of giving an error (#245).
 
 ## Major changes

--- a/R/constants.R
+++ b/R/constants.R
@@ -116,7 +116,8 @@ utils::globalVariables(c(
     "cls", "i.class_name", "i.value_chr", "i.value_id", "i.value_num", "pointer",
     "src_object_name", "i.field_id", "i.field_index", "i.object_name",
     "i.src_object_id", "i.src_value_chr", "i.src_value_id", "i.src_value_num",
-    "is_resource", "merged", "object_id_dup", "removed"
+    "is_resource", "merged", "object_id_dup", "removed", "src_type_enum",
+    "src_value_num"
 ))
 # }}}
 # nocov end

--- a/tests/testthat/test_idf.R
+++ b/tests/testthat/test_idf.R
@@ -284,7 +284,8 @@ test_that("Idf class", {
     expect_equal(idf_full$Material_NoMass$R13LAYER$value(simplify = TRUE),
         c("R13LAYER", "Rough", "2.290965", "0.9", "0.75", "0.75")
     )
-    expect_error(idf$insert(idf_full$Version), class = "error_insert_version")
+    # can skip Version object
+    expect_silent(idf$insert(idf_full$Version))
     expect_error(idf$insert(idf$Material_NoMass$R13LAYER, .unique = FALSE), class = "error_validity")
     expect_null(idf$insert(idf$Material_NoMass$R13LAYER))
     expect_null(idf$insert(idf$Material_NoMass$R13LAYER, idf$Material_NoMass$R13LAYER))
@@ -297,7 +298,7 @@ test_that("Idf class", {
     expect_equal(idf1$object_id()$ScheduleTypeLimits, 2L)
     # can directly insert an Idf
     expect_silent(idf1$insert(idf2))
-    expect_equal(idf1$object_id(), list(Version = 1L))
+    expect_equal(idf1$object_id(), list(Version = 1L, ScheduleTypeLimits = 2L))
     # }}}
 
     # DELETE {{{

--- a/tests/testthat/test_idf.R
+++ b/tests/testthat/test_idf.R
@@ -288,6 +288,9 @@ test_that("Idf class", {
     expect_error(idf$insert(idf$Material_NoMass$R13LAYER, .unique = FALSE), class = "error_validity")
     expect_null(idf$insert(idf$Material_NoMass$R13LAYER))
     expect_null(idf$insert(idf$Material_NoMass$R13LAYER, idf$Material_NoMass$R13LAYER))
+    # can directly insert an Idf
+    expect_silent(idf1$insert(idf2))
+    expect_equal(idf1$object_id(), list(Version = 1L))
     # }}}
 
     # DELETE {{{

--- a/tests/testthat/test_impl-idf.R
+++ b/tests/testthat/test_impl-idf.R
@@ -865,10 +865,6 @@ test_that("Insert", {
         class = "error_insert_unique"
     )
     expect_error(
-        insert_idf_object(idd_env, idf_env, version = idf$version(), idf$Version),
-        class = "error_insert_version"
-    )
-    expect_error(
         insert_idf_object(idd_env, idf_env, version = numeric_version("8.7.0"), idf$Material),
         class = "error_not_same_version"
     )
@@ -876,6 +872,12 @@ test_that("Insert", {
         insert_idf_object(idd_env, idf_env, version = idf$version(), idf$Material, .unique = FALSE),
         class = "error_validity"
     )
+    # can skip Version object
+    expect_silent(
+        ins <- insert_idf_object(idd_env, idf_env, version = idf$version(), idf$Version)
+    )
+    expect_equal(nrow(ins$object), 0L)
+    expect_equal(nrow(ins$value), 0L)
     new_mat <- idf$clone()$Material[[1L]]$set(name = "new_mat")
     expect_silent(
         ins <- insert_idf_object(idd_env, idf_env, version = idf$version(), new_mat)


### PR DESCRIPTION
Pull request overview
---------------------

Add support in `Idf$insert()` to directly take an `Idf` object or a list of `Idf` objects as input. And also `Version` objects in the input will be directly skipped instead of giving an error.
