### PR TITLE
[feat] Add `ParametricJob$param()` and `ParametricJob$cases()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.14.2.9014
+Version: 0.14.2.9015
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,38 @@
   outputs in the model. Setting it to `FALSE` will not affect any data
   extraction functionalities in eplusr, as it uses the SQLite output instead of
   the CSVs (#467).
+* A new argument `names` can be specified in `ParametricJob$models()` to rename
+  the parametric models created.
+* A new interface for creating parametric models has been introduced using
+  `ParametricJob$param()`. It takes parameter definitions in list format, which
+  is similar to `Idf$set()` except that each field is not assigned with a single
+  value, but a vector of any length, indicating the levels of each parameter.
+  For example, the code block below defines 3 parameters:
+
+  * Field `Fan Total Efficiency` in object named `Supply Fan 1` in class
+    `Fan:VariableVolume` class, with 10 levels being 0.1 to 1.0 with a
+    0.1 step.
+  * Field `Thickness` in all objects in class `Material`, with 10
+    levels being 0.01 to 0.1 m with a 0.1 m step.
+  * Field `Conductivity` in all objects in class `Material`, with 10
+   levels being 0.1 to 1.0 W/m-K with a 0.1 W/m-K step.
+
+  ```
+  param$param(
+      `Supply Fan 1` = list(Fan_Total_Efficiency = seq(0.1, 1.0, 0.1)),
+      Material := list(Thickness = seq(0.01, 0.1, 0.1), Conductivity = seq(0.1, 1.0, 0.1))
+  )
+  ```
+* `ParametricJob$cases()` is added to get a summary of parametric models and
+  parameter values. It returns a `data.table` giving you the indices and names
+  of the parametric models, and all parameter values used to create those
+  models.For parametric models created using `ParametricJob$param()`, the column
+  names will be the same as what you specified in `.names`. For the case of
+  `ParametricJob$apply_measure()`, this will be the argument names of the
+  measure functions.
+* Now `.names` in `ParametricJob$apply_measure()` can be a single character. In
+  this case, it will be used as the prefix of all parametric models. The models
+  will be named in the pattern `.names_X` where `X` is the model index.
 
 ## Break changes
 
@@ -54,6 +86,8 @@
   downloaded instead of downloading both `EPW` and `DDY` files (#453).
 * `EplusJob$output_dir()` now use backslash in the returned path on Windows
   (#467).
+* Better error message when no arguments are given to the measure function in
+  `ParametricJob$apply_measure()`.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,12 +42,12 @@
   extraction functionalities in eplusr, as it uses the SQLite output instead of
   the CSVs (#467).
 * A new argument `names` can be specified in `ParametricJob$models()` to rename
-  the parametric models created.
+  the parametric models created (#487).
 * A new interface for creating parametric models has been introduced using
   `ParametricJob$param()`. It takes parameter definitions in list format, which
   is similar to `Idf$set()` except that each field is not assigned with a single
   value, but a vector of any length, indicating the levels of each parameter.
-  For example, the code block below defines 3 parameters:
+  For example, the code block below defines 3 parameters (#487):
 
   * Field `Fan Total Efficiency` in object named `Supply Fan 1` in class
     `Fan:VariableVolume` class, with 10 levels being 0.1 to 1.0 with a
@@ -69,10 +69,10 @@
   models.For parametric models created using `ParametricJob$param()`, the column
   names will be the same as what you specified in `.names`. For the case of
   `ParametricJob$apply_measure()`, this will be the argument names of the
-  measure functions.
+  measure functions (#487).
 * Now `.names` in `ParametricJob$apply_measure()` can be a single character. In
   this case, it will be used as the prefix of all parametric models. The models
-  will be named in the pattern `.names_X` where `X` is the model index.
+  will be named in the pattern `.names_X` where `X` is the model index (#487).
 
 ## Break changes
 
@@ -87,7 +87,7 @@
 * `EplusJob$output_dir()` now use backslash in the returned path on Windows
   (#467).
 * Better error message when no arguments are given to the measure function in
-  `ParametricJob$apply_measure()`.
+  `ParametricJob$apply_measure()` (#487).
 
 ## Bug fixes
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,3 @@
-comment: true
-
 coverage:
   status:
     project:

--- a/man/ParametricJob.Rd
+++ b/man/ParametricJob.Rd
@@ -41,18 +41,15 @@ automatically created if it does not exists, like \link{Idf} class does.
 
 \dontrun{
 if (is_avail_eplus(8.8)) {
-    idf_name <- "1ZoneUncontrolled.idf"
-    epw_name <-  "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw"
-
-    idf_path <- file.path(eplus_config(8.8)$dir, "ExampleFiles", idf_name)
-    epw_path <- file.path(eplus_config(8.8)$dir, "WeatherData", epw_name)
+     path_idf <- path_eplus_example(8.8, "5Zone_Transformer.idf")
+     path_epw <- path_eplus_weather(8.8, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")
 
     # create from an IDF and an EPW
-    param <- param_job(idf_path, epw_path)
-    param <- ParametricJob$new(idf_path, epw_path)
+    param <- param_job(path_idf, path_epw)
+    param <- ParametricJob$new(path_idf, path_epw)
 
     # create from an Idf and an Epw object
-    param_job(read_idf(idf_path), read_epw(epw_path))
+    param_job(read_idf(path_idf), read_epw(path_epw))
 }
 }
 
@@ -85,11 +82,37 @@ param$weather()
 
 
 ## ------------------------------------------------
-## Method `ParametricJob$models`
+## Method `ParametricJob$param`
 ## ------------------------------------------------
 
 \dontrun{
-param$models()
+
+param$param(
+    Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8))
+)
+
+# specify parameter values
+param$param(
+    Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)),
+    .names = c("thickness", "conduct", "fan_eff")
+)
+
+# each parameter should have the same length of values
+try(
+param$param(
+    Material := list(Thickness = c(0.1, 0.2)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8))
+)
+)
+
+# use all combinations of parameters
+param$param(
+    Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)),
+    .cross = TRUE
+)
 }
 
 
@@ -137,6 +160,24 @@ param$apply_measure(rotate_building, degree = seq(30, 360, 30))
 param$apply_measure(rotate_building, degree = seq(30, 360, 30),
     .names = paste0("rotate_", seq(30, 360, 30))
 )
+}
+
+
+## ------------------------------------------------
+## Method `ParametricJob$models`
+## ------------------------------------------------
+
+\dontrun{
+param$models()
+}
+
+
+## ------------------------------------------------
+## Method `ParametricJob$cases`
+## ------------------------------------------------
+
+\dontrun{
+param$cases()
 }
 
 
@@ -196,8 +237,10 @@ Hongyuan Jia
 \item \href{#method-version}{\code{ParametricJob$version()}}
 \item \href{#method-seed}{\code{ParametricJob$seed()}}
 \item \href{#method-weather}{\code{ParametricJob$weather()}}
-\item \href{#method-models}{\code{ParametricJob$models()}}
+\item \href{#method-param}{\code{ParametricJob$param()}}
 \item \href{#method-apply_measure}{\code{ParametricJob$apply_measure()}}
+\item \href{#method-models}{\code{ParametricJob$models()}}
+\item \href{#method-cases}{\code{ParametricJob$cases()}}
 \item \href{#method-save}{\code{ParametricJob$save()}}
 \item \href{#method-run}{\code{ParametricJob$run()}}
 \item \href{#method-print}{\code{ParametricJob$print()}}
@@ -250,18 +293,15 @@ A \code{ParametricJob} object.
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{\dontrun{
 if (is_avail_eplus(8.8)) {
-    idf_name <- "1ZoneUncontrolled.idf"
-    epw_name <-  "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw"
-
-    idf_path <- file.path(eplus_config(8.8)$dir, "ExampleFiles", idf_name)
-    epw_path <- file.path(eplus_config(8.8)$dir, "WeatherData", epw_name)
+     path_idf <- path_eplus_example(8.8, "5Zone_Transformer.idf")
+     path_epw <- path_eplus_weather(8.8, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")
 
     # create from an IDF and an EPW
-    param <- param_job(idf_path, epw_path)
-    param <- ParametricJob$new(idf_path, epw_path)
+    param <- param_job(path_idf, path_epw)
+    param <- ParametricJob$new(path_idf, path_epw)
 
     # create from an Idf and an Epw object
-    param_job(read_idf(idf_path), read_epw(epw_path))
+    param_job(read_idf(path_idf), read_epw(path_epw))
 }
 }
 
@@ -351,34 +391,104 @@ param$weather()
 
 }
 \if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-models"></a>}}
-\if{latex}{\out{\hypertarget{method-models}{}}}
-\subsection{Method \code{models()}}{
-Get created parametric \link{Idf} objects
+\if{html}{\out{<a id="method-param"></a>}}
+\if{latex}{\out{\hypertarget{method-param}{}}}
+\subsection{Method \code{param()}}{
+Set parameters for parametric simulations
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$models()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$param(..., .names = NULL, .cross = FALSE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{...}}{Lists of paramter definitions. Please see above on the
+syntax.}
+
+\item{\code{.names}}{A character vector of the parameter names. If \code{NULL},
+the parameter will be named in format \code{param_X}, where
+\code{X} is the index of parameter. Default: \code{NULL}.}
+
+\item{\code{.cross}}{If \code{TRUE}, all combinations of parameter values will be
+used to create models. If \code{FALSE}, each parameter should have
+the same length of values. Default: \code{FALSE}.}
+}
+\if{html}{\out{</div>}}
+}
 \subsection{Details}{
-\verb{$models()} returns a list of parametric models generated using input
-\link{Idf} object and
-\href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}}
-method. Model names are assigned in the same way as the \code{.names}
-arugment in
-\href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}}.
-If no measure has been applied, \code{NULL} is returned. Note that it is
-not recommended to conduct any extra modification on those models
-directly, after they were created using
-\href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}},
-as this may lead to an un-reproducible process. A warning message
-will be issued if any of those models has been modified when running
-simulations.
+\verb{$param()} takes parameter definitions in list format, which is
+similar to \link[=Idf]{Idf$set()} except that each field is not assigned
+with a single value, but a vector of any length, indicating the
+levels of each parameter.
+
+Similar like the way of modifying object field values in
+\link[=Idf]{Idf$set()}, there are 3 different ways of defining a parameter
+in epluspar:
+\itemize{
+\item \code{object = list(field = c(value1, value2, ...))}: Where \code{object} is
+a valid object ID or name. Note object ID should be denoted with
+two periods \code{..}, e.g. \code{..10} indicates the object with ID \code{10}, It
+will set that specific field in that object as one parameter.
+\item \code{.(object, object) := list(field = c(value1, value2, ...))}:
+Simimar like above, but note the use of \code{.()} in the left hand
+side.  You can put multiple object ID or names in \code{.()}. It will
+set the field of all specified objects as one parameter.
+\item \code{class := list(field = c(value1, value2, ...))}: Note the use of
+\verb{:=} instead of \code{=}. The main difference is that, unlike \code{=}, the
+left hand side of \verb{:=} should be a valid class name in current
+\link{Idf}. It will set that field of all objects in specified
+class as one parameter.
 }
 
+For example, the code block below defines 3 parameters:
+\itemize{
+\item Field \verb{Fan Total Efficiency} in object named \verb{Supply Fan 1} in class
+\code{Fan:VariableVolume} class, with 10 levels being 0.1 to 1.0 with a
+0.1 step.
+\item Field \code{Thickness} in all objects in class \code{Material}, with 10
+levels being 0.01 to 0.1 m with a 0.1 m step.
+\item Field \code{Conductivity} in all objects in class \code{Material}, with 10
+levels being 0.1 to 1.0 W/m-K with a 0.1 W/m-K step.
+}\preformatted{param$param(
+    `Supply Fan 1` = list(Fan_Total_Efficiency = seq(0.1, 1.0, 0.1)),
+    Material := list(Thickness = seq(0.01, 0.1, 0.1), Conductivity = seq(0.1, 1.0, 0.1))
+)
+}
+}
+
+\subsection{Returns}{
+The modified \code{ParametricJob} object invisibly.
+}
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{\dontrun{
-param$models()
+
+param$param(
+    Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8))
+)
+
+# specify parameter values
+param$param(
+    Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)),
+    .names = c("thickness", "conduct", "fan_eff")
+)
+
+# each parameter should have the same length of values
+try(
+param$param(
+    Material := list(Thickness = c(0.1, 0.2)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8))
+)
+)
+
+# use all combinations of parameters
+param$param(
+    Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+    "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)),
+    .cross = TRUE
+)
 }
 
 }
@@ -466,6 +576,96 @@ param$apply_measure(rotate_building, degree = seq(30, 360, 30))
 param$apply_measure(rotate_building, degree = seq(30, 360, 30),
     .names = paste0("rotate_", seq(30, 360, 30))
 )
+}
+
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-models"></a>}}
+\if{latex}{\out{\hypertarget{method-models}{}}}
+\subsection{Method \code{models()}}{
+Get created parametric \link{Idf} objects
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$models(names = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{names}}{A character vector of new names for parametric models.
+If a single string, it will be used as a prefix and all models
+will be named in pattern \code{names_X}, where \code{X} is the model
+index. If \code{NULL}, existing parametric models are directly
+returned. Default: \code{NULL}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\verb{$models()} returns a list of parametric models generated using input
+\link{Idf} object and
+\href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}}
+method. Model names are assigned in the same way as the \code{.names}
+arugment in
+\href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}}.
+If no measure has been applied, \code{NULL} is returned. Note that it is
+not recommended to conduct any extra modification on those models
+directly, after they were created using
+\href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}},
+as this may lead to an un-reproducible process. A warning message
+will be issued if any of those models has been modified when running
+simulations.
+}
+
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+param$models()
+}
+
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-cases"></a>}}
+\if{latex}{\out{\hypertarget{method-cases}{}}}
+\subsection{Method \code{cases()}}{
+Get a summary of parametric models and parameters
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$cases()}\if{html}{\out{</div>}}
+}
+
+\subsection{Details}{
+\verb{$cases()} returns a \link[data.table:data.table]{data.table} giving a
+summary of parametric models and parameter values.
+
+The returned \code{data.table} has the following columns:
+\itemize{
+\item \code{index}: Integer type. The indices of parameter models
+\item \code{case}: Character type. The names of parameter models
+\item Parameters: Type depends on the parameter values. Each parameter
+stands in a separate column. For parametric models created using
+\code{ParametricJob$param()}, the column names will be the same as what
+you specified in \code{.names}. For the case of
+\code{ParametricJob$apply_measure()}, this will be the argument names of
+the measure functions.
+}
+}
+
+\subsection{Returns}{
+If no parametric models have been created, \code{NULL} is
+returned. Otherwise, a \link[data.table:data.table]{data.table}.
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+param$cases()
 }
 
 }

--- a/tests/testthat/help-eplus.R
+++ b/tests/testthat/help-eplus.R
@@ -1,0 +1,3 @@
+    if (!is_avail_eplus(8.8)) {
+        install_eplus(8.8)
+    }

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -1,284 +1,200 @@
 test_that("Parametric methods", {
     skip_on_cran()
-    eplusr_option(verbose_info = FALSE)
 
-    if (!is_avail_eplus(8.8)) install_eplus(8.8)
-
+    # can stop if idf is not saved
     expect_error(param_job(empty_idf(8.8), NULL), class = "eplusr_error_idf_not_local")
 
-    example <- copy_example()
+    path_idf <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    path_epw <- path_eplus_weather(8.8, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")
 
-    param <- param_job(example$idf, example$epw)
+    param <- param_job(path_idf, path_epw)
 
-    priv <- get_priv_env(param)
-
+    # $version()
     expect_equal(param$version(), numeric_version("8.8.0"))
-    expect_output(param$print())
-    expect_null(param_job(example$idf, NULL)$weather())
 
-    # Seed and Weather {{{
+    # $seed()
     expect_is(param$seed(), "Idf")
+
+    # $weather()
     expect_is(param$weather(), "Epw")
+    expect_null(param_job(path_idf, NULL)$weather())
+})
+
+test_that("$apply_measure()", {
+    skip_on_cran()
+
+    path_idf <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path_idf, NULL)
+
+    mea <- function(idf, num) idf
+
+    expect_error(param$apply_measure(function(idf) idf))
+    expect_error(param$apply_measure(function(idf, ...) 1, a = 1:5))
+    expect_is(param$apply_measure(mea, num = 1:2, .names = "case"), "ParametricJob")
+    expect_equal(names(param$models()), c("case_1", "case_2"))
+    expect_error(param$apply_measure(mea, num = 1:2, .names = c("a", "b", "c")))
+
+    eplusr_option(verbose_info = FALSE)
+    param <- param_job(path_idf, NULL)
+    eplusr_option(verbose_info = TRUE)
+    expect_message(param$apply_measure(function(idf, num) idf, num = 1:2), "function")
+    expect_message(param$apply_measure(mea, num = 1:2), "mea")
+})
+
+test_that("$param()", {
+    skip_on_cran()
+
+    path <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path, NULL)
+
+    expect_is(class = "ParametricJob",
+        param$param("Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)), .cross = TRUE)
+    )
+    expect_equal(length(param$models()), 3L)
+
+    expect_is(class = "ParametricJob",
+        param$param(
+            Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+            "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8))
+        )
+    )
+    expect_equal(length(param$models()), 3L)
+
+    expect_is(class = "ParametricJob",
+        param$param(
+            Material := list(Thickness = seq(0.1, 1, length.out = 3), Conductivity = seq(0.1, 0.6, length.out = 3)),
+            "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)),
+            .cross = TRUE
+        )
+    )
+    expect_equal(length(param$models()), 27L)
+
+    expect_error(
+        param$param(
+            "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)),
+            .names = c("p1", "p2")
+        )
+    )
+    expect_is(class = "ParametricJob",
+        param$param(
+            "Supply Fan 1" = list(fan_total_efficiency = c(0.1, 0.5, 0.8)),
+            .names = "fan_eff"
+        )
+    )
+})
+
+test_that("$models()", {
+    skip_on_cran()
+
+    eplusr_option(verbose_info = FALSE)
+    path_idf <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path_idf, NULL)
+
     expect_null(param$models())
-    # }}}
+    expect_null(param$models("new name"))
 
-    # Measure {{{
-    pa <- param_job(example$idf, NULL)
-    test <- function(x, y) x
-    param$apply_measure(test, 1:5)
-    expect_equal(names(param$models()), sprintf("test_%i", 1:5))
-    param$apply_measure(function (x, y) x, 1:5)
-    expect_equal(names(param$models()), sprintf("case_%i", 1:5))
+    param$apply_measure(function(idf, num) idf, num = 1:2)
 
-    # set_infil_rate {{{
-    set_infil_rate <- function (idf, infil_rate) {
-
-        # validate input value
-        # this is optional, as validations will be made when setting values to `Idf`
-        stopifnot(is.numeric(infil_rate), infil_rate >= 0)
-
-        if (!idf$is_valid_class("ZoneInfiltration:DesignFlowRate"))
-          stop("Input model does not have any object in class `ZoneInfiltration:DesignFlowRate`")
-
-        ids <- idf$object_id("ZoneInfiltration:DesignFlowRate", simplify = TRUE)
-        val <- rep(list(list(design_flow_rate_calculation_method = "AirChanges/Hour", air_changes_per_hour = infil_rate)), length(ids))
-        setattr(val, "names", paste0("..", ids))
-        idf$set(val)
-
-        idf
-    }
-    # }}}
-    # names are unique
-    param$apply_measure(set_infil_rate, seq(0, 4, by = 1), .names = rep("A", 5))
-    expect_equal(names(priv$m_idfs), c("A", paste0("A_", 1:4)))
-
-    # auto assign name
-    param$apply_measure(set_infil_rate, seq(0, 4, by = 1), .names = NULL)
-    expect_equal(length(priv$m_idfs), 5)
-    expect_equal(names(priv$m_idfs), paste0("set_infil_rate_", 1:5))
-    expect_equal(unname(vlapply(priv$m_idfs, is_idf)), rep(TRUE, times = 5))
-    # }}}
-
-    # Models {{{
     expect_is(param$models(), "list")
-    expect_equal(length(param$models()), 5)
-    expect_equal(names(param$models()), paste0("set_infil_rate_", 1:5))
-    expect_equal(unname(vlapply(priv$m_idfs, is_idf)), rep(TRUE, times = 5))
-    # }}}
+    expect_equal(length(param$models()), 2)
+    expect_equal(names(param$models()), c("case_1", "case_2"))
 
-    # Save {{{
-    # can preserve name
-    param$apply_measure(set_infil_rate, seq(0, 4, by = 1), .names = 1:5)
-    expect_equal(names(param$models()), as.character(1:5))
-    expect_silent(paths <- param$save())
-    expect_equal(paths,
-        data.table::data.table(
-            model = normalizePath(file.path(tempdir(), 1:5, paste0(1:5, ".idf"))),
-            weather = normalizePath(file.path(tempdir(), 1:5, basename(param$weather()$path())))
+    expect_equal(names(param$models(names = "model")), c("model_1", "model_2"))
+    expect_error(names(param$models(names = c("a", "b", "c"))), "names")
+})
+
+test_that("$cases()", {
+    skip_on_cran()
+
+    path <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path, NULL)
+
+    expect_null(param$cases())
+
+    param$param(
+        "Supply Fan 1" = list(
+            fan_total_efficiency = c(0.1, 0.2),
+            availability_schedule_name = c("FanAvailSched", "Always On")
+        )
+    )
+    expect_equivalent(param$cases(),
+        data.table(index = 1:2, case = c("case_1", "case_2"),
+            param_1 = c(0.1, 0.2), param_2 = c("FanAvailSched", "Always On")
         )
     )
 
-    param$apply_measure(set_infil_rate, seq(0, 4, by = 1), .names = NULL)
-    expect_silent(paths <- param$save())
-    expect_equal(paths,
-        data.table::data.table(
-            model = normalizePath(file.path(tempdir(), paste0("set_infil_rate_", 1:5), paste0("set_infil_rate_", 1:5, ".idf"))),
-            weather = normalizePath(file.path(tempdir(), paste0("set_infil_rate_", 1:5), basename(param$weather()$path())))
+    param$apply_measure(
+        function(idf, eff, sch) {
+            idf$set("Supply Fan 1" = list(fan_total_efficiency = eff, availability_schedule_name = sch))
+            idf
+        },
+        c("FanAvailSched", "Always On"),
+        eff = c(0.1, 0.2)
+    )
+    expect_equivalent(param$cases(),
+        data.table(index = 1:2, case = c("case_1", "case_2"),
+            eff = c(0.1, 0.2), sch = c("FanAvailSched", "Always On")
         )
     )
-    expect_silent(paths <- param$save(separate = FALSE))
-    expect_equal(paths,
-        data.table::data.table(
-            model = normalizePath(file.path(tempdir(), paste0("set_infil_rate_", 1:5, ".idf"))),
-            weather = normalizePath(file.path(tempdir(), basename(param$weather()$path())))
-        )
-    )
-    # can save when no weather are provided
-    expect_silent(paths <- {
-        empty <- empty_idf(8.8)
-        empty$save(tempfile(fileext = ".idf"))
-        par <- param_job(empty, NULL)
-        par$apply_measure(function (idf, x) idf, 1:2, .names = 1:2)
-        par$save()
-    })
-    expect_equal(paths,
-        data.table::data.table(
-            model = normalizePath(file.path(tempdir(), 1:2, paste0(1:2, ".idf"))),
+})
+
+test_that("$run()", {
+    skip_on_cran()
+
+    path <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path, NULL)
+
+    expect_error(param$run(), "No measure")
+
+    param$apply_measure(function(idf, num) idf, num = 1:2)
+    param$models()[[1L]]$set(Material := list(thickness = 0.05))
+    expect_warning(param$run())
+})
+
+test_that("$save()", {
+    skip_on_cran()
+
+    path <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path, NULL)
+    expect_error(param$save())
+
+    param$apply_measure(function(idf, num) idf, num = 1:2)
+    expect_equivalent(param$save(),
+        data.table(
+            model = normalizePath(file.path(tempdir(), c("case_1", "case_2"), c("case_1.idf", "case_2.idf"))),
             weather = NA_character_
         )
     )
-    # }}}
 
-    # Run and Status {{{
-
-    # Can detect if models are modified before running
-    model2 <- param$models()$set_infil_rate_2
-    model2$Output_Variable <- NULL
-    expect_warning(param$run(echo = FALSE), class = "warn_param_modified")
-
-    dir_nms <- paste0("set_infil_rate_", 1:5)
-    param$apply_measure(set_infil_rate, seq(0, 4, by = 1), .names = NULL)
-    # can run the simulation and get status of simulation
-    expect_equal({param$run(dir = NULL, echo = FALSE); status <- param$status(); names(status)},
-        c("run_before", "alive", "terminated", "successful", "changed_after", "job_status")
-    )
-    expect_equal(status[c("run_before", "alive", "terminated", "successful", "changed_after")],
-        list(run_before = TRUE, alive = FALSE, terminated = FALSE,
-            successful = TRUE, changed_after = FALSE
+    param <- param_job(path, path_eplus_weather(8.8, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw"))
+    param$apply_measure(function(idf, num) idf, num = 1:2)
+    expect_equivalent(param$save(separate = FALSE),
+        data.table(
+            model = normalizePath(file.path(tempdir(), c("case_1.idf", "case_2.idf"))),
+            weather = normalizePath(file.path(tempdir(), "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw"))
         )
     )
-    expect_equal(names(status$job_status),
-        c("index", "status", "idf", "epw", "version", "exit_status", "start_time", "end_time",
-          "output_dir", "energyplus", "stdout", "stderr"
-        )
-    )
-    # }}}
+})
 
-    # Report Data Dict {{{
-    expect_is(param$report_data_dict(), "data.table")
-    expect_true(has_names(param$report_data_dict(), "case"))
-    expect_equal(nrow(param$report_data_dict(2)), 20)
-    expect_equal(nrow(param$report_data_dict("set_infil_rate_2")), 20)
-    # }}}
+test_that("$print()", {
+    skip_on_cran()
 
-    # Tabular Data {{{
-    expect_equal(nrow(param$tabular_data()), 6662 * 5)
-    expect_equal(nrow(param$tabular_data(
-        report_name = c(
-            "AnnualBuildingUtilityPerformanceSummary",
-            "Initialization Summary"
-        ))),
-        3774 * 5
-    )
-    expect_equal(nrow(param$tabular_data(table_name = "Site and Source Energy")), 12 * 5)
-    expect_equal(nrow(param$tabular_data(column_name = "Total Energy")), 4 * 5)
-    expect_equal(nrow(param$tabular_data(row_name = "Total Site Energy")), 3 * 5)
-    expect_equal(nrow(param$tabular_data(2)), 6662)
-    expect_equal(nrow(param$tabular_data(2,
-        report_name = c(
-            "AnnualBuildingUtilityPerformanceSummary",
-            "Initialization Summary"
-        ))),
-        3774
-    )
-    expect_equal(nrow(param$tabular_data(2, table_name = "Site and Source Energy")), 12)
-    expect_equal(nrow(param$tabular_data(2, column_name = "Total Energy")), 4)
-    expect_equal(nrow(param$tabular_data(2, row_name = "Total Site Energy")), 3)
-    expect_equal(nrow(param$tabular_data("set_infil_rate_2")), 6662)
-    expect_equal(nrow(param$tabular_data("set_infil_rate_2",
-        report_name = c(
-            "AnnualBuildingUtilityPerformanceSummary",
-            "Initialization Summary"
-        ))),
-        3774
-    )
-    expect_equal(nrow(param$tabular_data("set_infil_rate_2", table_name = "Site and Source Energy")), 12)
-    expect_equal(nrow(param$tabular_data("set_infil_rate_2" ,column_name = "Total Energy")), 4)
-    expect_equal(nrow(param$tabular_data("set_infil_rate_2", row_name = "Total Site Energy")), 3)
-    # }}}
+    path <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path, NULL)
+    expect_output(param$print())
 
-    # Report Data {{{
-    expect_equal(nrow(param$report_data(2, param$report_data_dict())), 3840)
-    expect_equal(nrow(param$report_data(2)), 3840)
-    expect_equal(nrow(param$report_data(2, "")), 1344L)
-    expect_equal(nrow(param$report_data(2,
-        "TRANSFORMER 1", "Transformer Load Loss Rate")),
-        192L
-    )
-    expect_equal(nrow(param$report_data(2,
-        "TRANSFORMER 1", "Transformer Load Loss Rate")),
-        192L
-    )
-    expect_equal(year(param$report_data(2,
-        "TRANSFORMER 1", "Transformer Load Loss Rate", year = 2010)$datetime),
-        rep(2010, 192)
-    )
-    expect_equal(lubridate::tz(param$report_data(2, tz = "Asia/Shanghai")$datetime),
-        "Asia/Shanghai"
-    )
-    expect_equal(names(param$report_data(2, all = TRUE)),
-        c("index", "case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
-          "simulation_days", "day_type", "environment_name",
-          "environment_period_index", "is_meter", "type", "index_group",
-          "timestep_type", "key_value", "name", "reporting_frequency",
-          "schedule_name", "units", "value"
-        )
-    )
-    expect_equal(nrow(param$report_data(2, period = seq(
-        lubridate::ymd_hms("2019-01-14 0:0:0"), lubridate::ymd_hms("2019-01-15 0:0:0"), "15 min")
-    )), 1900)
-    expect_equal(nrow(param$report_data(2, month = 1)), 1920)
-    expect_equal(nrow(param$report_data(2, month = 1, hour = 1)), 80)
-    expect_equal(nrow(param$report_data(2, minute = 0)), 960)
-    expect_equal(nrow(param$report_data(2, interval = 15)), 3840)
-    expect_equal(nrow(param$report_data(2, simulation_days = 1)), 3840)
-    expect_equal(nrow(param$report_data(2, day_type = "Tuesday")), 3840)
-    expect_equal(nrow(param$report_data(2, environment_name = "WINTERDAY")), 1920)
+    mea <- function(idf, num) idf
+    param$apply_measure(mea, num = 1:2)
+    expect_output(param$print())
+})
 
-    expect_equal(nrow(param$report_data(NULL, param$report_data_dict())), 3840 * 5)
-    expect_equal(nrow(param$report_data()), 3840 * 5)
-    expect_equal(nrow(param$report_data(NULL, "")), 1344L * 5)
-    expect_equal(nrow(param$report_data(NULL,
-        "TRANSFORMER 1", "Transformer Load Loss Rate")),
-        192L * 5
-    )
-    expect_equal(nrow(param$report_data(NULL,
-        "TRANSFORMER 1", "Transformer Load Loss Rate")),
-        192L * 5
-    )
-    expect_equal(year(param$report_data(NULL,
-        "TRANSFORMER 1", "Transformer Load Loss Rate", year = 2010)$datetime),
-        rep(2010, 192 * 5)
-    )
-    expect_equal(lubridate::tz(param$report_data(NULL, tz = "Asia/Shanghai")$datetime),
-        "Asia/Shanghai"
-    )
-    expect_equal(names(param$report_data(all = TRUE)),
-        c("index", "case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
-          "simulation_days", "day_type", "environment_name",
-          "environment_period_index", "is_meter", "type", "index_group",
-          "timestep_type", "key_value", "name", "reporting_frequency",
-          "schedule_name", "units", "value"
-        )
-    )
-    expect_equal(nrow(param$report_data(period = seq(
-        lubridate::ymd_hms("2019-01-14 0:0:0"), lubridate::ymd_hms("2019-01-15 0:0:0"), "15 min")
-    )), 1900 * 5)
-    expect_equal(nrow(param$report_data(month = 1)), 1920 * 5)
-    expect_equal(nrow(param$report_data(month = 1, hour = 1)), 80 * 5)
-    expect_equal(nrow(param$report_data(minute = 0)), 960 * 5)
-    expect_equal(nrow(param$report_data(interval = 15)), 3840 * 5)
-    expect_equal(nrow(param$report_data(simulation_days = 1)), 3840 * 5)
-    expect_equal(nrow(param$report_data(day_type = "Tuesday")), 3840 * 5)
-    expect_equal(nrow(param$report_data(environment_name = "WINTERDAY")), 1920 * 5)
-    # }}}
+test_that("==.ParametricJob and !=.ParametricJob", {
+    skip_on_cran()
 
-    # S3 {{{
+    path <- copy_eplus_example(8.8, "5Zone_Transformer.idf")
+    param <- param_job(path, NULL)
+
     expect_false(param == 1)
     expect_true(param == param)
     expect_false(param != param)
-    # }}}
-
-    skip_on_os("mac")
-    # Locate Output {{{
-    expect_equal(param$locate_output(suffix = ".sql"),
-        normalizePath(file.path(dirname(example$idf), dir_nms, paste0(dir_nms, ".sql"))))
-    expect_equal(param$locate_output(2, suffix = ".sql"),
-        normalizePath(file.path(dirname(example$idf), dir_nms[2], paste0(dir_nms[2], ".sql"))))
-    expect_equal(param$locate_output("set_infil_rate_2", suffix = ".sql"),
-        normalizePath(file.path(dirname(example$idf), dir_nms[2], paste0(dir_nms[2], ".sql"))))
-    # }}}
-
-    # Output Dir {{{
-    expect_equal(param$output_dir(),
-        normalizePath(file.path(dirname(example$idf), dir_nms)))
-    expect_equal(param$output_dir(2),
-        normalizePath(file.path(dirname(example$idf), dir_nms[2])))
-    expect_equal(param$output_dir("set_infil_rate_2"),
-        normalizePath(file.path(dirname(example$idf), dir_nms[2])))
-    # }}}
-
-    # clean
-    lapply(dir_nms, unlink, recursive = TRUE, force = TRUE)
-    unlink(c(example$idf, example$epw))
 })

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -149,6 +149,10 @@ test_that("$run()", {
     param$apply_measure(function(idf, num) idf, num = 1:2)
     param$models()[[1L]]$set(Material := list(thickness = 0.05))
     expect_warning(param$run())
+
+    path_epw <- path_eplus_weather(8.8, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")
+    param <- param_job(path, path_epw)
+    expect_is(param$run(), "ParametricJob")
 })
 
 test_that("$save()", {

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -152,6 +152,7 @@ test_that("$run()", {
 
     path_epw <- path_eplus_weather(8.8, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")
     param <- param_job(path, path_epw)
+    param$apply_measure(function(idf, num) idf, num = 1:2)
     expect_is(param$run(), "ParametricJob")
 })
 

--- a/vignettes/param.Rmd
+++ b/vignettes/param.Rmd
@@ -163,6 +163,13 @@ param$apply_measure(ecm,
 )
 ```
 
