### PR TITLE
[feat] Use SQL `year` field introduced in EnergyPlus v8.9 and above

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -111,6 +111,9 @@
   SAVINGS` and `DATA PERIODS`, `read_epw()` will still give an error if any
   parsing errors are found. This is because the values of those 2 headers are
   used to parsing the actual weather data.
+* Now `EplusSql$report_data()` will set the year values of day type
+  `SummerDesignDay` and `WinterDesignDay` to current year and the `day_type`
+  value will be left unchanged (#258).
 
 ## Minor changes
 


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #34

The SQL output of EnergyPlus v8.9 and above has a `Year` field in the `Time` table. This PR makes `EplusSql$report_data()` use this value whenever possible. 

Also, previously, when extracting design day simulation results, the `day_type` values were overwritten to `Monday` and a year value was calculated according. This behavior introduces some confusing. In this PR, the `day_type` column is left unchanged and the year value for design days is always set to current year.