### PR TITLE
[fix] Remove trailing spaces after class names during parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -166,6 +166,7 @@
   bug report (#263).
 * Fix output directory creation error in `EplusGroupJob`(#270).
 * Fix IDF header option parsing (#278).
+* Trailing spaces after class names in IDF can be handled correctly (#294).
 
 # eplusr 0.12.0
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -1232,7 +1232,7 @@ sep_object_table <- function (dt, type_enum, idd) {
             # in case there are invalid class names ends with semicolon
             n[is.na(n)] <- 0L
             l <- stri_length(body)
-            class_name_lower <- stri_trans_tolower(stri_sub(body, to = n - 1L))
+            class_name_lower <- stri_trim_right(stri_trans_tolower(stri_sub(body, to = n - 1L)))
             body[n < l] <- stri_trim_left(stri_sub(body[n < l], n[n < l] + 1L))
             type[n <  l] <- type_enum$object_value
             type[n == l] <- type_enum$object

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -556,5 +556,13 @@ test_that("parse_idf_file()", {
     file.create(ddy)
     expect_silent(idf_parsed <- parse_idf_file(ddy, 8.8))
     unlink(ddy)
+
+    # can handle trailing spaces after class names
+    idf_str <- "
+        Version , 8.8 ;
+        SurfaceConvectionAlgorithm:Inside   ,
+            Simple  ; !- Algorithm
+    "
+    expect_is(idf_parsed <- parse_idf_file(idf_str, 8.8), "list")
 })
 # }}}


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #294
