### PR TITLE
Change rgl.* to *3d calls.

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -330,7 +330,7 @@ IdfGeometry <- R6Class("IdfGeometry", cloneable = FALSE,
         #' For more detailed control on the scene, see [IdfViewer].
         #'
         #' @param new If `TRUE`, a new rgl window will be open using
-        #'        [rgl::rgl.open()]. If `FALSE`, existing rgl window will be
+        #'        [rgl::open3d()]. If `FALSE`, existing rgl window will be
         #'        reused if possible. Default: `FALSE`.
         #'
         #' @param render_by A single string specifying the way of rendering the

--- a/R/idf.R
+++ b/R/idf.R
@@ -2585,7 +2585,7 @@ Idf <- R6::R6Class(classname = "Idf",
         #' * Wheel: Zoom
         #'
         #' @param new If `TRUE`, a new rgl window will be open using
-        #'        [rgl::rgl.open()]. If `FALSE`, existing rgl window will be
+        #'        [rgl::open3d()]. If `FALSE`, existing rgl window will be
         #'        reused if possible. Default: `FALSE`.
         #'
         #' @param render_by A single string specifying the way of rendering the

--- a/R/impl-viewer.R
+++ b/R/impl-viewer.R
@@ -57,8 +57,8 @@ rgl_viewpoint <- function (dev, look_at = "iso", theta = NULL, phi = NULL, fov =
 
     m <- get_viewpoint_matrix(rot[1], rot[2], rot[3])
 
-    rgl::rgl.set(dev)
-    rgl::rgl.viewpoint(fov = fov, zoom = zoom, scale = scale, userMatrix = m)
+    rgl::set3d(dev)
+    rgl::view3d(fov = fov, zoom = zoom, scale = scale, userMatrix = m)
 
     list(userMatrix = m, fov = fov, zoom = zoom, scale = scale)
 }
@@ -77,7 +77,7 @@ rgl_view_surface <- function (dev, geoms, type = "surface_type", x_ray = FALSE, 
         on.exit(rgl_vertice_trans_to_eplus(geoms$vertices2), add = TRUE)
     }
 
-    rgl::rgl.set(dev)
+    rgl::set3d(dev)
 
     geoms <- map_view_color(geoms, type = type, x_ray = x_ray)
 
@@ -178,13 +178,13 @@ rgl_view_surface <- function (dev, geoms, type = "surface_type", x_ray = FALSE, 
 # rgl_view_surface_twoside_tri {{{
 rgl_view_surface_twoside_tri <- function (vertices) {
     if (!nrow(vertices)) return(integer())
-    ext <- rgl::rgl.triangles(
+    ext <- rgl::triangles3d(
         x = as.matrix(fast_subset(vertices, c("x", "y", "z"))),
         color = as.matrix(fast_subset(vertices, rep("color_ext", 3L))),
         alpha = as.matrix(fast_subset(vertices, rep("alpha", 3L))),
         front = "filled", back = "culled", lit = FALSE
     )
-    int <- rgl::rgl.triangles(
+    int <- rgl::triangles3d(
         x = as.matrix(fast_subset(vertices, c("x", "y", "z"))),
         color = as.matrix(fast_subset(vertices, rep("color_int", 3L))),
         alpha = as.matrix(fast_subset(vertices, rep("alpha", 3L))),
@@ -197,13 +197,13 @@ rgl_view_surface_twoside_tri <- function (vertices) {
 # rgl_view_surface_twoside_quad {{{
 rgl_view_surface_twoside_quad <- function (vertices) {
     if (!nrow(vertices)) return(integer())
-    ext <- rgl::rgl.quads(
+    ext <- rgl::quads3d(
         x = as.matrix(fast_subset(vertices, c("x", "y", "z"))),
         color = as.matrix(fast_subset(vertices, rep("color_ext", 3L))),
         alpha = as.matrix(fast_subset(vertices, rep("alpha", 3L))),
         front = "filled", back = "culled", lit = FALSE
     )
-    int <- rgl::rgl.quads(
+    int <- rgl::quads3d(
         x = as.matrix(fast_subset(vertices, c("x", "y", "z"))),
         color = as.matrix(fast_subset(vertices, rep("color_int", 3L))),
         alpha = as.matrix(fast_subset(vertices, rep("alpha", 3L))),
@@ -218,7 +218,7 @@ rgl_view_surface_oneside_tri <- function (vertices) {
     if (!nrow(vertices)) return(integer())
     col <- if (has_names(vertices, "color_int")) "color_int" else "color"
 
-    as.integer(rgl::rgl.triangles(
+    as.integer(rgl::triangles3d(
         x = as.matrix(fast_subset(vertices, c("x", "y", "z"))),
         color = as.matrix(fast_subset(vertices, rep(col, 3L))),
         alpha = as.matrix(fast_subset(vertices, rep("alpha", 3L))),
@@ -232,7 +232,7 @@ rgl_view_surface_oneside_quad <- function (vertices) {
     if (!nrow(vertices)) return(integer())
     col <- if (has_names(vertices, "color_int")) "color_int" else "color"
 
-    as.integer(rgl::rgl.quads(
+    as.integer(rgl::quads3d(
         x = as.matrix(fast_subset(vertices, c("x", "y", "z"))),
         color = as.matrix(fast_subset(vertices, rep(col, 3L))),
         alpha = as.matrix(fast_subset(vertices, rep("alpha", 3L))),
@@ -251,9 +251,9 @@ rgl_view_wireframe <- function (dev, geoms, color = "black", width = 1.5, alpha 
         on.exit(rgl_vertice_trans_to_eplus(geoms$vertices), add = TRUE)
     }
 
-    rgl::rgl.set(dev)
+    rgl::set3d(dev)
     l <- pair_line_vertex(geoms$vertices)
-    as.integer(rgl::rgl.lines(l$x, l$y, l$z, color = color, lwd = width, lit = FALSE, alpha = alpha, ...))
+    as.integer(rgl::segments3d(l$x, l$y, l$z, color = color, lwd = width, lit = FALSE, alpha = alpha, ...))
 }
 # }}}
 
@@ -270,8 +270,8 @@ rgl_view_point <- function (dev, geoms, color = "red", size = 8.0, lit = TRUE, .
 
     v <- geoms$vertices[J(geoms$daylighting_point$id), on = "id", nomatch = NULL]
 
-    rgl::rgl.set(dev)
-    as.integer(rgl::rgl.points(v$x, v$y, v$z, color = color, size = size, lit = lit, ...))
+    rgl::set3d(dev)
+    as.integer(rgl::points3d(v$x, v$y, v$z, color = color, size = size, lit = lit, ...))
 }
 # }}}
 
@@ -366,7 +366,7 @@ rgl_view_ground <- function (dev, geoms, expand = 1.02, color = "#EDEDEB", alpha
     # transform geometry from EnergyPlus to OpenGL coordinate system
     vert <- rgl_vertice_trans_to_opengl(vert)
 
-    as.integer(rgl::rgl.quads(
+    as.integer(rgl::quads3d(
         vert$x, vert$y, vert$z,
         color = color, lit = FALSE, alpha = alpha
     ))
@@ -378,7 +378,7 @@ rgl_snapshot <- function (dev, filename, webshot = FALSE, ...) {
     assert_string(filename)
 
     # set the last plot device as active
-    if (!rgl::rgl.useNULL()) rgl::rgl.set(dev)
+    if (!rgl::rgl.useNULL()) rgl::set3d(dev)
 
     if (!dir.exists(dirname(filename))) dir.create(dirname(filename), recursive = TRUE)
 
@@ -540,7 +540,7 @@ triangulate_surfaces <- function (vertices) {
 
 # pan3d {{{
 # adapted from rgl examples
-pan3d <- function(button, dev = rgl::rgl.cur(), subscene = rgl::currentSubscene3d(dev)) {
+pan3d <- function(button, dev = rgl::cur3d(), subscene = rgl::currentSubscene3d(dev)) {
     start <- list()
 
     begin <- function(x, y) {
@@ -578,7 +578,7 @@ pan_view <- function (dev, x, y, z) {
 
 # rgl_pop {{{
 rgl_pop <- function (id, type = "shapes") {
-    try(as.integer(rgl::rgl.pop(id = id, type = "shapes")), silent = TRUE)
+    try(as.integer(rgl::pop3d(id = id, type = "shapes")), silent = TRUE)
 }
 # }}}
 

--- a/R/viewer.R
+++ b/R/viewer.R
@@ -590,7 +590,7 @@ idfviewer_device <- function (self, private) {
 idfviewer_background <- function (self, private, color = "white") {
     assert_string(color)
     private$m_background <- color
-    if (!is.null(self$device())) rgl::rgl.bg(color = color)
+    if (!is.null(self$device())) rgl::bg3d(color = color)
     invisible()
 }
 # }}}
@@ -794,8 +794,8 @@ idfviewer_show <- function (self, private, type = "all", zone = NULL, surface = 
 
     # open a new device
     if (!length(self$device())) {
-        rgl::rgl.open()
-        private$m_device <- rgl::rgl.cur()
+        rgl::open3d()
+        private$m_device <- rgl::cur3d()
 
         # apply window size
         rgl::par3d(dev = private$m_device, windowRect = private$m_win_size)
@@ -804,7 +804,7 @@ idfviewer_show <- function (self, private, type = "all", zone = NULL, surface = 
         do.call(self$viewpoint, private$m_viewpoint)
 
         # apply background
-        rgl::rgl.bg(color = private$m_background)
+        rgl::bg3d(color = private$m_background)
 
         # apply mouse mode
         do.call(self$mouse_mode, private$m_mouse_mode)
@@ -854,7 +854,7 @@ idfviewer_focus <- function (self, private) {
     if (is.null(self$device())) {
         verbose_info("No viewer window found. Skip.")
     } else {
-        rgl::rgl.set(private$m_device)
+        rgl::set3d(private$m_device)
         rgl::rgl.bringtotop()
     }
 
@@ -866,8 +866,8 @@ idfviewer_close <- function (self, private) {
     if (is.null(self$device())) {
         verbose_info("No viewer window found. Skip.")
     } else {
-        rgl::rgl.set(private$m_device)
-        rgl::rgl.close()
+        rgl::set3d(private$m_device)
+        rgl::close3d()
     }
 
     invisible()

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -4196,7 +4196,7 @@ View 3D \code{Idf} geometry
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{new}}{If \code{TRUE}, a new rgl window will be open using
-\code{\link[rgl:rgl.open]{rgl::rgl.open()}}. If \code{FALSE}, existing rgl window will be
+\code{\link[rgl:open3d]{rgl::open3d()}}. If \code{FALSE}, existing rgl window will be
 reused if possible. Default: \code{FALSE}.}
 
 \item{\code{render_by}}{A single string specifying the way of rendering the

--- a/man/IdfGeometry.Rd
+++ b/man/IdfGeometry.Rd
@@ -543,7 +543,7 @@ View 3D geometry
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{new}}{If \code{TRUE}, a new rgl window will be open using
-\code{\link[rgl:rgl.open]{rgl::rgl.open()}}. If \code{FALSE}, existing rgl window will be
+\code{\link[rgl:open3d]{rgl::open3d()}}. If \code{FALSE}, existing rgl window will be
 reused if possible. Default: \code{FALSE}.}
 
 \item{\code{render_by}}{A single string specifying the way of rendering the

--- a/tests/testthat/test-impl-viewer.R
+++ b/tests/testthat/test-impl-viewer.R
@@ -12,16 +12,16 @@ test_that("IdfViewer Implemention", {
     rgl_init <- function (clear = TRUE) {
         new <- FALSE
         if (clear) {
-            if (rgl::rgl.cur() == 0) new <- TRUE else rgl::rgl.clear()
+            if (rgl::cur3d() == 0) new <- TRUE else rgl::rgl.clear()
         }
         if (!new) {
-            dev <- rgl::rgl.cur()
+            dev <- rgl::cur3d()
         } else {
-            rgl::rgl.open()
-            dev <- rgl::rgl.cur()
+            rgl::open3d()
+            dev <- rgl::cur3d()
 
             # set viewpoint
-            rgl::rgl.viewpoint(0, -60, 60)
+            rgl::view3d(0, -60, 60)
 
             # change mouse control method
             cur <- rgl::par3d("mouseMode")
@@ -32,9 +32,9 @@ test_that("IdfViewer Implemention", {
             pan3d(2L)
         }
 
-        rgl::rgl.bg(color = "white")
+        rgl::bg3d(color = "white")
 
-        rgl::rgl.set(dev)
+        rgl::set3d(dev)
         dev
     }
 
@@ -92,6 +92,6 @@ test_that("IdfViewer Implemention", {
     expect_type(rgl_pop(id = unlist(id_surface)), "integer")
     expect_type(id_surface <- rgl_view_surface(dev, geoms, "normal"), "integer")
 
-    rgl::rgl.close()
+    rgl::close3d()
 })
 # }}}


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to eplusr.  I will be deprecating a number of rgl.* function calls.  You can read about the issues here:

     https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to eplusr in the attached patch. These changes should work with both old and new rgl versions.
