### PR TITLE
[fix] Rename EnergyPlus 9.1 installer properly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.15.0.9000
+Version: 0.15.0.9001
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 ## Bug fixes
 
 * Fix `ParametricJob$cases()` when multiple objects are specified on the LHS in
-  `ParametricJob$param()` (#492)
+  `ParametricJob$param()` (#492).
+* Fix `install_eplus(9.1)` on Linux ().
 
 # eplusr v0.15.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * Fix `ParametricJob$cases()` when multiple objects are specified on the LHS in
   `ParametricJob$param()` (#492).
-* Fix `install_eplus(9.1)` on Linux ().
+* Fix `install_eplus(9.1)` on Linux (#494).
 
 # eplusr v0.15.0
 

--- a/R/install.R
+++ b/R/install.R
@@ -423,7 +423,7 @@ install_eplus_linux <- function (ver, exec, local = FALSE, dir = NULL, dir_bin =
     if (ver == 9.1) {
         if (Sys.which("sed") != "") {
             # copy the original installer
-            temp_exec <- file.path(tempdir(), basename(exec))
+            temp_exec <- file.path(tempdir(), paste("patched-", basename(exec)))
             flag <- file.copy(exec, temp_exec, overwrite = TRUE, copy.date = TRUE)
             if (!flag) {
                 abort(paste0(

--- a/tests/testthat/helper-eplus.R
+++ b/tests/testthat/helper-eplus.R
@@ -1,3 +1,3 @@
 if (identical(Sys.getenv("NOT_CRAN"), "true") && !is_avail_eplus(8.8)) {
-    install_eplus(8.8)
+    install_eplus(8.8, local = TRUE)
 }


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #495 
- Fix the error in `install_eplus(9.1)` on Linux. The error is caused by `file.copy()` with same input for `from` and `to`.
