### PR TITLE
[fix] Handle empty geometry in `IdfGeometry$coord_system()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.15.1.9000
+Version: 0.15.1.9001
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # eplusr (development version)
 
+## Bug fixes
+
+* Now `IdfGeometry$coord_system()` can correctly work. The coordinate system
+  type can also be `"world"`. `"absolute"` input now is automatically converted
+  to `"world"` to be compatible with EnergyPlus. `IdfGeometry$coord_system()`
+  now returns itself by default, instead of the parent `Idf` object. This
+  enables to check the modified coordinate systems by printing the `IdfGeometry`
+  (#506 #507).
+
 # eplusr 0.15.1
 
 ## Bug fixes

--- a/R/geom.R
+++ b/R/geom.R
@@ -162,20 +162,21 @@ IdfGeometry <- R6Class("IdfGeometry", cloneable = FALSE,
         #'
         #' @details
         #' `$coord_system()` converts all vertices of geometries into specified
-        #' coordinate systems, e.g. from absolute to relative, and vice versa.
+        #' coordinate systems, e.g. from world to relative, and vice versa.
         #' Besides, it also updates the `GlobalGeometryRules` in parent [Idf]
         #' accordingly.
         #'
         #' @param detailed,simple,daylighting A string specifying the coordinate
         #'        system for detailed geometries, simple (rectangular surface)
         #'        geometries, and daylighting reference points. Should be one of
-        #'        `"relative"` and `"absolute"`.
+        #'        `"relative"`, `"world"` and `"absolute"`. `"absolute"` is the
+        #'        same as `"world"` and converted to it.
         #'
         #' @return The modified [Idf] object.
         #'
         #' @examples
         #' \dontrun{
-        #' geom$coord_system("absolute", "absolute", "absolute")
+        #' geom$coord_system("world", "world", "world")
         #' }
         coord_system = function (detailed = NULL, simple = NULL, daylighting = NULL)
             idfgeom_coord_system(self, private, detailed, simple, daylighting),
@@ -485,6 +486,14 @@ idfgeom_rules <- function (self, private) {
 idfgeom_coord_system <- function (self, private, detailed = NULL, simple = NULL, daylighting = NULL) {
     if (is.null(detailed) && is.null(simple) && is.null(daylighting)) return(invisible(private$m_parent))
 
+    assert_choice(detailed, c("world", "absolute", "relative"), null.ok = TRUE)
+    assert_choice(simple, c("world", "absolute", "relative"), null.ok = TRUE)
+    assert_choice(daylighting, c("world", "absolute", "relative"), null.ok = TRUE)
+
+    if (!is.null(detailed) && detailed == "absolute") detailed <- "world"
+    if (!is.null(simple) && simple == "absolute") simple <- "world"
+    if (!is.null(daylighting) && daylighting == "absolute") daylighting <- "world"
+
     rules <- private$geoms()$rules
 
     private$m_geoms <- align_coord_system(private$geoms(), detailed, simple, daylighting)
@@ -717,9 +726,9 @@ idfgeom_print <- function (self, private) {
     cli::cat_line(sprintf(" * Dayl Ref Pnt Num: %s", NROW(geoms$daylighting_point)))
     cli::cat_line(" * Coordinate System:")
     cli::cat_line(c(
-        sprintf("   - Detailed: '%s'", ifelse(geoms$rules$coordinate_system == "absolute", "Absolute", "Relative")),
-        sprintf("   - Simple:   '%s'", ifelse(geoms$rules$rectangular_surface_coordinate_system == "absolute", "Absolute", "Relative")),
-        sprintf("   - Daylighting: '%s'", ifelse(geoms$rules$daylighting_reference_point_coordinate_system == "absolute", "Absolute", "Relative"))
+        sprintf("   - Detailed: '%s'", ifelse(geoms$rules$coordinate_system == "world", "World", "Relative")),
+        sprintf("   - Simple:   '%s'", ifelse(geoms$rules$rectangular_surface_coordinate_system == "world", "World", "Relative")),
+        sprintf("   - Daylighting: '%s'", ifelse(geoms$rules$daylighting_reference_point_coordinate_system == "world", "World", "Relative"))
     ))
 }
 # }}}

--- a/R/geom.R
+++ b/R/geom.R
@@ -519,9 +519,9 @@ idfgeom_coord_system <- function (self, private, detailed = NULL, simple = NULL,
     # update vertices of detailed geometries
     if (rules$coordinate_system != private$m_geoms$rules$coordinate_system) {
         meta <- rbindlist(list(
-            fast_subset(private$m_geoms$surface, c("id", "class")),
-            fast_subset(private$m_geoms$subsurface, c("id", "class")),
-            fast_subset(private$m_geoms$shading, c("id", "class"))
+            if (nrow(private$m_geoms$surface)) fast_subset(private$m_geoms$surface, c("id", "class")),
+            if (nrow(private$m_geoms$subsurface)) fast_subset(private$m_geoms$subsurface, c("id", "class")),
+            if (nrow(private$m_geoms$shading)) fast_subset(private$m_geoms$shading, c("id", "class"))
         ))
         set_geom_vertices(private$m_parent, list(meta = meta, vertices = private$m_geoms$vertices))
     }

--- a/R/geom.R
+++ b/R/geom.R
@@ -484,7 +484,7 @@ idfgeom_rules <- function (self, private) {
 # }}}
 # idfgeom_coord_system {{{
 idfgeom_coord_system <- function (self, private, detailed = NULL, simple = NULL, daylighting = NULL) {
-    if (is.null(detailed) && is.null(simple) && is.null(daylighting)) return(invisible(private$m_parent))
+    if (is.null(detailed) && is.null(simple) && is.null(daylighting)) return(self)
 
     assert_choice(detailed, c("world", "absolute", "relative"), null.ok = TRUE)
     assert_choice(simple, c("world", "absolute", "relative"), null.ok = TRUE)
@@ -534,7 +534,7 @@ idfgeom_coord_system <- function (self, private, detailed = NULL, simple = NULL,
     private$log_parent_order()
     private$log_geom_class()
 
-    invisible(private$m_parent)
+    self
 }
 # }}}
 # idfgeom_convert {{{

--- a/R/impl-geom.R
+++ b/R/impl-geom.R
@@ -69,7 +69,7 @@ get_global_geom_rules <- function (idf) {
                 rules[[i]] <- stri_trans_tolower(rules[[i]])
             }
 
-            if (rules[[i]] == "world") rules[[i]] <- "absolute"
+            if (rules[[i]] == "absolute") rules[[i]] <- "world"
         }
 
         setattr(rules, "names", lower_name(names(rules)))
@@ -1271,9 +1271,9 @@ subset_geom <- function (geoms, type = c("all", "floor", "wall", "roof", "window
 
 # align_coord_system {{{
 align_coord_system <- function (geoms, detailed = NULL, simple = NULL, daylighting = NULL) {
-    assert_choice(detailed, c("absolute", "relative"), null.ok = TRUE)
-    assert_choice(simple, c("absolute", "relative"), null.ok = TRUE)
-    assert_choice(daylighting, c("absolute", "relative"), null.ok = TRUE)
+    assert_choice(detailed, c("world", "relative"), null.ok = TRUE)
+    assert_choice(simple, c("world", "relative"), null.ok = TRUE)
+    assert_choice(daylighting, c("world", "relative"), null.ok = TRUE)
 
     if (is.null(detailed) && is.null(simple) && is.null(daylighting)) return(geoms)
     if (!nrow(geoms$zone)) return(geoms)
@@ -1326,7 +1326,7 @@ align_coord_system <- function (geoms, detailed = NULL, simple = NULL, daylighti
         # update rules
         geoms$rules$coordinate_system <- detailed
 
-        # -1 for absolute to relative and 1 for relative to absolute
+        # -1 for world to relative and 1 for relative to world
         mult <- if (detailed == "relative") -1L else 1L
 
         if (any(is_det_surf)) {
@@ -1355,7 +1355,7 @@ align_coord_system <- function (geoms, detailed = NULL, simple = NULL, daylighti
         # update rules
         geoms$rules$rectangular_surface_coordinate_system <- simple
 
-        # -1 for absolute to relative and 1 for relative to absolute
+        # -1 for world to relative and 1 for relative to world
         mult <- if (simple == "relative") -1L else 1L
 
         if (any(is_sim_surf)) {
@@ -1375,7 +1375,7 @@ align_coord_system <- function (geoms, detailed = NULL, simple = NULL, daylighti
         geoms$rules$daylighting_reference_point_coordinate_system <- daylighting
 
         if (nrow(geoms$daylighting_point)) {
-            # -1 for absolute to relative and 1 for relative to absolute
+            # -1 for world to relative and 1 for relative to world
             mult <- if (daylighting == "relative") -1L else 1L
             set(geoms$daylighting_point, NULL, "mult", mult)
         }

--- a/R/impl-geom.R
+++ b/R/impl-geom.R
@@ -355,13 +355,9 @@ extract_geom_subsurface_detailed <- function (idf, geom_class = NULL, object = N
     setnames(meta, c("object_id", "class_name"), c("id", "class"))
 
     # vertices
-    if (idf$version() < 9.0) {
-        vertices <- dt[J(11:22), on = "field_index"][, by = "object_id",
-            list(index = rep(1:4, each = 3L), field = rep(c("x", "y", "z"), 4L), value_num)]
-    } else {
-        vertices <- dt[J(10:21), on = "field_index"][, by = "object_id",
-            list(index = rep(1:4, each = 3L), field = rep(c("x", "y", "z"), 4L), value_num)]
-    }
+    fldid_start <- dt[stri_startswith_fixed(field_name, "Vertex 1"), min(field_index)]
+    vertices <- dt[J(fldid_start:(fldid_start + 11)), on = "field_index"][, by = "object_id",
+        list(index = rep(1:4, each = 3L), field = rep(c("x", "y", "z"), 4L), value_num)]
     vertices <- dcast.data.table(vertices, object_id + index ~ field, value.var = "value_num")
     setnames(vertices, "object_id", "id")
 

--- a/R/impl-geom.R
+++ b/R/impl-geom.R
@@ -1287,28 +1287,24 @@ align_coord_system <- function (geoms, detailed = NULL, simple = NULL, daylighti
         on.exit(set(geoms$surface, NULL, "mult", NULL), add = TRUE)
     } else {
         geoms$surface <- empty
-        on.exit(geoms$surface <- data.table(), add = TRUE)
     }
     if (nrow(geoms$subsurface)) {
         set(geoms$subsurface, NULL, "mult", 0L)
         on.exit(set(geoms$subsurface, NULL, c("mult", "zone_name"), NULL), add = TRUE)
     } else {
         geoms$subsurface <- empty
-        on.exit(geoms$subsurface <- data.table(), add = TRUE)
     }
     if (nrow(geoms$shading)) {
         set(geoms$shading, NULL, "mult", 0L)
         on.exit(set(geoms$shading, NULL, c("mult", "zone_name"), NULL), add = TRUE)
     } else {
         geoms$shading <- empty
-        on.exit(geoms$shading <- data.table(), add = TRUE)
     }
     if (nrow(geoms$daylighting_point)) {
         set(geoms$daylighting_point, NULL, "mult", 0L)
         on.exit(set(geoms$daylighting_point, NULL, "mult", NULL), add = TRUE)
     } else {
         geoms$daylighting_point <- empty
-        on.exit(geoms$daylighting_point <- data.table(), add = TRUE)
     }
 
     # indicates whether detailed/simple class names have been checked
@@ -1417,6 +1413,10 @@ align_coord_system <- function (geoms, detailed = NULL, simple = NULL, daylighti
 
     set(geoms$vertices, NULL, c("zone_name", "mult"), NULL)
 
+    if (!nrow(geoms$surface)) geoms$surface <- data.table()
+    if (!nrow(geoms$subsurface)) geoms$subsurface <- data.table()
+    if (!nrow(geoms$shading)) geoms$shading <- data.table()
+    if (!nrow(geoms$daylighting_point)) geoms$daylighting_point <- data.table()
     geoms
 }
 # }}}

--- a/R/viewer.R
+++ b/R/viewer.R
@@ -526,7 +526,7 @@ IdfViewer <- R6Class("IdfViewer", cloneable = FALSE,
 
                 # change all vertices to world coordinate system
                 private$m_log$geoms <- align_coord_system(
-                    private$m_log$geoms, "absolute", "absolute", "absolute"
+                    private$m_log$geoms, "world", "world", "world"
                 )
 
                 # vertices2 for triangulation

--- a/man/IdfGeometry.Rd
+++ b/man/IdfGeometry.Rd
@@ -73,7 +73,7 @@ geom$convert()
 ## ------------------------------------------------
 
 \dontrun{
-geom$coord_system("absolute", "absolute", "absolute")
+geom$coord_system("world", "world", "world")
 }
 
 ## ------------------------------------------------
@@ -310,13 +310,14 @@ Convert vertices to specified coordinate systems
 \item{\code{detailed, simple, daylighting}}{A string specifying the coordinate
 system for detailed geometries, simple (rectangular surface)
 geometries, and daylighting reference points. Should be one of
-\code{"relative"} and \code{"absolute"}.}
+\code{"relative"}, \code{"world"} and \code{"absolute"}. \code{"absolute"} is the
+same as \code{"world"} and converted to it.}
 }
 \if{html}{\out{</div>}}
 }
 \subsection{Details}{
 \verb{$coord_system()} converts all vertices of geometries into specified
-coordinate systems, e.g. from absolute to relative, and vice versa.
+coordinate systems, e.g. from world to relative, and vice versa.
 Besides, it also updates the \code{GlobalGeometryRules} in parent \link{Idf}
 accordingly.
 }
@@ -327,7 +328,7 @@ The modified \link{Idf} object.
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{\dontrun{
-geom$coord_system("absolute", "absolute", "absolute")
+geom$coord_system("world", "world", "world")
 }
 }
 \if{html}{\out{</div>}}

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -13,7 +13,9 @@ test_that("IdfGeometry", {
 
     expect_is(geom$parent(), "Idf")
     expect_is(geom$rules(), "list")
+    expect_is(geom$coord_system(), "IdfGeometry")
     expect_is(geom$coord_system("world", "world", "world"), "IdfGeometry")
+    expect_is(geom$coord_system("absolute", "absolute", "absolute"), "IdfGeometry")
     expect_equal(unlist(geom$rules()[3:5], use.names = FALSE), rep("world", 3L))
     expect_equal(unlist(idf$GlobalGeometryRules$value(3:5), use.names = FALSE), rep("World", 3L))
 

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -13,9 +13,9 @@ test_that("IdfGeometry", {
 
     expect_is(geom$parent(), "Idf")
     expect_is(geom$rules(), "list")
-    expect_is(geom$coord_system("absolute", "absolute", "absolute"), "Idf")
-    expect_equal(unlist(geom$rules()[3:5], use.names = FALSE), rep("absolute", 3L))
-    expect_equal(unlist(idf$GlobalGeometryRules$value(3:5), use.names = FALSE), rep("Absolute", 3L))
+    expect_is(geom$coord_system("world", "world", "world"), "IdfGeometry")
+    expect_equal(unlist(geom$rules()[3:5], use.names = FALSE), rep("world", 3L))
+    expect_equal(unlist(idf$GlobalGeometryRules$value(3:5), use.names = FALSE), rep("World", 3L))
 
     expect_is(conv <- geom$convert(), "Idf")
     expect_is(attr(conv, "mapping"), "data.table")

--- a/tests/testthat/test-impl-geom.R
+++ b/tests/testthat/test-impl-geom.R
@@ -35,11 +35,23 @@ test_that("Geometry Extraction", {
             rectangular_surface_coordinate_system = "relative"
         )
     )
+    idf$GlobalGeometryRules$Coordinate_System <- "Absolute"
+    expect_equal(get_global_geom_rules(idf)$coordinate_system, "world")
+    ## can handle malformed global geometry rules
+    without_checking(idf$GlobalGeometryRules$set(..3 = NULL, ..4 = NULL, ..5 = NULL, .default = FALSE, .empty = TRUE))
+    expect_warning(rules <- get_global_geom_rules(idf))
+    expect_equal(unlist(rules, FALSE, FALSE)[3:5], rep("relative", 3))
+    without_checking(idf$GlobalGeometryRules$set(..3 = "Invalid", ..4 = "Invalid", ..5 = "Invalid", .default = FALSE, .empty = TRUE))
+    expect_warning(rules <- get_global_geom_rules(idf))
+    expect_equal(unlist(rules, FALSE, FALSE)[3:5], rep("relative", 3))
 
     # building transformation
     expect_equal(get_building_transformation(idf),
         list(id = 3L, name = "Building", north_axis = 30)
     )
+    ## can handle malformed building object
+    without_checking(idf$Building$North_Axis <- NULL)
+    expect_equal(expect_warning(get_building_transformation(idf))$north_axis, 0)
 
     # zone transformation
     expect_equal(d <- get_zone_transformation(idf),
@@ -200,10 +212,14 @@ test_that("Align coordinate system", {
     cls <- get_geom_class(idf)
 
     expect_is(geoms <- extract_geom(idf), "list")
+    expect_is(geoms <- align_coord_system(geoms), "list")
     expect_is(geoms <- align_coord_system(geoms, "relative", "relative", "relative"), "list")
     expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("relative", 3L))
     expect_is(geoms <- align_coord_system(geoms, "world", "world", "world"), "list")
     expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("world", 3L))
+
+    expect_warning(geoms <- extract_geom(empty_idf(8.8)))
+    expect_is(geoms <- align_coord_system(geoms, "world", "world", "world"), "list")
 })
 # }}}
 

--- a/tests/testthat/test-impl-geom.R
+++ b/tests/testthat/test-impl-geom.R
@@ -202,8 +202,8 @@ test_that("Align coordinate system", {
     expect_is(geoms <- extract_geom(idf), "list")
     expect_is(geoms <- align_coord_system(geoms, "relative", "relative", "relative"), "list")
     expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("relative", 3L))
-    expect_is(geoms <- align_coord_system(geoms, "absolute", "absolute", "absolute"), "list")
-    expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("absolute", 3L))
+    expect_is(geoms <- align_coord_system(geoms, "world", "world", "world"), "list")
+    expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("world", 3L))
 })
 # }}}
 

--- a/tests/testthat/test-impl-viewer.R
+++ b/tests/testthat/test-impl-viewer.R
@@ -6,7 +6,7 @@ test_that("IdfViewer Implemention", {
     idf <- read_idf(file.path(eplus_config(8.8)$dir, "ExampleFiles/4ZoneWithShading_Simple_1.idf"))
 
     expect_is(geoms <- extract_geom(idf), "list")
-    expect_is(geoms <- align_coord_system(geoms, "absolute", "absolute", "absolute"), "list")
+    expect_is(geoms <- align_coord_system(geoms, "world", "world", "world"), "list")
     expect_is(geoms$vertices2 <- triangulate_geoms(geoms), "data.table")
 
     rgl_init <- function (clear = TRUE) {
@@ -63,8 +63,8 @@ test_that("IdfViewer Implemention", {
     expect_is(geoms <- extract_geom(idf), "list")
     expect_is(geoms <- align_coord_system(geoms, "relative", "relative", "relative"), "list")
     expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("relative", 3L))
-    expect_is(geoms <- align_coord_system(geoms, "absolute", "absolute", "absolute"), "list")
-    expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("absolute", 3L))
+    expect_is(geoms <- align_coord_system(geoms, "world", "world", "world"), "list")
+    expect_equal(unlist(geoms$rules[3:5], FALSE, FALSE), rep("world", 3L))
     expect_is(geoms$vertices2 <- triangulate_geoms(geoms), "data.table")
 
     expect_is(dev <- rgl_init(), "integer")

--- a/vignettes/geom.Rmd
+++ b/vignettes/geom.Rmd
@@ -141,7 +141,7 @@ attr(simple, "mapping")
 # Change coordinate systems
 
 `$coord_system()` converts all vertices of geometries into specified
-coordinate systems, e.g. from absolute to relative, and vice versa.
+coordinate systems, e.g. from world to relative, and vice versa.
 Besides, it also updates the `GlobalGeometryRules` in parent [Idf]
 accordingly.
 
@@ -150,7 +150,7 @@ geom$rules()
 
 geom$parent()$to_table("Floor 1 Cafe Slab")
 
-geom$coord_system("absolute")
+geom$coord_system("world")
 
 geom$parent()$to_table("Floor 1 Cafe Slab")
 ```


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #506
- Fixes #507
- Empty subsurface and shading geometry is now correctly handled in `IdfGeometry$coord_system()`/
- The coordinate system type can also be `"world"`. `"absolute"` input now is automatically converted to `"world"` to be compatible with EnergyPlus.
- `IdfGeometry$coord_system()` now returns itself by default, instead of the parent `Idf` object. This enables to check the modified coordinate systems by printing the `IdfGeometry`.

