### PR TITLE
[feat] Respect validate level option when parsing EPW files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.15.1.9005
+Version: 0.15.1.9006
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@
 * A new `encoding` parameter has been added in `read_idf()`, `use_idd()` and
   `read_epw()`. The default value is `unknown` which indicates that the input
   file is native encoded (#515).
+* Now `validate_level` option is respected when parsing EPW files. This makes it
+  possible to parse EPW files with non-standard EPW header values, which is
+  useful when only the core EPW data is needed (#520). E.g:
+  ```
+  with_option(list(validate_level = "none"), read_epw(YOUR_EPW_PATH))
+  ```
 
 ## Bug fixes
 

--- a/R/impl-epw.R
+++ b/R/impl-epw.R
@@ -659,7 +659,7 @@ validate_epw_header <- function (header, strict = FALSE) {
 # }}}
 # validate_epw_header_basic {{{
 validate_epw_header_basic <- function (header, class = NULL, field = NULL) {
-    chk <- level_checks("final")
+    chk <- level_checks()
     chk$auto_field <- FALSE
     chk$reference <- FALSE
 


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #520
- Previously, the final validate level is used when parsing EPW headers. This makes it impossible to read EPW files with non-standard header specs, especially ones not from the EnergyPlus website that do not follow strictly the EPW header format. This PR changes the behavior to use the current validate level when parsing EPW. So that one can still read those files by setting a less permissive validate level, e.g. "none".
