### PR TITLE
[fix] Fix invalid references introduced by setting field values to empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
   output directory when `copy_external` is set to `TRUE`.
 * Fix the error when using an `Idf` as input in `Idf$insert()` (#348).
 * Sub-hourly EPW files are supported (#351).
+* Fix invalid references introduced by setting field values to empty (#355).
 
 # eplusr 0.13.0
 


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #355


### Keep empty fields

```r
idf <- eplusr::read_idf(system.file("extdata/1ZoneUncontrolled.idf", package = "eplusr"))

idf$Construction$ROOF31
# <IdfObject: 'Construction'> [ID:17] `ROOF31`
# Class: <Construction>
# +- 1*: "ROOF31",   !- Name
# \- 2*: "R31LAYER"; !- Outside Layer

idf$Construction$ROOF31$set(..3 = "R13LAYER")
# <IdfObject: 'Construction'> [ID:17] `ROOF31`
# Class: <Construction>
# +- 1*: "ROOF31",   !- Name
# |- 2*: "R31LAYER", !- Outside Layer
# \- 3 : "R13LAYER"; !- Layer 2

idf$Construction$ROOF31$set(..3 = NULL, .empty = TRUE)
# <IdfObject: 'Construction'> [ID:17] `ROOF31`
# Class: <Construction>
# +- 1*: "ROOF31",   !- Name
# |- 2*: "R31LAYER", !- Outside Layer
# \- 3 : <"Blank">;  !- Layer 2

idf$Material_NoMass$R13LAYER$ref_by_object()
# $R13WALL
# <IdfObject: 'Construction'> [ID:15] `R13WALL`
# Class: <Construction>
# +- 1*: "R13WALL",  !- Name
# \- 2*: "R13LAYER"; !- Outside Layer
# 
```

### Remove empty fields

```r
idf$Construction$ROOF31$set(..3 = "R13LAYER")
# <IdfObject: 'Construction'> [ID:17] `ROOF31`
# Class: <Construction>
# +- 1*: "ROOF31",   !- Name
# |- 2*: "R31LAYER", !- Outside Layer
# \- 3 : "R13LAYER"; !- Layer 2

idf$Construction$ROOF31$set(..3 = NULL, .empty = FALSE)
# <IdfObject: 'Construction'> [ID:17] `ROOF31`
# Class: <Construction>
# +- 1*: "ROOF31",   !- Name
# \- 2*: "R31LAYER"; !- Outside Layer

idf$Material_NoMass$R13LAYER$ref_by_object()
# $R13WALL
# <IdfObject: 'Construction'> [ID:15] `R13WALL`
# Class: <Construction>
# +- 1*: "R13WALL",  !- Name
# \- 2*: "R13LAYER"; !- Outside Layer
# 
```