### PR TITLE
[fix] Always use the seed model directory in `ParametricJob$run(dir = NULL)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.14.2.9012
+Version: 0.14.2.9013
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,8 @@
   for Sizing Periods` is set to `Yes` in `SimulationControl` (#461).
 * Now `read_idf()` and other functions that read files from disk can use
   `stringi::stri_enc_detect()` to fix encoding issue (#467).
+* Now `ParametricJob$run(dir = NULL)` will always use the seed model directory
+  (#483).
 
 # eplusr 0.14.2
 

--- a/R/group.R
+++ b/R/group.R
@@ -974,8 +974,6 @@ epgroup_run_models <- function (self, private, output_dir = NULL, wait = TRUE,
         design_day <- is.na(path_epw)
     }
 
-    expand_obj <- vlapply(private$m_idfs, idf_has_hvactemplate)
-
     if (is.null(output_dir))
         output_dir <- dirname(path_idf)
     else if (length(output_dir) == 1L) {
@@ -988,9 +986,11 @@ epgroup_run_models <- function (self, private, output_dir = NULL, wait = TRUE,
     if (any(!dir.exists(uniq_dir <- unique(output_dir)))) {
         dir_to_create <- uniq_dir[!dir.exists(uniq_dir)]
         create_dir <- vlapply(dir_to_create, dir.create, showWarnings = FALSE, recursive = TRUE)
+        # nocov start
         if (any(!create_dir)) {
             abort(paste0("Failed to create output directory: ", collapse(dir_to_create)[!create_dir]))
         }
+        # nocov end
     }
 
     # check if the model is still running

--- a/R/param.R
+++ b/R/param.R
@@ -495,6 +495,7 @@ param_run <- function (self, private, output_dir = NULL, wait = TRUE,
     }
 
     private$log_new_uuid()
+    if (is.null(output_dir)) output_dir <- dirname(private$m_seed$path())
     epgroup_run_models(self, private, output_dir, wait, force, copy_external, echo, separate)
 }
 # }}}


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #483
