### PR TITLE
[fix] Use correct year during parsing for non-realyear EPWs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -144,6 +144,8 @@
   names are allowed.
 * The suffix of automatcially created names in `Idf$dup()` has been changed
   from `_X` to ` X`.
+* The `warning` parameter in `read_epw()`, `Epw$add()` and `Epw$set()` has been
+  deprecated (#298).
 
 ## Minor changes
 

--- a/R/impl-epw.R
+++ b/R/impl-epw.R
@@ -1317,7 +1317,7 @@ match_epw_data <- function (epw_data, epw_header, period = NULL, tz = "UTC", che
 
     # validate_datetime_range {{{
     validate_datetime_range <- function (datetime, matched, realyear) {
-        if (length(datetime) - matched$line + 1L < length(matched$num)) {
+        if (length(datetime) - matched$line + 1L < matched$num) {
             parse_error("epw", paste("Invalid WEATHER DATA"), subtype = "data",
                 post = sprintf("%i rows of weather data (starting from row %i) are expected for data period #%i '%s', but only '%i' were found.",
                     matched$num, matched$line, matched$index, matched$name, length(datetime) - matched$line + 1L

--- a/man/Epw.Rd
+++ b/man/Epw.Rd
@@ -388,7 +388,7 @@ epw$purge()
 \dontrun{
 # will fail since date time in input data has already been covered by
 # existing data period
-epw$add(epw$data())
+try(epw$add(epw$data()), silent = TRUE)
 }
 
 
@@ -398,7 +398,7 @@ epw$add(epw$data())
 
 \dontrun{
 # change the weather data
-epw$set(epw$data(), warning = FALSE)
+epw$set(epw$data())
 }
 
 
@@ -477,7 +477,7 @@ Hongyuan Jia
 \subsection{Method \code{new()}}{
 Create an \code{Epw} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Epw$new(path, warning = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Epw$new(path)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -487,9 +487,6 @@ Create an \code{Epw} object
 single string or a raw vector) to an EnergyPlus Weather File
 (EPW).  If a file path, that file usually has a extension
 \code{.epw}.}
-
-\item{\code{warning}}{If \code{TRUE}, warnings are given if any missing data,
-out-of-range data are found. Default: \code{TRUE}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1737,8 +1734,7 @@ Add a data period
   realyear = FALSE,
   name = NULL,
   start_day_of_week = NULL,
-  after = 0L,
-  warning = TRUE
+  after = 0L
 )}\if{html}{\out{</div>}}
 }
 
@@ -1766,9 +1762,6 @@ AMY data.  Default: \code{NULL}.}
 where input new data period to be inserted after. IF \code{0},
 input new data period will be the first data period. Default:
 \code{0}.}
-
-\item{\code{warning}}{If \code{TRUE}, warnings are given if any missing data,
-out-of-range data are found. Default: \code{TRUE}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1806,7 +1799,7 @@ The modified \code{Epw} object itself, invisibly.
 \preformatted{\dontrun{
 # will fail since date time in input data has already been covered by
 # existing data period
-epw$add(epw$data())
+try(epw$add(epw$data()), silent = TRUE)
 }
 
 }
@@ -1826,8 +1819,7 @@ Replace a data period
   realyear = FALSE,
   name = NULL,
   start_day_of_week = NULL,
-  period = 1L,
-  warning = TRUE
+  period = 1L
 )}\if{html}{\out{</div>}}
 }
 
@@ -1853,9 +1845,6 @@ AMY data.  Default: \code{NULL}.}
 
 \item{\code{period}}{A single integer identifying the index of data period
 to set.}
-
-\item{\code{warning}}{If \code{TRUE}, warnings are given if any missing data,
-out-of-range data are found. Default: \code{TRUE}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -1891,7 +1880,7 @@ The modified \code{Epw} object itself, invisibly.
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{\dontrun{
 # change the weather data
-epw$set(epw$data(), warning = FALSE)
+epw$set(epw$data())
 }
 
 }

--- a/man/read_epw.Rd
+++ b/man/read_epw.Rd
@@ -4,14 +4,10 @@
 \alias{read_epw}
 \title{Read and Parse EnergyPlus Weather File (EPW)}
 \usage{
-read_epw(path, warning = FALSE)
+read_epw(path)
 }
 \arguments{
 \item{path}{A path of an EnergyPlus \code{EPW} file.}
-
-\item{warning}{If \code{TRUE}, warnings are given if any missing data, out of
-range data and redundant data is found. Default: \code{FALSE}. All these data can
-be also retrieved using methods in \link{Epw} class.}
 }
 \value{
 An \code{Epw} object.

--- a/tests/testthat/test-epw.R
+++ b/tests/testthat/test-epw.R
@@ -345,11 +345,13 @@ test_that("Data Setter", {
     expect_equal(nrow(epw$data()), 48L)
 
     expect_error({
+        epw <- read_epw(path_epw)
         suppressWarnings(d <- epw$data(start_year = 2020))
         epw$set(d, TRUE)
     })
 
     expect_error({
+        epw <- read_epw(path_epw)
         suppressWarnings(d <- epw$data(start_year = 2020))
         d[100L, datetime := lubridate::as_datetime("2020-01-01 00:00:00")]
         epw$set(d)

--- a/tests/testthat/test-epw.R
+++ b/tests/testthat/test-epw.R
@@ -343,6 +343,17 @@ test_that("Data Setter", {
         )
     )
     expect_equal(nrow(epw$data()), 48L)
+
+    expect_error({
+        suppressWarnings(d <- epw$data(start_year = 2020))
+        epw$set(d, TRUE)
+    })
+
+    expect_error({
+        suppressWarnings(d <- epw$data(start_year = 2020))
+        d[100L, datetime := lubridate::as_datetime("2020-01-01 00:00:00")]
+        epw$set(d)
+    })
     # }}}
 
     # $add() {{{


### PR DESCRIPTION
Pull request overview
---------------------
- Fixes #297
- Deprecate the `warning` parameter in `read_epw()`, `Epw$add()` and `Epw$set()`
- Use default year during parsing for non-realyear EPWs
