### PR TITLE
[feat] Add `encoding` parameter when parsing inputs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.15.1.9004
+Version: 0.15.1.9005
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # eplusr (development version)
 
+## New features
+
+* A new `encoding` parameter has been added in `read_idf()`, `use_idd()` and
+  `read_epw()`. The default value is `unknown` which indicates that the input
+  file is native encoded (#515).
+
 ## Bug fixes
 
 * Now `IdfGeometry$coord_system()` can correctly work. The coordinate system

--- a/R/epw.R
+++ b/R/epw.R
@@ -13,12 +13,12 @@ NULL
 EpwIdd <- R6::R6Class(classname = "EpwIdd", cloneable = FALSE, lock_objects = FALSE,
     inherit = Idd,
     public = list(
-        initialize = function (path) {
+        initialize = function (path, encoding = "unknown") {
             # add a uuid
             private$m_log <- new.env(hash = FALSE, parent = emptyenv())
             private$m_log$uuid <- unique_id()
 
-            idd_file <- parse_idd_file(path, epw = TRUE)
+            idd_file <- parse_idd_file(path, epw = TRUE, encoding = encoding)
             private$m_version <- idd_file$version
             private$m_build <- idd_file$build
 
@@ -129,6 +129,10 @@ Epw <- R6::R6Class(classname = "Epw",
         #'        single string or a raw vector) to an EnergyPlus Weather File
         #'        (EPW).  If a file path, that file usually has a extension
         #'        `.epw`.
+        #' @param encoding The file encoding of input IDD. Should be one of
+        #'        `"unknown"`, `"Latin-1" and `"UTF-8"`. The default is
+        #'        `"unknown"` which means that the file is encoded in the native
+        #'        encoding.
         #'
         #' @return An `Epw` object.
         #'
@@ -152,14 +156,14 @@ Epw <- R6::R6Class(classname = "Epw",
         #' }
         #' }
         #'
-        initialize = function (path) {
+        initialize = function (path, encoding = "unknown") {
             if (checkmate::test_file_exists(path, "r")) {
                 private$m_path <- normalizePath(path)
             }
 
             private$m_idd <- get_epw_idd()
 
-            epw_file <- parse_epw_file(path, idd = private$m_idd)
+            epw_file <- parse_epw_file(path, idd = private$m_idd, encoding = encoding)
 
             private$m_idf_env <- list2env(epw_file$header, parent = emptyenv())
             private$m_data <- epw_file$data
@@ -1294,6 +1298,9 @@ formals(Epw$public_methods$clone)$deep <- TRUE
 #' simplifications. For more details on `Epw`, please see [Epw] class.
 #'
 #' @param path A path of an EnergyPlus `EPW` file.
+#' @param encoding The file encoding of input IDD. Should be one of `"unknown"`,
+#'        `"Latin-1" and `"UTF-8"`. The default is `"unknown"` which means that
+#'        the file is encoded in the native encoding.
 #' @return An `Epw` object.
 #' @examples
 #' \dontrun{

--- a/R/idd.R
+++ b/R/idd.R
@@ -77,6 +77,10 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
         #'        string or a raw vector) to an EnergyPlus Input Data Dictionary
         #'        (IDD). If a file path, that file usually has a extension
         #'        `.idd`.
+        #' @param encoding The file encoding of input IDD. Should be one of
+        #'        `"unknown"`, `"Latin-1" and `"UTF-8"`. The default is
+        #'        `"unknown"` which means that the file is encoded in the native
+        #'        encoding.
         #'
         #' @return An `Idd` object.
         #'
@@ -87,7 +91,7 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
         #' idd <- use_idd(8.8, download = "auto")
         #' }
         #'
-        initialize = function (path) {
+        initialize = function (path, encoding = "unknown") {
             # only store if input is a path
             if (is.character(path) && length(path) == 1L) {
                 if (file.exists(path)) private$m_path <- normalizePath(path)
@@ -97,7 +101,7 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
             private$m_log <- new.env(hash = FALSE, parent = emptyenv())
             private$m_log$uuid <- unique_id()
 
-            idd_file <- parse_idd_file(path)
+            idd_file <- parse_idd_file(path, encoding = encoding)
             private$m_version <- idd_file$version
             private$m_build <- idd_file$build
 
@@ -986,8 +990,8 @@ format.Idd <- function (x, ...) {
 # }}}
 
 # read_idd {{{
-read_idd <- function (path) {
-    Idd$new(path)
+read_idd <- function (path, encoding = "unknown") {
+    Idd$new(path, encoding = encoding)
 }
 # }}}
 

--- a/R/idd.R
+++ b/R/idd.R
@@ -1010,6 +1010,9 @@ read_idd <- function (path) {
 #'     means the latest version.
 #' @param dir A directory to indicate where to save the IDD file. Default:
 #'     current working directory.
+#' @param encoding The file encoding of input IDD. Should be one of `"unknown"`,
+#'     `"Latin-1" and `"UTF-8"`. The default is `"unknown"` which means that the
+#'     file is encoded in the native encoding.
 #'
 #' @details
 #' `use_idd()` takes a valid version or a path of an EnergyPlus Input Data
@@ -1077,14 +1080,14 @@ read_idd <- function (path) {
 #' @export
 #' @author Hongyuan Jia
 # use_idd {{{
-use_idd <- function (idd, download = FALSE) {
+use_idd <- function (idd, download = FALSE, encoding = "unknown") {
     if (is_idd(idd)) return(idd)
 
     assert_vector(idd, len = 1L)
 
     # if input is a file path or literal IDD string
     if (!is_idd_ver(idd)) {
-        return(tryCatch(read_idd(idd), eplusr_error_read_lines = function (e) {
+        return(tryCatch(read_idd(idd, encoding = encoding), eplusr_error_read_lines = function (e) {
             abort(paste0("Parameter 'idd' should be a valid version, a path, or ",
                 "a single character string of an EnergyPlus Input Data ",
                 "Dictionary (IDD) file (usually named 'Energy+.idd'). ",
@@ -1171,7 +1174,7 @@ use_idd <- function (idd, download = FALSE) {
 
     verbose_info("IDD file found: ", surround(idd), ".")
     verbose_info("Start parsing...")
-    idd <- read_idd(idd)
+    idd <- read_idd(idd, encoding = encoding)
     verbose_info("Parsing completed.")
     idd
 }

--- a/R/idf.R
+++ b/R/idf.R
@@ -72,6 +72,10 @@ Idf <- R6::R6Class(classname = "Idf",
         #'        default, the version of IDF will be passed to [use_idd()]. If
         #'        the input is an `.ddy` file which does not have a version
         #'        field, the latest version of [Idf] cached will be used.
+        #' @param encoding The file encoding of input IDF. Should be one of
+        #'        `"unknown"`, `"Latin-1" and `"UTF-8"`. The default is
+        #'        `"unknown"` which means that the file is encoded in the native
+        #'        encoding.
         #'
         #' @return An `Idf` object.
         #'
@@ -104,13 +108,13 @@ Idf <- R6::R6Class(classname = "Idf",
         #' Idf$new(string_idf, use_idd(8.8, download = "auto"))
         #' }
         #'
-        initialize = function (path, idd = NULL) {
+        initialize = function (path, idd = NULL, encoding = "unknown") {
             # only store if input is a path
             if (is.character(path) && length(path) == 1L) {
                 if (file.exists(path)) private$m_path <- normalizePath(path)
             }
 
-            idf_file <- parse_idf_file(path, idd)
+            idf_file <- parse_idf_file(path, idd, encoding = encoding)
             idd <- use_idd(idf_file$version)
 
             # in case there is no version field in input IDF
@@ -3578,12 +3582,15 @@ idf_has_hvactemplate <- function (idf) {
 #' `Idf` object. For more details on `Idf` object, please see [Idf] class.
 #'
 #' @param path Either a path, a connection, or literal data (either a single
-#' string or a raw vector) to an EnergyPlus Input Data File (IDF). If a file
-#' path, that file usually has a extension `.idf`.
+#'        string or a raw vector) to an EnergyPlus Input Data File (IDF). If a
+#'        file path, that file usually has a extension `.idf`.
 #' @param idd  Any acceptable input of [use_idd()]. If `NULL`, which is the
-#' default, the version of IDF will be passed to [use_idd()]. If the input is an
-#' `.ddy` file which does not have a version field, the latest version of [Idf]
-#' cached will be used.
+#'        default, the version of IDF will be passed to [use_idd()]. If the
+#'        input is an `.ddy` file which does not have a version field, the
+#'        latest version of [Idf] cached will be used.
+#' @param encoding The file encoding of input IDD. Should be one of `"unknown"`,
+#'        `"Latin-1" and `"UTF-8"`. The default is `"unknown"` which means that
+#'        the file is encoded in the native encoding.
 #'
 #' @details
 #' Currently, Imf file is not fully supported. All EpMacro lines will be treated
@@ -3631,8 +3638,8 @@ idf_has_hvactemplate <- function (idf) {
 #' @export
 #' @author Hongyuan Jia
 # read_idf {{{
-read_idf <- function (path, idd = NULL) {
-    Idf$new(path, idd)
+read_idf <- function (path, idd = NULL, encoding = "unknown") {
+    Idf$new(path, idd, encoding = encoding)
 }
 # }}}
 

--- a/R/impl-epw.R
+++ b/R/impl-epw.R
@@ -176,12 +176,12 @@ get_epw_idd_env <- function () {
 #    01:00:00, Hour of 2 corresponds to the period between 01:00:01 to 02:00:00,
 #    and etc. The minute column is **not used** to determine currently sub-hour
 #    time.
-parse_epw_file <- function (path, idd = NULL) {
+parse_epw_file <- function (path, idd = NULL, encoding = "unknown") {
     # read and parse header
-    epw_header <- parse_epw_header(path)
+    epw_header <- parse_epw_header(path, encoding = encoding)
 
     # read core weather data
-    epw_data <- parse_epw_data(path)
+    epw_data <- parse_epw_data(path, encoding = encoding)
 
     # add line indicator
     set(epw_data, NULL, "line", seq_len(nrow(epw_data)))
@@ -201,10 +201,10 @@ parse_epw_file <- function (path, idd = NULL) {
 # }}}
 ## HEADER
 # parse_epw_header {{{
-parse_epw_header <- function (path, strict = FALSE) {
+parse_epw_header <- function (path, strict = FALSE, encoding = "unknown") {
     idd_env <- get_epw_idd_env()
 
-    dt_in <- read_lines(path, nrows = 8L)
+    dt_in <- read_lines(path, nrows = 8L, encoding = encoding)
 
     # in case header does not any fields, e.g. "LOCATION\n"
     dt_in[!stri_detect_fixed(string, ","), string := paste0(string, ",")]
@@ -1194,7 +1194,7 @@ as.POSIXct.EpwDate <- function (x, ...) {
 # }}}
 ## DATA
 # parse_epw_data {{{
-parse_epw_data <- function (path) {
+parse_epw_data <- function (path, encoding = "unknown") {
     num_header <- 8L
 
     idd_env <- get_epw_idd_env()
@@ -1205,7 +1205,7 @@ parse_epw_data <- function (path) {
     # colnames refers to column "Long Name" in Table 2.8 in
     # "AuxiliaryPrograms.pdf" of EnergyPlus 8.6
     # TODO: fread will directly skip those few abnormal rows
-    header_epw_data <- fread(path, sep = ",", skip = num_header, nrows = 0L, header = FALSE)
+    header_epw_data <- fread(path, sep = ",", skip = num_header, nrows = 0L, header = FALSE, encoding = encoding)
     if (ncol(header_epw_data) != cls$min_fields) {
         parse_error("epw", "Invalid weather data column", num = 1L,
             post = sprintf("Expected %i fields in EPW weather data instead of '%i' in current file",

--- a/R/parse.R
+++ b/R/parse.R
@@ -100,9 +100,9 @@ FIELD_COLS <- list(
 # }}}
 
 # parse_idd_file {{{
-parse_idd_file <- function(path, epw = FALSE) {
+parse_idd_file <- function(path, epw = FALSE, encoding = "unknown") {
     # read idd string, get idd version and build
-    idd_dt <- read_lines(path)
+    idd_dt <- read_lines(path, encoding = encoding)
 
     idd_version <- get_idd_ver(idd_dt)
     idd_build <- get_idd_build(idd_dt)
@@ -183,9 +183,9 @@ parse_idd_file <- function(path, epw = FALSE) {
 # }}}
 
 # parse_idf_file {{{
-parse_idf_file <- function (path, idd = NULL, ref = TRUE) {
+parse_idf_file <- function (path, idd = NULL, ref = TRUE, encoding = "unknown") {
     # read IDF string and get version first to get corresponding IDD
-    idf_dt <- read_lines(path)
+    idf_dt <- read_lines(path, encoding = encoding)
     # delete blank lines
     idf_dt <- idf_dt[!stri_isempty(string)]
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -128,17 +128,6 @@ read_lines <- function(input, trim = TRUE, encoding = "unknown", ...) {
     if (!nrow(dt)) return(data.table(string = character(0L), line = integer(0L)))
     set(dt, j = "line", value = seq_along(dt[["string"]]))
 
-    # stringi will silent convert every inputs to UTF-8 encoded
-    if (any(not_valid <- !stringi::stri_enc_isutf8(dt$string) & !stringi::stri_enc_isascii(dt$string))) {
-        # try to fix the problems using the most possible encoding guessed from
-        # stringi
-        enc <- vcapply(stringi::stri_enc_detect(dt$string[not_valid]),
-            function(l) .subset2(.subset2(l, "Encoding"), 1L)
-        )
-        enc <- names(table(enc))[1L]
-        set(dt, which(not_valid), "string", stringi::stri_encode(dt$string[not_valid], enc, "UTF-8"))
-    }
-
     if (trim) set(dt, j = "string", value = stri_trim_both(dt[["string"]]))
 
     setcolorder(dt, c("line", "string"))

--- a/man/Epw.Rd
+++ b/man/Epw.Rd
@@ -477,7 +477,7 @@ Hongyuan Jia
 \subsection{Method \code{new()}}{
 Create an \code{Epw} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Epw$new(path)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Epw$new(path, encoding = "unknown")}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -487,6 +487,10 @@ Create an \code{Epw} object
 single string or a raw vector) to an EnergyPlus Weather File
 (EPW).  If a file path, that file usually has a extension
 \code{.epw}.}
+
+\item{\code{encoding}}{The file encoding of input IDD. Should be one of
+\code{"unknown"}, \verb{"Latin-1" and }"UTF-8"\verb{. The default is }"unknown"` which means that the file is encoded in the native
+encoding.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Idd.Rd
+++ b/man/Idd.Rd
@@ -330,7 +330,7 @@ Hongyuan Jia
 \subsection{Method \code{new()}}{
 Create an \code{Idd} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Idd$new(path)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Idd$new(path, encoding = "unknown")}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -340,6 +340,10 @@ Create an \code{Idd} object
 string or a raw vector) to an EnergyPlus Input Data Dictionary
 (IDD). If a file path, that file usually has a extension
 \code{.idd}.}
+
+\item{\code{encoding}}{The file encoding of input IDD. Should be one of
+\code{"unknown"}, \verb{"Latin-1" and }"UTF-8"\verb{. The default is }"unknown"` which means that the file is encoded in the native
+encoding.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -921,7 +921,7 @@ Hongyuan Jia
 \subsection{Method \code{new()}}{
 Create an \code{Idf} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Idf$new(path, idd = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Idf$new(path, idd = NULL, encoding = "unknown")}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -936,6 +936,10 @@ string or a raw vector) to an EnergyPlus Input Data File
 default, the version of IDF will be passed to \code{\link[=use_idd]{use_idd()}}. If
 the input is an \code{.ddy} file which does not have a version
 field, the latest version of \link{Idf} cached will be used.}
+
+\item{\code{encoding}}{The file encoding of input IDF. Should be one of
+\code{"unknown"}, \verb{"Latin-1" and }"UTF-8"\verb{. The default is }"unknown"` which means that the file is encoded in the native
+encoding.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/read_epw.Rd
+++ b/man/read_epw.Rd
@@ -8,6 +8,10 @@ read_epw(path)
 }
 \arguments{
 \item{path}{A path of an EnergyPlus \code{EPW} file.}
+
+\item{encoding}{The file encoding of input IDD. Should be one of \code{"unknown"},
+\verb{"Latin-1" and }"UTF-8"\verb{. The default is }"unknown"` which means that
+the file is encoded in the native encoding.}
 }
 \value{
 An \code{Epw} object.

--- a/man/read_idf.Rd
+++ b/man/read_idf.Rd
@@ -4,17 +4,21 @@
 \alias{read_idf}
 \title{Read an EnergyPlus Input Data File (IDF)}
 \usage{
-read_idf(path, idd = NULL)
+read_idf(path, idd = NULL, encoding = "unknown")
 }
 \arguments{
 \item{path}{Either a path, a connection, or literal data (either a single
-string or a raw vector) to an EnergyPlus Input Data File (IDF). If a file
-path, that file usually has a extension \code{.idf}.}
+string or a raw vector) to an EnergyPlus Input Data File (IDF). If a
+file path, that file usually has a extension \code{.idf}.}
 
 \item{idd}{Any acceptable input of \code{\link[=use_idd]{use_idd()}}. If \code{NULL}, which is the
-default, the version of IDF will be passed to \code{\link[=use_idd]{use_idd()}}. If the input is an
-\code{.ddy} file which does not have a version field, the latest version of \link{Idf}
-cached will be used.}
+default, the version of IDF will be passed to \code{\link[=use_idd]{use_idd()}}. If the
+input is an \code{.ddy} file which does not have a version field, the
+latest version of \link{Idf} cached will be used.}
+
+\item{encoding}{The file encoding of input IDD. Should be one of \code{"unknown"},
+\verb{"Latin-1" and }"UTF-8"\verb{. The default is }"unknown"` which means that
+the file is encoded in the native encoding.}
 }
 \value{
 An \link{Idf} object.

--- a/man/use_idd.Rd
+++ b/man/use_idd.Rd
@@ -7,7 +7,7 @@
 \alias{is_avail_idd}
 \title{Use a specific EnergyPlus Input Data Dictionary (IDD) file}
 \usage{
-use_idd(idd, download = FALSE)
+use_idd(idd, download = FALSE, encoding = "unknown")
 
 download_idd(ver = "latest", dir = ".")
 
@@ -29,6 +29,10 @@ automatically download corresponding IDD file if the Idd object is
 currently not available. It is useful in case when you only want to edit
 an EnergyPlus Input Data File (IDF) directly but do not want to install
 whole EnergyPlus software. Default is \code{FALSE}.}
+
+\item{encoding}{The file encoding of input IDD. Should be one of \code{"unknown"},
+\verb{"Latin-1" and }"UTF-8"\verb{. The default is }"unknown"` which means that the
+file is encoded in the native encoding.}
 
 \item{ver}{A valid EnergyPlus version, e.g. \code{8}, \code{8.7}, \code{"8.7"} or \code{"8.7.0"}.
 For \code{download_idd()}, the special value \code{"latest"}, which is default,


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #515
- * A new `encoding` parameter has been added in `read_idf()`, `use_idd()` and `read_epw()`. The default value is `unknown` which indicates that the input file is native encoded.