+After parametric models have been created, you can retrive the summary of the
+parameter values and model names using `$cases()`.
+
+```{r}
+param$cases()
+```
+
 # Run parametric simulations in parallel
 
 The `$run()` method will run all parametric simulations in parallel and place


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #475
- A new argument `names` can be specified in `ParametricJob$models()` to rename the parametric models created.
- A new interface for creating parametric models has been introduced using `ParametricJob$param()`. It takes parameter definitions in list format, which is similar to `Idf$set()` except that each field is not assigned with a single value, but a vector of any length, indicating the levels of each parameter. For example, the code block below defines 3 parameters:

  * Field `Fan Total Efficiency` in object named `Supply Fan 1` in class `Fan:VariableVolume` class, with 10 levels being 0.1 to 1.0 with a 0.1 step.
  * Field `Thickness` in all objects in class `Material`, with 10 levels being 0.01 to 0.1 m with a 0.1 m step.
  * Field `Conductivity` in all objects in class `Material`, with 10 levels being 0.1 to 1.0 W/m-K with a 0.1 W/m-K step.

  ```
  param$param(
      `Supply Fan 1` = list(Fan_Total_Efficiency = seq(0.1, 1.0, 0.1)),
      Material := list(Thickness = seq(0.01, 0.1, 0.1), Conductivity = seq(0.1, 1.0, 0.1))
  )
  ```
- `ParametricJob$cases()` is added to get a summary of parametric models and parameter values. It returns a `data.table` giving you the indices and names of the parametric models, and all parameter values used to create those models.For parametric models created using `ParametricJob$param()`, the column names will be the same as what you specified in `.names`. For the case of `ParametricJob$apply_measure()`, this will be the argument names of the measure functions.
- Now `.names` in `ParametricJob$apply_measure()` can be a single character. In this case, it will be used as the prefix of all parametric models. The models will be named in the pattern `.names_X` where `X` is the model index.