### PR TITLE
[fix] Add index column in report data and tabular data for group simulations

### DIFF
--- a/R/group.R
+++ b/R/group.R
@@ -1117,15 +1117,17 @@ epgroup_report_data <- function (self, private, which = NULL, key_value = NULL,
                                  period = NULL, month = NULL, day = NULL, hour = NULL, minute = NULL,
                                  interval = NULL, simulation_days = NULL, day_type = NULL,
                                  environment_name = NULL) {
-    sqls <- epgroup_sql_path(self, private, which)
-    cases <- epgroup_case_from_which(self, private, which, name = TRUE)
-
-    rbindlist(mapply(get_sql_report_data, sql = sqls, case = cases,
-        MoreArgs = list(key_value = key_value, name = name, all = all, wide = wide, year = year,
+    rbindlist(Map(get_sql_report_data,
+        sql = epgroup_sql_path(self, private, which),
+        index = epgroup_case_from_which(self, private, which, name = FALSE),
+        case = epgroup_case_from_which(self, private, which, name = TRUE),
+        MoreArgs = list(
+            key_value = key_value, name = name, all = all, wide = wide, year = year,
             tz = tz, period = period, month = month, day = day, hour = hour, minute = minute,
             interval = interval, simulation_days = simulation_days, day_type = day_type,
-            environment_name = environment_name),
-        SIMPLIFY = FALSE, USE.NAMES = FALSE
+            environment_name = environment_name
+        ),
+        USE.NAMES = FALSE
     ), fill = TRUE)
 }
 # }}}
@@ -1133,10 +1135,9 @@ epgroup_report_data <- function (self, private, which = NULL, key_value = NULL,
 epgroup_tabular_data <- function (self, private, which = NULL, report_name = NULL, report_for = NULL,
                                   table_name = NULL, column_name = NULL, row_name = NULL,
                                   wide = FALSE, string_value = !wide) {
-    cases <- epgroup_case_from_which(self, private, which, name = TRUE)
-
     l <- Map(get_sql_tabular_data,
         sql = epgroup_sql_path(self, private, which),
+        index = epgroup_case_from_which(self, private, which, name = FALSE),
         case = epgroup_case_from_which(self, private, which, name = TRUE),
         MoreArgs = list(
             report_name = report_name, report_for = report_for,

--- a/R/impl-sql.R
+++ b/R/impl-sql.R
@@ -114,7 +114,7 @@ get_sql_report_data <- function (sql, key_value = NULL, name = NULL, year = NULL
                                  tz = "UTC", case = "auto", all = FALSE, wide = FALSE,
                                  period = NULL, month = NULL, day = NULL, hour = NULL, minute = NULL,
                                  interval = NULL, simulation_days = NULL, day_type = NULL,
-                                 environment_name = NULL) {
+                                 environment_name = NULL, index = NULL) {
     dict <- read_sql_table(sql, "ReportDataDictionary")
     env <- read_sql_table(sql, "EnvironmentPeriods")
     time <- read_sql_table(sql, "Time")
@@ -131,7 +131,12 @@ get_sql_report_data <- function (sql, key_value = NULL, name = NULL, year = NULL
         assert_scalar(case)
         case_name <- as.character(case)
         set(res, NULL, "case", case_name)
-        setcolorder(res, c("case", setdiff(names(res), "case")))
+        setcolorder(res, "case")
+    }
+    if (!is.null(index)) {
+        assert_int(index)
+        set(res, NULL, "index", index)
+        setcolorder(res, "index")
     }
 
     res
@@ -141,7 +146,7 @@ get_sql_report_data <- function (sql, key_value = NULL, name = NULL, year = NULL
 #' @importFrom checkmate assert_scalar
 get_sql_tabular_data <- function (sql, report_name = NULL, report_for = NULL,
                                   table_name = NULL, column_name = NULL, row_name = NULL,
-                                  case = "auto", wide = FALSE, string_value = !wide) {
+                                  case = "auto", wide = FALSE, string_value = !wide, index = NULL) {
     q <- get_sql_tabular_data_query(report_name, report_for, table_name, column_name, row_name)
     dt <- setnames(get_sql_query(sql, q), "tabular_data_index", "index")[]
 
@@ -149,7 +154,12 @@ get_sql_tabular_data <- function (sql, report_name = NULL, report_for = NULL,
         assert_scalar(case)
         case_name <- as.character(case)
         set(dt, NULL, "case", case_name)
-        setcolorder(dt, c("case", setdiff(names(dt), "case")))
+        setcolorder(dt, "case")
+    }
+    if (!is.null(index)) {
+        assert_int(index)
+        set(dt, NULL, "index", index)
+        setcolorder(dt, "index")
     }
 
     if (!wide) return(dt)

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -157,7 +157,7 @@ test_that("Group methods", {
         "Asia/Shanghai"
     )
     expect_equal(names(grp$report_data(2, all = TRUE)),
-        c("case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
+        c("index", "case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
           "simulation_days", "day_type", "environment_name",
           "environment_period_index", "is_meter", "type", "index_group",
           "timestep_type", "key_value", "name", "reporting_frequency",

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -199,7 +199,7 @@ test_that("Parametric methods", {
         "Asia/Shanghai"
     )
     expect_equal(names(param$report_data(2, all = TRUE)),
-        c("case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
+        c("index", "case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
           "simulation_days", "day_type", "environment_name",
           "environment_period_index", "is_meter", "type", "index_group",
           "timestep_type", "key_value", "name", "reporting_frequency",
@@ -236,7 +236,7 @@ test_that("Parametric methods", {
         "Asia/Shanghai"
     )
     expect_equal(names(param$report_data(all = TRUE)),
-        c("case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
+        c("index", "case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
           "simulation_days", "day_type", "environment_name",
           "environment_period_index", "is_meter", "type", "index_group",
           "timestep_type", "key_value", "name", "reporting_frequency",


### PR DESCRIPTION
Pull request overview
---------------------
 - Fixes #388
- In previous PR #389, only results from `EplusGroupJob$report_data_dict()`, `EplusGroupJob$read_table()`will have the new `index` column. This PR makes sure `EplusGroupJob$report_data()` and `EplusGroupJob$tabular_data()`have the same behaviour.
