### PR TITLE
Use OS version specific EnergyPlus installer downlaod URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.2
+Version: 0.16.2.9000
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# eplusr (development version)
+
+## New features
+
+* Now `install_eplus()` can choose the installer most suitable for current OS
+  version (#579).
+
 # eplusr 0.16.2
 
 ## Bug fixes

--- a/R/constants.R
+++ b/R/constants.R
@@ -28,6 +28,7 @@ ALL_IDD_VER <- c(
 
 ALL_EPLUS_RELEASE_COMMIT <- data.table::fread(
     "version , commit
+     23.2.0  , 7636e6b3e9
      23.1.0  , 87ed9199d4
      22.2.0  , c249759bad
      22.1.0  , ed759b17ee
@@ -47,6 +48,80 @@ ALL_EPLUS_RELEASE_COMMIT <- data.table::fread(
      8.4.0   , 832e4bb9cb
      8.3.0   , 6d97d074ea
     "
+)
+
+# data for OS version specific EnergyPlus installers
+ALL_EPLUS_OSVER <- list(
+    "23.2.0" = list(
+        macos = list(
+            x86_64 = c("macOS10.15", "macOS11.6", "macOS12.1"),
+            arm64  = c("macOS12.1")
+        ),
+        linux = list(
+            # Ubuntu18.04 support dropped
+            x86_64 = c("Ubuntu20.04", "Ubuntu22.04"),
+            arm64  = c("Ubuntu22.04")
+        )
+    ),
+    "23.1.0" = list(
+        macos = list(
+            x86_64 = c("macOS10.15", "macOS11.6", "macOS12.1"),
+            arm64  = c("macOS12.1")
+        ),
+        linux = list(
+            x86_64 = c("Ubuntu18.04", "Ubuntu20.04", "Ubuntu22.04"),
+            # arm64 support added
+            arm64  = c("Ubuntu22.04")
+        )
+    ),
+    "22.2.0" = list(
+        macos = list(
+            x86_64 = c("macOS10.15", "macOS11.6", "macOS12.1"),
+            arm64  = c("macOS12.1")
+        ),
+        linux = list(
+            # Ubuntu22.04 support added
+            x86_64 = c("Ubuntu18.04", "Ubuntu20.04", "Ubuntu22.04")
+        )
+    ),
+    "22.1.0" = list(
+        macos = list(
+            # macOS12.1 support added
+            x86_64 = c("macOS10.15", "macOS11.6", "macOS12.1"),
+            # arm64 support added again
+            arm64  = c("macOS12.1")
+        ),
+        linux = list(
+            x86_64 = c("Ubuntu18.04", "Ubuntu20.04")
+        )
+    ),
+    "9.6.0" = list(
+        macos = list(
+            # no arm64 support for macOS11.6
+            x86_64 = c("macOS10.15", "macOS11.6")
+        ),
+        linux = list(
+            x86_64 = c("Ubuntu18.04", "Ubuntu20.04")
+        )
+    ),
+    "9.5.0" = list(
+        macos = list(
+            x86_64 = c("macOS10.15", "macOS11.2"),
+            # arm64 support added
+            arm64  = c("macOS11.2")
+        ),
+        linux = list(
+            x86_64 = c("Ubuntu18.04", "Ubuntu20.04")
+        )
+    ),
+    "9.4.0" = list(
+        macos = list(
+            x86_64 = c("macOS10.15")
+        ),
+        linux = list(
+            x86_64 = c("Ubuntu18.04", "Ubuntu20.04")
+        )
+    )
 )
 # }}}
 # MACRO_DICT {{{

--- a/R/constants.R
+++ b/R/constants.R
@@ -28,7 +28,6 @@ ALL_IDD_VER <- c(
 
 ALL_EPLUS_RELEASE_COMMIT <- data.table::fread(
     "version , commit
-     23.2.0  , 7636e6b3e9
      23.1.0  , 87ed9199d4
      22.2.0  , c249759bad
      22.1.0  , ed759b17ee

--- a/tests/testthat/helper-eplus.R
+++ b/tests/testthat/helper-eplus.R
@@ -1,4 +1,6 @@
-if (identical(Sys.getenv("NOT_CRAN"), "true") && !is_avail_eplus(LATEST_EPLUS_VER)) {
+if (identical(Sys.getenv("NOT_CRAN"), "true") &&
+    identical(Sys.getenv("CI"), "true") &&
+    !is_avail_eplus(LATEST_EPLUS_VER)) {
     install_eplus(LATEST_EPLUS_VER, local = TRUE)
     # NOTE: From EnergyPlus v23.1, the supported oldest version for transition
     # is v9.0. Have to install at least one version before v23.1 for testing

--- a/tests/testthat/test-geom.R
+++ b/tests/testthat/test-geom.R
@@ -37,6 +37,7 @@ test_that("IdfGeometry", {
     expect_s3_class(geom$tilt(), "data.table")
     expect_s3_class(geom$tilt(class = "Shading:Zone:Detailed"), "data.table")
 
+    skip_on_os("mac")
     expect_s3_class(v1 <- geom$view(render_by = "construction"), "IdfViewer")
     expect_s3_class(v2 <- geom$view(axis = FALSE), "IdfViewer")
     v1$close()

--- a/tests/testthat/test-idf.R
+++ b/tests/testthat/test-idf.R
@@ -1167,6 +1167,7 @@ test_that("$geometry()", {
 # VIEW {{{
 test_that("$view()", {
     skip_on_cran()
+    skip_on_os("mac")
     expect_warning(expect_warning(v <- empty_idf(LATEST_EPLUS_VER)$view()))
     v$close()
 

--- a/tests/testthat/test-impl-viewer.R
+++ b/tests/testthat/test-impl-viewer.R
@@ -1,6 +1,7 @@
 # IdfViewer Implemention {{{
 test_that("IdfViewer Implemention", {
     skip_on_cran()
+    skip_on_os("mac")
 
     # simple model
     idf <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "5ZoneAirCooledWithSpaces.idf"))

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,6 +1,7 @@
 test_that("Install EnergyPlus v9.0 and below", {
     skip_on_cran()
     skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_INSTALL_OLD_") != "")
+    skip_if_not(testthat:::on_ci())
 
     expect_equal(sort(as.character(avail_eplus())), sort(names(.globals$eplus)))
 
@@ -13,6 +14,7 @@ test_that("Install EnergyPlus v9.0 and below", {
 
 test_that("Install EnergyPlus v9.1 and above", {
     skip_on_cran()
+    skip_if_not(testthat:::on_ci())
 
     expect_equal(sort(as.character(avail_eplus())), sort(names(.globals$eplus)))
 

--- a/tests/testthat/test-transition.R
+++ b/tests/testthat/test-transition.R
@@ -1258,10 +1258,10 @@ test_that("Transition v8.7 --> v8.8", {
 
     # XXX:Detailed transition breaks in EnergyPlus v9.6
     # See: https://github.com/NREL/EnergyPlus/issues/9172
-    expect_equal(
-        idfVU$"Floor:Detailed"$Surf2$value(),
-        idfTR$"Floor:Detailed"$Surf2$value(1:21)
-    )
+    # expect_equal(
+    #     idfVU$"Floor:Detailed"$Surf2$value(1:21),
+    #     idfTR$"Floor:Detailed"$Surf2$value(1:21)
+    # )
 
     expect_equal(
         idfVU$"SurfaceProperty:ExposedFoundationPerimeter"[[1]]$value(1:14),

--- a/tests/testthat/test-transition.R
+++ b/tests/testthat/test-transition.R
@@ -2276,6 +2276,8 @@ test_that("Transition v9.5 --> v9.6", {
     skip_on_cran()
     skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
 
+    # do not install EnergyPlus if not on CI
+    skip_if_not(testthat:::on_ci())
     # Only install EnergyPlus v9.6 for testing v9.5 to v9.6 transition, because
     # this version of transition breaks `Wall:Detailed`, `Floor:Detailed`, etc.
     # See: https://github.com/NREL/EnergyPlus/issues/9172

--- a/tests/testthat/test-viewer.R
+++ b/tests/testthat/test-viewer.R
@@ -1,6 +1,7 @@
 # IdfViewer {{{
 test_that("IdfViewer class", {
     skip_on_cran()
+    skip_on_os("mac")
 
     # simple model
     path <- path_eplus_example(LATEST_EPLUS_VER, "4ZoneWithShading_Simple_1.idf")


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #579 
- EnergyPlus v9.4 and above provide different installers for various Ubuntu
  distribution and macOS versions and are handled differently:
  * (macOS) use x86_64 installer if arm64 one is not available
  * (Linux) message if the current distribution is not Ubuntu
  * (all) use the nearest version match for the current OS
- Minor tweak tests:
  * skip rgl-related tests on macOS (xquartz...)
  * do not install old EnergyPlus when developing locally
  * disable one transition test for v9.5-v9.6 as that the VersionUpdater cannot
    handle `Floor:Detailed` correctly