### PR TITLE
feat(install): add support to use portable EnergyPlus installer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.2.9000
+Version: 0.16.2.9001
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",
@@ -43,7 +43,7 @@ Suggests:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace",
     "collate"))
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 SystemRequirements: EnergyPlus (optional)
     (<https://energyplus.net>); udunits2
 Collate:

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,11 @@
 * Now `install_eplus()` can choose the installer most suitable for current OS
   version (#579).
 
+* Now `install_eplus()` gains a new `portable` parameter. If set to `TRUE`, it
+  the `zip` (on Windows) and `tar.gz` (on macOS and Linux) file provided for
+  EnergyPlus v8.8 and above and directly uncompressed it into the target
+  directory (#583).
+
 # eplusr 0.16.2
 
 ## Bug fixes

--- a/man/install_eplus.Rd
+++ b/man/install_eplus.Rd
@@ -6,11 +6,18 @@
 \alias{download_eplus}
 \title{Download and Install EnergyPlus}
 \usage{
-install_eplus(ver = "latest", local = FALSE, dir = NULL, force = FALSE, ...)
+install_eplus(
+  ver = "latest",
+  local = FALSE,
+  dir = NULL,
+  force = FALSE,
+  portable = FALSE,
+  ...
+)
 
 uninstall_eplus(ver)
 
-download_eplus(ver = "latest", dir)
+download_eplus(ver = "latest", dir, portable = FALSE)
 }
 \arguments{
 \item{ver}{The EnergyPlus version number, e.g., \code{"8.7"}. For \code{download_eplus()}
@@ -32,10 +39,10 @@ Default: \code{"."}.
 \item For \code{install_eplus()}, the installer will always be saved into
 \code{\link[=tempdir]{tempdir()}}. But you can use \code{dir} to specify the \strong{parent} directory
 of EnergyPlus installation, i.e. the \strong{parent} directory of
-\code{EnergyPlusVX-Y-0} on Windows and \code{EnergyPlus-X-Y-0} on Linux. macOS is
-not supported. If \code{NULL}, the default installation path will be used.
-See details for more information. Please note that \code{dir} does not work
-on macOS and EnergyPlus will always be installed into the default
+\code{EnergyPlusVX-Y-0} on Windows and \code{EnergyPlus-X-Y-0} on Linux and macOS.
+If \code{NULL}, the default installation path will be used.
+See details for more information. Please note that \code{dir} only works
+when on macOS and EnergyPlus will always be installed into the default
 location. Default: \code{NULL}.
 }}
 
@@ -44,6 +51,9 @@ installed. Setting to \code{TRUE} if you want to install the downloaded
 EnergyPlus anyway. Please note that this may results in multiple
 EnergyPlus installations of the same version at different locations.
 eplusr will only use the first EnergyPlus installation. Default: \code{FALSE}.}
+
+\item{portable}{Whether to download the portable version of EnergyPlus. Only
+works for EnergyPlus v8.8 and above. Default: \code{FALSE}.}
 
 \item{...}{Other arguments to be passed to the installer. Current only one
 additional argument exists and is only for Linux:
@@ -95,14 +105,14 @@ The user level EnergyPlus installation path is:
 \item \verb{C:\Users\<User>\AppData\Local\EnergyPlusVX-Y-0} if environment
 variable \code{"LOCALAPPDATA"} is not set
 }
-\item macOS: \verb{/Users/<User>/Applications/EnergyPlus-X-Y-0}
+\item macOS: \verb{/Users/User/Applications/EnergyPlus-X-Y-0}
 \item Linux: \code{"~/.local/EnergyPlus-X-Y-0"}
 }
 
 On Windows and Linux, you can also specify your custom directory using the
 \code{dir} argument. Remember to change \code{local} to \code{FALSE} in order to ask for
 administrator privileges if you do not have the write access to that
-directory.
+directory. On macOS, \code{dir} only works when \code{portable} is set to \code{TRUE}.
 
 Please note that when \code{local} is set to \code{FALSE}, no symbolic links
 will be created, since this process requires administrative privileges.


### PR DESCRIPTION
Pull request overview
---------------------

- Fixes #583 
- Add the `portable` parameter in `install_eplus()` to support unzipping EnergyPlus to any place you want.
