### PR TITLE
[feat] Add 'all' option in 'IdfObject$print()'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends:
     R (>= 3.2.0)
 Imports:
     callr (>= 2.0.4),
-    cli,
+    cli (>= 1.1.0),
     crayon,
     data.table (>= 1.9.8),
     lubridate,

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,9 @@
 * Now `Idf$insert()` can directly take an `Idf` object or a list of `Idf`
   objects as input. And also `Version` objects in input will be directly
   skipped instead of giving an error (#245).
+* A new option `all` has been added in `IdfObject$print()` with default being
+  `FALSE`. If `TRUE`, all fields defined in [Idd] are printed even they do not
+  exist in current object (#247).
 
 ## Major changes
 

--- a/R/idf_object.R
+++ b/R/idf_object.R
@@ -1371,6 +1371,9 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #' @param brief If `TRUE`, only OBJECT part is printed. Default:
         #'        `FALSE`.
         #'
+        #' @param all If `TRUE`, all fields defined in [Idd] are printed even
+        #'        they do not exist in current object. Default: `FALSE`.
+        #'
         #' @return The `IdfObject` itself, invisibly.
         #'
         #' @examples
@@ -1383,8 +1386,8 @@ IdfObject <- R6::R6Class(classname = "IdfObject", lock_objects = FALSE,
         #' mat$print(auto_sep = TRUE)
         #' }
         #'
-        print = function (comment = TRUE, auto_sep = TRUE, brief = FALSE)
-            idfobj_print(self, private, comment, auto_sep, brief)
+        print = function (comment = TRUE, auto_sep = TRUE, brief = FALSE, all = FALSE)
+            idfobj_print(self, private, comment, auto_sep, brief, all)
         # }}}
         # }}}
     ),
@@ -1877,7 +1880,7 @@ idfobj_to_string <- function (self, private, comment = TRUE, leading = 4L, sep_a
 }
 # }}}
 # idfobj_print {{{
-idfobj_print <- function (self, private, comment = TRUE, auto_sep = FALSE, brief = FALSE) {
+idfobj_print <- function (self, private, comment = TRUE, auto_sep = FALSE, brief = FALSE, all = FALSE) {
     obj <- get_idf_object(private$idd_env(), private$idf_env(), object = private$m_object_id)
 
     if (is.na(obj$object_name)) {
@@ -1890,7 +1893,7 @@ idfobj_print <- function (self, private, comment = TRUE, auto_sep = FALSE, brief
 
     if (brief) return(invisible(self))
 
-    val <- get_idf_value(private$idd_env(), private$idf_env(), object = private$m_object_id)
+    val <- get_idf_value(private$idd_env(), private$idf_env(), object = private$m_object_id, all = all)
 
     # comment
     if (comment && !is.null(obj$comment[[1L]])) {
@@ -1982,9 +1985,9 @@ str.IdfObject <- function (object, ...) {
 
 #' @export
 # print.IdfObject {{{
-print.IdfObject <- function (x, comment = TRUE, auto_sep = TRUE, brief = FALSE, ...) {
+print.IdfObject <- function (x, comment = TRUE, auto_sep = TRUE, brief = FALSE, all = FALSE, ...) {
     add_idfobj_field_bindings(x, update = TRUE)
-    x$print(comment = comment, auto_sep = auto_sep, brief = brief)
+    x$print(comment = comment, auto_sep = auto_sep, brief = brief, all = all)
 }
 # }}}
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -487,10 +487,10 @@ wday <- function (x, label = FALSE) {
 # }}}
 
 # str_trunc {{{
-str_trunc <- function (x, width = getOption("width", 60L)) {
+str_trunc <- function (x, width = cli::console_width()) {
     # in case invalid UTF-8 character in IDF
     x <- stringi::stri_encode(x)
-    tr <- nchar(x, "width") > (0.95 * width)
+    tr <- nchar(crayon::strip_style(x), "width") > (0.95 * width)
     x[tr] <- paste0(stri_sub(x[tr], to = width - 5L), "...")
     x
 }

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -2077,7 +2077,7 @@ mat$to_string(leading = 0)
 \subsection{Method \code{print()}}{
 Print \code{IdfObject} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{IdfObject$print(comment = TRUE, auto_sep = TRUE, brief = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{IdfObject$print(comment = TRUE, auto_sep = TRUE, brief = FALSE, all = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -2090,6 +2090,9 @@ the largest character length of values. Default: \code{FALSE}.}
 
 \item{\code{brief}}{If \code{TRUE}, only OBJECT part is printed. Default:
 \code{FALSE}.}
+
+\item{\code{all}}{If \code{TRUE}, all fields defined in \link{Idd} are printed even
+they do not exist in current object. Default: \code{FALSE}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-idfobj.R
+++ b/tests/testthat/test-idfobj.R
@@ -395,5 +395,6 @@ test_that("IdfObject class", {
     # }}}
 
     expect_output(con$print())
+    expect_output(con$print(all = TRUE), "11 :")
 })
 # }}}


### PR DESCRIPTION
Pull request overview
---------------------
 - Add a new option `all`in `IdfObject$print()` to print all possible fields including empty ones.
