### PR TITLE
feat(eplus): add support for EnergyPlus v24.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.3.9000
+Version: 0.16.3.9001
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New features
 
+* Add support for EnergyPlus v24.1.0 (#582).
+
 * Add support for EnergyPlus v23.2.0 (#578, #601).
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-* Add support for EnergyPlus v24.1.0 (#582).
+* Add support for EnergyPlus v24.1.0 (#582, #602).
 
 * Add support for EnergyPlus v23.2.0 (#578, #601).
 

--- a/R/constants.R
+++ b/R/constants.R
@@ -5,7 +5,8 @@ ALL_EPLUS_VER <- c(
     paste0("8.", 0:9, ".0"), paste0("8.3.", 1:3),
     paste0("9.0.", 0:1), paste0("9.", 1:6, ".0"),
     paste0("22.", 1:2, ".0"),
-    paste0("23.", 1:2, ".0")
+    paste0("23.", 1:2, ".0"),
+    paste0("24.1.0")
 )
 
 LATEST_EPLUS_VER <- ALL_EPLUS_VER[length(ALL_EPLUS_VER)]
@@ -23,11 +24,13 @@ ALL_IDD_VER <- c(
     paste0("9.0.", 0:1),
     paste0("9.", 1:6, ".0"),
     paste0("22.", 1:2, ".0"),
-    paste0("23.", 1:2, ".0")
+    paste0("23.", 1:2, ".0"),
+    paste0("24.1.0")
 )
 
 ALL_EPLUS_RELEASE_COMMIT <- data.table::fread(
     "version , commit
+     24.1.0  , 9d7789a3ac
      23.2.0  , 7636e6b3e9
      23.1.0  , 87ed9199d4
      22.2.0  , c249759bad
@@ -52,6 +55,16 @@ ALL_EPLUS_RELEASE_COMMIT <- data.table::fread(
 
 # data for OS version specific EnergyPlus installers
 ALL_EPLUS_OSVER <- list(
+    "24.1.0" = list(
+        macos = list(
+            x86_64 = c("macOS11.6", "macOS12.1"),
+            arm64  = c("macOS12.1")
+        ),
+        linux = list(
+            x86_64 = c("Ubuntu20.04", "Ubuntu22.04"),
+            arm64  = c("Ubuntu22.04")
+        )
+    ),
     "23.2.0" = list(
         macos = list(
             x86_64 = c("macOS10.15", "macOS11.6", "macOS12.1"),

--- a/R/transition.R
+++ b/R/transition.R
@@ -4475,6 +4475,298 @@ trans_funs$f2310t2320 <- function(idf) {
     trans_postprocess(new_idf, idf$version(), new_idf$version())
 }
 # }}}
+# f2320t2410 {{{
+trans_funs$f2320t2410 <- function(idf) {
+    assert_true(idf$version()[, 1:2] == "23.2")
+
+    target_cls <- c(
+        "AirLoopHVAC:UnitarySystem",
+        "ComfortViewFactorAngles",
+        "HeatExchanger:AirToAir:SensibleAndLatent",
+        "People",
+        "ZoneHVAC:PackagedTerminalAirConditioner",
+        "ZoneHVAC:PackagedTerminalHeatPump",
+        "ZoneHVAC:WaterToAirHeatPump"
+    )
+
+    new_idf <- trans_preprocess(idf, "24.1", target_cls)
+
+    value_at <- function(dt, field_index) {
+        value <- dt[list(field_index), on = "index", value]
+        if (!length(value)) NA_character_ else value[[1L]]
+    }
+
+    value_lower <- function(value) {
+        stri_trans_tolower(stri_trim_both(as.character(value)))
+    }
+
+    same_string <- function(value, target) {
+        value <- value_lower(value)
+        target <- value_lower(target)
+        !is.na(value) && value == target
+    }
+
+    replace_value <- function(dt, field_index, old, new) {
+        if (!nrow(dt)) return(dt)
+        field_index <- field_index[field_index <= max(dt$index)]
+        if (!length(field_index)) return(dt)
+
+        set(dt, NULL, "value_lower", value_lower(dt$value))
+        dt[J(field_index, value_lower(old)), on = c("index", "value_lower"), value := new]
+        set(dt, NULL, "value_lower", NULL)
+        dt
+    }
+
+    remap_object <- function(obj, old_index, new_index, blank_index = integer(),
+                             blank_value = rep(NA_character_, length(blank_index)),
+                             max_index = NULL) {
+        rows <- list()
+
+        old_index <- as.integer(old_index)
+        new_index <- as.integer(new_index)
+        use <- old_index <= max(obj$index)
+        if (length(old_index) && any(use)) {
+            old_index_use <- old_index[use]
+            new_index_use <- new_index[use]
+            src <- obj[J(old_index_use), on = "index", nomatch = 0L]
+            if (nrow(src)) {
+                src[, old_index := index]
+                src[, index := new_index_use[match(old_index, old_index_use)]]
+                set(src, NULL, "old_index", NULL)
+                rows[[length(rows) + 1L]] <- src
+            }
+        }
+
+        if (length(blank_index)) {
+            blank <- obj[rep(1L, length(blank_index))]
+            set(blank, NULL, "index", as.integer(blank_index))
+            set(blank, NULL, "field", NA_character_)
+            set(blank, NULL, "value", rep(blank_value, length.out = length(blank_index)))
+            rows[[length(rows) + 1L]] <- blank
+        }
+
+        if (!length(rows)) return(obj)
+
+        out <- rbindlist(rows, use.names = TRUE)
+        if (!is.null(max_index)) out <- out[index <= max_index]
+        setorderv(out, c("id", "index"))
+        out <- out[!duplicated(out, by = c("id", "index"), fromLast = TRUE)]
+        out
+    }
+
+    insert_field_dt <- function(dt, insert_at, value, do_insert = function(obj, cur_args) TRUE) {
+        if (!nrow(dt)) return(dt)
+
+        rbindlist(lapply(unique(dt$id), function(obj_id) {
+            obj <- dt[list(obj_id), on = "id"]
+            cur_args <- max(obj$index)
+            if (!do_insert(obj, cur_args)) return(obj)
+
+            old_index <- seq_len(cur_args)
+            new_index <- old_index + as.integer(old_index >= insert_at)
+            remap_object(obj, old_index, new_index,
+                blank_index = insert_at,
+                blank_value = value(obj),
+                max_index = cur_args + 1L
+            )
+        }), use.names = TRUE)
+    }
+
+    delete_field_dt <- function(dt, delete_at) {
+        if (!nrow(dt)) return(dt)
+
+        rbindlist(lapply(unique(dt$id), function(obj_id) {
+            obj <- dt[list(obj_id), on = "id"]
+            cur_args <- max(obj$index)
+            if (cur_args < delete_at) return(obj)
+
+            old_index <- setdiff(seq_len(cur_args), delete_at)
+            new_index <- old_index - as.integer(old_index > delete_at)
+            remap_object(obj, old_index, new_index, max_index = cur_args - 1L)
+        }), use.names = TRUE)
+    }
+
+    next_generated_id <- local({
+        i <- 0L
+        function() {
+            i <<- i + 1L
+            -i
+        }
+    })
+
+    old_field_default <- function(class, field_index) {
+        idd_env <- get_priv_env(idf)$idd_env()
+        class_id <- idd_env$class[J(class), on = "class_name", class_id]
+        default <- idd_env$field[J(class_id, as.integer(field_index)), on = c("class_id", "field_index")]
+
+        if (nrow(default) && !is.na(default$default_chr[[1L]])) {
+            default$default_chr[[1L]]
+        } else if (nrow(default) && !is.na(default$default_num[[1L]])) {
+            as.character(default$default_num[[1L]])
+        } else if (same_string(class, "HeatExchanger:AirToAir:SensibleAndLatent") && field_index %in% 4:11) {
+            "0.0"
+        } else {
+            NA_character_
+        }
+    }
+
+    field_or_default <- function(obj, class, field_index) {
+        value <- value_at(obj, field_index)
+        if (is.na(value) || !nzchar(stri_trim_both(as.character(value)))) {
+            old_field_default(class, field_index)
+        } else {
+            as.character(value)
+        }
+    }
+
+    no_load_control <- function(obj, heating_index = NULL, cooling_index = NULL) {
+        is_variable_speed <- FALSE
+        if (!is.null(heating_index)) {
+            is_variable_speed <- is_variable_speed ||
+                same_string(value_at(obj, heating_index), "Coil:Heating:DX:VariableSpeed")
+        }
+        if (!is.null(cooling_index)) {
+            is_variable_speed <- is_variable_speed ||
+                same_string(value_at(obj, cooling_index), "Coil:Cooling:DX:VariableSpeed")
+        }
+
+        if (is_variable_speed) "Yes" else "No"
+    }
+
+    hx_air_to_air <- function(dt) {
+        if (!nrow(dt)) return(dt)
+
+        class <- "HeatExchanger:AirToAir:SensibleAndLatent"
+        out <- list()
+        tables <- list()
+        table_lookup_list <- "effectiveness_IndependentVariableList"
+        table_variable <- "HxAirFlowRatio"
+
+        for (obj_id in unique(dt$id)) {
+            obj <- dt[list(obj_id), on = "id"]
+            cur_args <- max(obj$index)
+
+            effect_75 <- vapply(c(6L, 7L, 10L, 11L), function(field_index) {
+                field_or_default(obj, class, field_index)
+            }, character(1L))
+            effect_100 <- vapply(c(4L, 5L, 8L, 9L), function(field_index) {
+                field_or_default(obj, class, field_index)
+            }, character(1L))
+            effect_diff <- suppressWarnings(as.numeric(effect_75) != as.numeric(effect_100))
+            effect_diff[is.na(effect_diff)] <- FALSE
+
+            hx_name <- as.character(value_at(obj, 1L))
+            table_names <- rep("", 4L)
+            table_names[effect_diff] <- paste0(hx_name, "_", which(effect_diff))
+
+            old_cooling <- if (cur_args >= 8L) seq.int(8L, min(9L, cur_args)) else integer()
+            old_tail <- if (cur_args >= 12L) seq.int(12L, cur_args) else integer()
+            old_index <- c(seq_len(min(5L, cur_args)), old_cooling, old_tail)
+            new_index <- c(
+                seq_len(min(5L, cur_args)),
+                if (length(old_cooling)) seq.int(6L, 6L + length(old_cooling) - 1L) else integer(),
+                if (length(old_tail)) seq.int(8L, 8L + length(old_tail) - 1L) else integer()
+            )
+
+            table_index <- (20:23)[20:23 <= cur_args]
+            out[[length(out) + 1L]] <- remap_object(obj, old_index, new_index,
+                blank_index = table_index,
+                blank_value = table_names[table_index - 19L],
+                max_index = cur_args
+            )
+
+            for (i in which(effect_diff)) {
+                tables[[length(tables) + 1L]] <- data.table(
+                    id = next_generated_id(),
+                    name = table_names[[i]],
+                    class = "Table:Lookup",
+                    index = 1:12,
+                    field = NA_character_,
+                    value = c(
+                        table_names[[i]],
+                        table_lookup_list,
+                        "DivisorOnly",
+                        effect_100[[i]],
+                        "0.0",
+                        "10.0",
+                        "Dimensionless",
+                        "",
+                        "",
+                        "",
+                        effect_75[[i]],
+                        effect_100[[i]]
+                    )
+                )
+            }
+        }
+
+        if (length(tables)) {
+            tables[[length(tables) + 1L]] <- data.table(
+                id = next_generated_id(),
+                name = table_lookup_list,
+                class = "Table:IndependentVariableList",
+                index = 1:2,
+                field = NA_character_,
+                value = c(table_lookup_list, table_variable)
+            )
+            tables[[length(tables) + 1L]] <- data.table(
+                id = next_generated_id(),
+                name = table_variable,
+                class = "Table:IndependentVariable",
+                index = 1:12,
+                field = NA_character_,
+                value = c(
+                    table_variable,
+                    "Linear",
+                    "Linear",
+                    "0.0",
+                    "10.0",
+                    "",
+                    "Dimensionless",
+                    "",
+                    "",
+                    "",
+                    "0.75",
+                    "1.0"
+                )
+            )
+        }
+
+        rbindlist(c(out, tables), use.names = TRUE)
+    }
+
+    dt1 <- insert_field_dt(
+        trans_action(idf, "AirLoopHVAC:UnitarySystem"),
+        39L,
+        function(obj) no_load_control(obj, heating_index = 12L, cooling_index = 15L),
+        function(obj, cur_args) cur_args > 38L
+    )
+    dt2 <- delete_field_dt(trans_action(idf, "ComfortViewFactorAngles"), 2L)
+    dt3 <- hx_air_to_air(trans_action(idf, "HeatExchanger:AirToAir:SensibleAndLatent"))
+    dt4 <- replace_value(trans_action(idf, "People"), 13L, "ZoneAveraged", "EnclosureAveraged")
+    dt5 <- insert_field_dt(
+        trans_action(idf, "ZoneHVAC:PackagedTerminalAirConditioner"),
+        10L,
+        function(obj) no_load_control(obj, cooling_index = 17L)
+    )
+    dt6 <- insert_field_dt(
+        trans_action(idf, "ZoneHVAC:PackagedTerminalHeatPump"),
+        10L,
+        function(obj) no_load_control(obj, heating_index = 15L, cooling_index = 18L)
+    )
+    dt7 <- insert_field_dt(
+        trans_action(idf, "ZoneHVAC:WaterToAirHeatPump"),
+        10L,
+        function(obj) "No"
+    )
+
+    dt <- rbindlist(mget(paste0("dt", 1:7)), use.names = TRUE)
+
+    trans_process(new_idf, idf, dt)
+
+    trans_postprocess(new_idf, idf$version(), new_idf$version())
+}
+# }}}
 
 # trans_preprocess {{{
 # 1. delete objects in deprecated class

--- a/tests/testthat/test-iddobj.R
+++ b/tests/testthat/test-iddobj.R
@@ -270,7 +270,7 @@ test_that("IddObject class", {
 
     skip_on_cran()
     # Outputs {{{
-    expect_equal(nrow(res <- use_idd(LATEST_EPLUS_VER, "auto")$Lights$outputs()), 49L)
+    expect_equal(nrow(res <- use_idd(LATEST_EPLUS_VER, "auto")$Lights$outputs()), 0L)
     expect_equal(names(res), c("index", "class", "reported_time_step",
         "report_type", "variable", "units"))
     expect_equal(

--- a/tests/testthat/test-impl-idd.R
+++ b/tests/testthat/test-impl-idd.R
@@ -309,7 +309,7 @@ test_that("Idd implementation", {
     expect_error(get_idd_relation(idd_env, class_id = fld$class_id, field_id = fld$field_id), class = "eplusr_error_idd_relation")
 
     fld <- get_idd_field(idd_env, "Construction")
-    expect_equal(nrow(get_idd_relation(idd_env, field_id = fld$field_id, direction = "ref_by", keep_all = TRUE, depth = 2L)), 32880L)
+    expect_equal(nrow(get_idd_relation(idd_env, field_id = fld$field_id, direction = "ref_by", keep_all = TRUE, depth = 2L)), 32901L)
 
     fld <- get_idd_field(idd_env, "Construction", 2L)
     expect_equal(nrow(get_idd_relation(idd_env, field_id = fld$field_id, direction = "ref_to", depth = 0L)), 14L)

--- a/tests/testthat/test-transition.R
+++ b/tests/testthat/test-transition.R
@@ -2808,5 +2808,98 @@ test_that("Transition v23.1 --> v23.2", {
     )
 })
 # }}}
+# v23.2 --> v24.1 {{{
+test_that("Transition v23.2 --> v24.1", {
+    skip_on_cran()
+    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+
+    from <- "23.2"
+    to <- "24.1"
+
+    expect_s3_class(
+        class = "Idf",
+        idfOri <- temp_idf(from,
+            `AirLoopHVAC:UnitarySystem` = list(
+                "UnitaryDX",
+                ..12 = "Coil:Heating:DX:VariableSpeed",
+                ..15 = "Coil:Cooling:DX:SingleSpeed",
+                ..39 = 12.3
+            ),
+            ComfortViewFactorAngles = list("ViewFactors", "Zone 1", "Surface 1", 0.6, "Surface 2", 0.4),
+            `HeatExchanger:AirToAir:SensibleAndLatent` = list(
+                "HX", "", 1.0, 0.8, 0.7, 0.6, 0.7, 0.9, 0.65, 0.9, 0.5,
+                "SupIn", "SupOut", "ExhIn", "ExhOut", 50, "Yes", "Rotary", "None", 1.7, 0.083, 0.012, "Yes"
+            ),
+            `HeatExchanger:AirToAir:SensibleAndLatent` = list(
+                "HXDefault", "", 1.0, "", "", 0.1, "", "", "", "", "",
+                "SupIn2", "SupOut2", "ExhIn2", "ExhOut2", 25, "No", "Plate", "None", 1.7, 0.083, 0.012, "No"
+            ),
+            People = list(
+                "People", "Zone 1", "PeopleSch", "People", 1, "", "", 0.3,
+                "", "ActivitySch", "", "", "ZoneAveraged"
+            ),
+            `ZoneHVAC:PackagedTerminalAirConditioner` = list(
+                "PTAC", "", "In", "Out", "", "", 1.0, 1.0, 0.1, 0.2, 0.3, 0.4,
+                "Fan:OnOff", "Fan", "Coil:Heating:Electric", "Heat",
+                "Coil:Cooling:DX:VariableSpeed", "Cool"
+            ),
+            `ZoneHVAC:PackagedTerminalHeatPump` = list(
+                "PTHP", "", "In", "Out", "", "", 1.0, 1.0, 0.1, 0.2, 0.3, 0.4,
+                "Fan:OnOff", "Fan", "Coil:Heating:DX:SingleSpeed", "Heat", 0.001,
+                "Coil:Cooling:DX:VariableSpeed", "Cool"
+            ),
+            `ZoneHVAC:WaterToAirHeatPump` = list("WAHP", "", "In", "Out", "", "", 1.0, 1.0, 0.1, 0.2),
+            .all = FALSE
+        )
+    )
+
+    expect_s3_class(idfTR <- transition(idfOri, to), "Idf")
+    expect_equal(idfTR$version(), numeric_version("24.1.0"))
+
+    expect_equal(idfTR$`AirLoopHVAC:UnitarySystem`$UnitaryDX$value(39)[[1L]], "Yes")
+    expect_equal(idfTR$`AirLoopHVAC:UnitarySystem`$UnitaryDX$value(40)[[1L]], 12.3)
+
+    expect_equal(idfTR$ComfortViewFactorAngles$ViewFactors$value(2)[[1L]], "Surface 1")
+    expect_equal(idfTR$ComfortViewFactorAngles$ViewFactors$value(3)[[1L]], 0.6)
+
+    expect_equal(
+        unname(unlist(idfTR$`HeatExchanger:AirToAir:SensibleAndLatent`$HX$value(4:7))),
+        c(0.8, 0.7, 0.9, 0.65)
+    )
+    expect_equal(
+        unname(unlist(idfTR$`HeatExchanger:AirToAir:SensibleAndLatent`$HX$value(20:23))),
+        c("HX_1", NA_character_, NA_character_, "HX_4")
+    )
+    expect_equal(
+        unname(unlist(idfTR$`HeatExchanger:AirToAir:SensibleAndLatent`$HXDefault$value(20:23))),
+        c("HXDefault_1", NA_character_, NA_character_, NA_character_)
+    )
+    expect_setequal(
+        idfTR$object_name("Table:Lookup", simplify = TRUE),
+        c("HX_1", "HX_4", "HXDefault_1")
+    )
+    expect_equal(
+        unname(unlist(idfTR$`Table:Lookup`$HX_1$value(c(2:4, 11:12)))),
+        c("effectiveness_IndependentVariableList", "DivisorOnly", 0.8, 0.6, 0.8)
+    )
+    expect_equal(
+        unname(unlist(idfTR$`Table:Lookup`$HXDefault_1$value(c(4, 11:12)))),
+        c(0.0, 0.1, 0.0)
+    )
+    expect_equal(
+        idfTR$object_name("Table:IndependentVariableList", simplify = TRUE),
+        "effectiveness_IndependentVariableList"
+    )
+    expect_equal(idfTR$object_name("Table:IndependentVariable", simplify = TRUE), "HxAirFlowRatio")
+
+    expect_equal(idfTR$People$People$value(13)[[1L]], "EnclosureAveraged")
+    expect_equal(idfTR$`ZoneHVAC:PackagedTerminalAirConditioner`$PTAC$value(10)[[1L]], "Yes")
+    expect_equal(idfTR$`ZoneHVAC:PackagedTerminalAirConditioner`$PTAC$value(11)[[1L]], 0.2)
+    expect_equal(idfTR$`ZoneHVAC:PackagedTerminalHeatPump`$PTHP$value(10)[[1L]], "Yes")
+    expect_equal(idfTR$`ZoneHVAC:PackagedTerminalHeatPump`$PTHP$value(11)[[1L]], 0.2)
+    expect_equal(idfTR$`ZoneHVAC:WaterToAirHeatPump`$WAHP$value(10)[[1L]], "No")
+    expect_equal(idfTR$`ZoneHVAC:WaterToAirHeatPump`$WAHP$value(11)[[1L]], 0.2)
+})
+# }}}
 
 # vim: set fdm=marker:


### PR DESCRIPTION
Pull request overview
---------------------

- Add support for EnergyPlus v24.1.0 (#582).
- Implement the EnergyPlus v23.2 to v24.1 transition rules, including no-load flow-control field migrations and heat exchanger lookup table generation.
- Update EnergyPlus v24.1 IDD/install metadata and latest-IDD expectations.