### PR TITLE
[fix] Create group simulation output dir sequentially

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -154,8 +154,9 @@
 * Now `Idf$insert()` and `Idf$load()` can now successfully remove duplicated
   objects by comparing field values case-insensitively (#243)
 * Now `Epw$save()` can work with empty `DESIGN CONDITIONS`, `TYPICAL/EXTREME
-* PERIODS` and `GROUND TEMPERATURES` headers. Thanks @lukas-rokka for the
+  PERIODS` and `GROUND TEMPERATURES` headers. Thanks @lukas-rokka for the
   bug report (#263).
+* Fix output directory creation error in `EplusGroupJob`(#270).
 
 # eplusr 0.12.0
 

--- a/R/group.R
+++ b/R/group.R
@@ -839,7 +839,7 @@ epgroup_run_models <- function (self, private, output_dir = NULL, wait = TRUE, f
 
     if (any(!dir.exists(uniq_dir <- unique(output_dir)))) {
         dir_to_create <- uniq_dir[!dir.exists(uniq_dir)]
-        create_dir <- dir.create(dir_to_create, showWarnings = FALSE, recursive = TRUE)
+        create_dir <- vlapply(dir_to_create, dir.create, showWarnings = FALSE, recursive = TRUE)
         if (any(!create_dir)) {
             abort(paste0("Failed to create output directory: ", collapse(dir_to_create)[!create_dir]))
         }


### PR DESCRIPTION
Pull request overview
---------------------
 - Create output directories of group simulation sequentially to avoid error `invalid 'path' argument`
