### PR TITLE
[fix] Keep empty comments in IdfObject$comment()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,7 @@
 * Fix the error message in `EplusGroupJob` when no CSV output was found (#357).
 * Fix false positive warnings when resolving IDF external file dependencies
   (#366).
+* Now empty comments are kept in `IdfObject$comment()` (#372).
 
 # eplusr 0.13.0
 

--- a/R/impl-idfobj.R
+++ b/R/impl-idfobj.R
@@ -226,7 +226,7 @@ set_idfobj_comment <- function (idd_env, idf_env, object_id, comment, append = T
         comment <- as.character(comment)
         assert_count(width)
 
-        cmt <- unlist(strsplit(comment, "\n", fixed = TRUE), use.names = FALSE)
+        cmt <- unlist(stri_split_fixed(comment, "\n", omit_empty = FALSE), use.names = FALSE)
 
         if (width != 0L) {
             cmt <- strwrap(cmt, width = width)


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #372
