### PR TITLE
fix(eplus): lazily locate EnergyPlus installations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace",
     "collate"))
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.3
 SystemRequirements: EnergyPlus (optional)
     (<https://energyplus.net>); udunits2
 Collate:

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 * Fix EnergyPlus IDD downloads from v23.2.0 and portable macOS tarball
   installation (#601).
 
+* Delay EnergyPlus installation discovery until needed and allow extra search
+  roots via `locate_eplus(dirs = ...)` and `options(eplusr.eplus_dirs = ...)`
+  (#609).
+
 # eplusr 0.16.3
 
 ## New features

--- a/R/idd.R
+++ b/R/idd.R
@@ -19,8 +19,8 @@ NULL
 #' of EnergyPlus, valid IDF files are defined by the "Energy+.idd" file shipped
 #' with the release.
 #'
-#' eplusr tries to detect all installed EnergyPlus in default installation
-#' locations when loading, i.e. `C:\\EnergyPlusVX-X-0` on Windows,
+#' eplusr tries to detect installed EnergyPlus lazily when that information is
+#' needed, using default installation locations, i.e. `C:\\EnergyPlusVX-X-0` on Windows,
 #' `/usr/local/EnergyPlus-X-Y-0` on Linux, and
 #' `/Applications/EnergyPlus-X-Y-0` on macOS and stores all found locations
 #' internally. This data is used to locate the distributed "Energy+.idd" file of
@@ -1033,9 +1033,9 @@ read_idd <- function(path, encoding = "unknown") {
 #' `is_avail_idd()` returns `TRUE` if input version of IDD file has been parsed
 #' and cached.
 #'
-#' eplusr tries to detect all installed EnergyPlus in default installation
-#' locations when loading. If argument `idd` is a version, eplusr will try the
-#' follow ways sequentially to find corresponding IDD:
+#' eplusr tries to detect installed EnergyPlus lazily when that information is
+#' needed. If argument `idd` is a version, eplusr will try the follow ways
+#' sequentially to find corresponding IDD:
 #'
 #' * The cached `Idd` object of that version
 #' * `"Energy+.idd"` file distributed with EnergyPlus of that version (see

--- a/R/install.R
+++ b/R/install.R
@@ -874,6 +874,10 @@ uninstall_eplus_portable <- function(ver, dir) {
 #' @param eplus An acceptable EnergyPlus version or an EnergyPlus installation
 #'        path.
 #' @param ver An acceptable EnergyPlus version.
+#' @param dirs A character vector of extra locations to search for EnergyPlus
+#'        installations. Each entry can be either an EnergyPlus installation
+#'        directory, or a parent directory that contains installations using
+#'        standard EnergyPlus directory names. Default: `NULL`.
 #'
 #' @details
 #'
@@ -882,14 +886,19 @@ uninstall_eplus_portable <- function(ver, dir) {
 #' parsing IDF files and call corresponding EnergyPlus to run models.
 #'
 #' `eplus_config()` returns the a list of configure data of specified version of
-#' EnergyPlus. If no data found, an empty list will be returned.
+#' EnergyPlus. If no data found, eplusr will try to locate that version in the
+#' default installation locations and extra locations set via the base R option
+#' `eplusr.eplus_dirs`. If still no data is found, an empty list will be
+#' returned.
 #'
-#' `avail_eplus()` returns all versions of available EnergyPlus.
+#' `avail_eplus()` returns all versions of available EnergyPlus. The first call
+#' will locate EnergyPlus installations in default installation locations and
+#' extra locations set via `options(eplusr.eplus_dirs = ...)`.
 #'
 #' `locate_eplus()` re-searches all EnergyPlus installations at the **default**
-#' locations and returns versions of EnergyPlus it finds. Please note that all
-#' configure data of EnergyPlus installed at custom locations will be
-#' **removed**.
+#' locations and any extra `dirs`, and returns versions of EnergyPlus it finds.
+#' Extra search locations can also be configured for the session using
+#' `options(eplusr.eplus_dirs = ...)`.
 #'
 #' `is_avail_eplus()` checks if the specified version of EnergyPlus is
 #' available or not.
@@ -930,44 +939,11 @@ use_eplus <- function(eplus) {
     assert_vector(eplus, len = 1L)
 
     ver <- convert_to_eplus_ver(eplus, strict = TRUE, max = FALSE)[[1L]]
-    # if eplus is a version, try to locate it in the default path
+    # if eplus is a version, try to locate it
     if (!anyNA(ver)) {
         ori_ver <- ver[, 1:2]
-        # try user-level first
-        eplus_dir <- eplus_default_path(ver, local = TRUE)
-        dir_cache <- eplus_dir
-        if (any(chk <- is_eplus_path(eplus_dir))) {
-            if (sum(chk) > 1L) {
-                verbose_info("Multiple versions found for EnergyPlus v", ori_ver, " in user directory: ",
-                    collapse(paste0("v", ver)), ". ",
-                    "The last patched version v", max(ver), " will be used. ",
-                    "Please explicitly give the full version if you want to use the other versions."
-                )
-                # which.max does not work with numeric_version objects
-                eplus_dir <- eplus_dir[max(order(ver))]
-                ver <- max(ver)
-            } else {
-                eplus_dir <- eplus_dir[chk]
-                ver <- ver[chk]
-                verbose_info("Found EnergyPlus v", ori_ver, " in user directory: ", eplus_dir)
-            }
-        # try system-level default location
-        } else if (any({eplus_dir <- eplus_default_path(ver); chk <- is_eplus_path(eplus_dir)})) {
-            if (sum(chk) > 1L) {
-                verbose_info("Multiple versions found for EnergyPlus v", ori_ver, " in system directory: ",
-                    collapse(paste0("v", ver)), ". ",
-                    "The last patched version v", max(ver), " will be used. ",
-                    "Please explicitly give the full version if you want to use the other versions."
-                )
-                # which.max does not work with numeric_version objects
-                eplus_dir <- eplus_dir[max(order(ver))]
-                ver <- max(ver)
-            } else {
-                eplus_dir <- eplus_dir[chk]
-                ver <- ver[chk]
-                verbose_info("Found EnergyPlus v", ori_ver, " in system directory: ", eplus_dir)
-            }
-        } else {
+        found <- find_eplus_install(ver)
+        if (is.null(found)) {
             msg <- NULL
             if (length(ver) > 1L) {
                 msg <- paste0("Multiple possible versions found for EnergyPlus v", ori_ver, ": ",
@@ -975,9 +951,13 @@ use_eplus <- function(eplus) {
             }
 
             fail <- paste0("Cannot locate EnergyPlus v", ori_ver, " at default ",
-                "installation path ", surround(c(dir_cache, eplus_dir)), collapse = "\n")
+                "installation path or extra paths from option 'eplusr.eplus_dirs': ",
+                surround(eplus_install_candidates(ver)), collapse = "\n")
             abort(paste0(msg, fail, "\nPlease specify explicitly the path of EnergyPlus installation."), "locate_eplus")
         }
+
+        ver <- found$version
+        eplus_dir <- found$dir
     } else if (is_eplus_path(eplus)) {
         ver <- get_ver_from_eplus_path(eplus)
         eplus_dir <- eplus
@@ -1022,6 +1002,10 @@ use_eplus <- function(eplus) {
 eplus_config <- function(ver) {
     assert_vector(ver, len = 1L)
     ver_m <- convert_to_eplus_ver(ver, all_ver = names(.globals$eplus))
+    if (is.na(ver_m)) {
+        suppressMessages(tryCatch(use_eplus(ver), error = function(e) NULL))
+        ver_m <- convert_to_eplus_ver(ver, all_ver = names(.globals$eplus))
+    }
 
     if (is.na(ver_m)) {
         warn(paste0("Failed to find configuration data of EnergyPlus v", standardize_ver(ver)), "miss_eplus_config")
@@ -1036,6 +1020,13 @@ eplus_config <- function(ver) {
 #' @export
 # avail_eplus {{{
 avail_eplus <- function() {
+    if (!isTRUE(.globals$eplus_scanned)) locate_eplus()
+    eplus_versions()
+}
+# }}}
+
+# eplus_versions {{{
+eplus_versions <- function() {
     res <- names(.globals$eplus)
     if (!length(res)) return(NULL)
     sort(numeric_version(res))
@@ -1053,15 +1044,92 @@ is_avail_eplus <- function(ver) {
 #' @rdname use_eplus
 #' @export
 # locate_eplus {{{
-locate_eplus <- function() {
+locate_eplus <- function(dirs = NULL) {
     find_eplus <- function(ver) {
+        if (!is.na(convert_to_eplus_ver(ver, all_ver = names(.globals$eplus)))) {
+            return(NULL)
+        }
+
         suppressMessages(tryCatch(use_eplus(ver),
             error = function(e) NULL))
     }
 
+    dirs <- eplus_extra_dirs(dirs)
     lapply(rev(ALL_EPLUS_RELEASE_COMMIT$version), find_eplus)
+    if (length(dirs)) {
+        lapply(rev(ALL_EPLUS_RELEASE_COMMIT$version), function(ver) {
+            found <- find_eplus_install(ver, dirs = dirs, default = FALSE)
+            if (!is.null(found) &&
+                is.na(convert_to_eplus_ver(found$version, all_ver = names(.globals$eplus)))) {
+                suppressMessages(use_eplus(found$dir))
+            }
+        })
+    }
 
-    avail_eplus()
+    .globals$eplus_scanned <- TRUE
+    eplus_versions()
+}
+# }}}
+# find_eplus_install {{{
+find_eplus_install <- function(ver, dirs = NULL, default = TRUE) {
+    ver <- convert_to_eplus_ver(ver)
+    paths <- eplus_install_candidates(ver, dirs = dirs, default = default)
+    paths <- paths[is_eplus_path(paths)]
+    if (!length(paths)) return(NULL)
+
+    vers <- vcapply(paths, function(path) {
+        tryCatch(as.character(get_ver_from_eplus_path(path)), error = function(e) NA_character_)
+    })
+    keep <- !is.na(vers) & vers %chin% as.character(ver)
+    if (!any(keep)) return(NULL)
+
+    paths <- paths[keep]
+    vers <- numeric_version(vers[keep])
+    i <- max(order(vers))
+
+    list(version = vers[i], dir = paths[i])
+}
+# }}}
+# eplus_install_candidates {{{
+eplus_install_candidates <- function(ver, dirs = NULL, default = TRUE) {
+    paths <- character()
+    if (default) {
+        paths <- c(eplus_default_path(ver, local = TRUE), eplus_default_path(ver))
+    }
+
+    extra <- eplus_extra_dirs(dirs)
+    if (length(extra)) {
+        paths <- c(paths, eplus_extra_candidates(ver, extra))
+    }
+
+    unique(paths[!is.na(paths) & nzchar(paths)])
+}
+# }}}
+# eplus_extra_dirs {{{
+eplus_extra_dirs <- function(dirs = NULL) {
+    dirs <- c(getOption("eplusr.eplus_dirs"), dirs)
+    dirs <- path.expand(as.character(dirs))
+    unique(dirs[!is.na(dirs) & nzchar(dirs)])
+}
+# }}}
+# eplus_extra_candidates {{{
+eplus_extra_candidates <- function(ver, dirs) {
+    if (!length(dirs)) return(character())
+
+    exact <- dirs[is_eplus_path(dirs)]
+    parent <- dirs[dir.exists(dirs) & !is_eplus_path(dirs)]
+    child <- unlist(lapply(parent, function(dir) {
+        file.path(dir, eplus_dir_names(ver))
+    }), use.names = FALSE)
+
+    unique(c(exact, child))
+}
+# }}}
+# eplus_dir_names {{{
+eplus_dir_names <- function(ver) {
+    ver <- convert_to_eplus_ver(ver)
+    ver_dash <- paste0(ver[, 1L], "-", ver[, 2L], "-", ver[, 3L])
+    c(paste0("EnergyPlus-", ver_dash), paste0("EnergyPlusV", ver_dash))
 }
 # }}}
 # eplus_default_path {{{

--- a/R/options.R
+++ b/R/options.R
@@ -7,6 +7,7 @@ NULL
 
 # for storing internal data
 .globals$eplus <- list()
+.globals$eplus_scanned <- FALSE
 .globals$idd <- list()
 .globals$epw <- list()
 .globals$color <- has_color()

--- a/R/run.R
+++ b/R/run.R
@@ -358,6 +358,11 @@ eplus_exe <- function(eplus) {
         return(normalizePath(eplus, mustWork = TRUE))
     }
 
+    if (is_eplus_path(eplus)) {
+        config <- suppressMessages(use_eplus(eplus))
+        return(normalizePath(file.path(config$dir, config$exe), mustWork = TRUE))
+    }
+
     if (!is_avail_eplus(eplus)) use_eplus(eplus)
     config <- tryCatch(eplus_config(eplus),
         eplusr_warning_miss_eplus_config = function(w) abort(conditionMessage(w), "miss_eplus_config")
@@ -2388,6 +2393,8 @@ run_idf <- function(model, weather, output_dir, design_day = FALSE,
     assert_flag(wait)
 
     if (is.null(weather)) design_day <- TRUE
+
+    eplus <- get_eplus_loc_from_input(model, eplus)
 
     start_time <- current()
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,11 +5,5 @@
     if (any(grepl("_R_CHECK", names(Sys.getenv()), fixed = TRUE))) {
         data.table::setDTthreads(2)
     }
-    locate_eplus()
-    reg_custom_units()
-}
-
-.onAttach <- function(libname, pkgname) {
-    locate_eplus()
     reg_custom_units()
 }

--- a/man/Idd.Rd
+++ b/man/Idd.Rd
@@ -20,8 +20,8 @@ the schema format is XSD; for IDF, the schema format is IDD. For each release
 of EnergyPlus, valid IDF files are defined by the "Energy+.idd" file shipped
 with the release.
 
-eplusr tries to detect all installed EnergyPlus in default installation
-locations when loading, i.e. \verb{C:\\\\EnergyPlusVX-X-0} on Windows,
+eplusr tries to detect installed EnergyPlus lazily when that information is
+needed, using default installation locations, i.e. \verb{C:\\\\EnergyPlusVX-X-0} on Windows,
 \verb{/usr/local/EnergyPlus-X-Y-0} on Linux, and
 \verb{/Applications/EnergyPlus-X-Y-0} on macOS and stores all found locations
 internally. This data is used to locate the distributed "Energy+.idd" file of

--- a/man/energyplus.Rd
+++ b/man/energyplus.Rd
@@ -208,9 +208,9 @@ Functions except for \code{energyplus()} return a list of two elements:
 \itemize{
 \item \code{ver}: EnergyPlus \link[=numeric_version]{version} used
 \item \code{energyplus}: EnergyPlus installation directory
-\item \code{start_time}: a \code{\link[=POSIXct]{POSIXct()}} giving the local time when the simulation
+\item \code{start_time}: a \code{\link[lubridate:posix_utils]{lubridate::POSIXct()}} giving the local time when the simulation
 starts
-\item \code{end_time}: a \code{\link[=POSIXct]{POSIXct()}} giving the local time when the simulation ends
+\item \code{end_time}: a \code{\link[lubridate:posix_utils]{lubridate::POSIXct()}} giving the local time when the simulation ends
 \item \code{output_dir}: full path of output directory of simulation outputs
 \item \code{file}: a named list of relative paths of output files under \code{output_dir}
 \item \code{run}: a \link[data.table:data.table]{data.table} of each outputs from the

--- a/man/use_eplus.Rd
+++ b/man/use_eplus.Rd
@@ -16,13 +16,18 @@ avail_eplus()
 
 is_avail_eplus(ver)
 
-locate_eplus()
+locate_eplus(dirs = NULL)
 }
 \arguments{
 \item{eplus}{An acceptable EnergyPlus version or an EnergyPlus installation
 path.}
 
 \item{ver}{An acceptable EnergyPlus version.}
+
+\item{dirs}{A character vector of extra locations to search for EnergyPlus
+installations. Each entry can be either an EnergyPlus installation
+directory, or a parent directory that contains installations using
+standard EnergyPlus directory names. Default: \code{NULL}.}
 }
 \value{
 \itemize{
@@ -43,14 +48,19 @@ eplusr. That cache will be used to get corresponding \link{Idd} object when
 parsing IDF files and call corresponding EnergyPlus to run models.
 
 \code{eplus_config()} returns the a list of configure data of specified version of
-EnergyPlus. If no data found, an empty list will be returned.
+EnergyPlus. If no data found, eplusr will try to locate that version in the
+default installation locations and extra locations set via the base R option
+\code{eplusr.eplus_dirs}. If still no data is found, an empty list will be
+returned.
 
-\code{avail_eplus()} returns all versions of available EnergyPlus.
+\code{avail_eplus()} returns all versions of available EnergyPlus. The first call
+will locate EnergyPlus installations in default installation locations and
+extra locations set via \code{options(eplusr.eplus_dirs = ...)}.
 
 \code{locate_eplus()} re-searches all EnergyPlus installations at the \strong{default}
-locations and returns versions of EnergyPlus it finds. Please note that all
-configure data of EnergyPlus installed at custom locations will be
-\strong{removed}.
+locations and any extra \code{dirs}, and returns versions of EnergyPlus it finds.
+Extra search locations can also be configured for the session using
+\code{options(eplusr.eplus_dirs = ...)}.
 
 \code{is_avail_eplus()} checks if the specified version of EnergyPlus is
 available or not.

--- a/man/use_idd.Rd
+++ b/man/use_idd.Rd
@@ -69,9 +69,9 @@ useful in case where you only want to edit an EnergyPlus Input Data File
 \code{is_avail_idd()} returns \code{TRUE} if input version of IDD file has been parsed
 and cached.
 
-eplusr tries to detect all installed EnergyPlus in default installation
-locations when loading. If argument \code{idd} is a version, eplusr will try the
-follow ways sequentially to find corresponding IDD:
+eplusr tries to detect installed EnergyPlus lazily when that information is
+needed. If argument \code{idd} is a version, eplusr will try the follow ways
+sequentially to find corresponding IDD:
 \itemize{
 \item The cached \code{Idd} object of that version
 \item \code{"Energy+.idd"} file distributed with EnergyPlus of that version (see

--- a/tests/testthat/test-idd.R
+++ b/tests/testthat/test-idd.R
@@ -40,10 +40,23 @@ test_that("can read IDD", {
     # EnergyPlus is EnergyPlus v9.0
     expect_s3_class(use_idd("9.0"), "Idd")
 
-    # can stop if that EnergyPlus is not available and IDD if not found in any
+    # can lazily discover EnergyPlus and use corresponding IDD
+    rm_global_cache("eplus", avail_eplus())
+    rm_global_cache("idd")
+    expect_s3_class(use_idd(LATEST_EPLUS_VER), "Idd")
+    expect_true(is_avail_eplus(LATEST_EPLUS_VER))
+
+    # can stop if that EnergyPlus is not available and IDD is not found in any
     # existing VersionUpdater folder
     rm_global_cache("eplus", avail_eplus())
-    expect_error(use_idd(LATEST_EPLUS_VER), class = "eplusr_error_locate_idd")
+    rm_global_cache("idd")
+    local({
+        local_mocked_bindings(
+            is_avail_eplus = function(ver) FALSE,
+            find_idd_from_updater = function(ver) NULL
+        )
+        expect_error(use_idd(LATEST_EPLUS_VER), class = "eplusr_error_locate_idd")
+    })
 
     # can direct read if corresponding EnergyPlus is found
     use_eplus(LATEST_EPLUS_VER)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,3 +1,97 @@
+fake_eplus_install <- function(parent, ver = LATEST_EPLUS_VER, name = NULL) {
+    ver <- standardize_ver(ver)
+    if (is.null(name)) name <- paste0("EnergyPlus-", gsub(".", "-", ver, fixed = TRUE))
+
+    dir <- file.path(parent, name)
+    dir.create(dir, recursive = TRUE)
+    writeLines(paste0("!IDD_Version ", ver), file.path(dir, "Energy+.idd"))
+    file.create(file.path(dir, paste0("energyplus", if (is_windows()) ".exe" else "")))
+    dir
+}
+
+with_clean_eplus_cache <- function(code) {
+    old_eplus <- .globals$eplus
+    old_scanned <- .globals$eplus_scanned
+    old_dirs <- getOption("eplusr.eplus_dirs")
+    on.exit({
+        .globals$eplus <- old_eplus
+        .globals$eplus_scanned <- old_scanned
+        options(eplusr.eplus_dirs = old_dirs)
+    }, add = TRUE)
+
+    .globals$eplus <- list()
+    .globals$eplus_scanned <- FALSE
+    options(eplusr.eplus_dirs = NULL)
+
+    force(code)
+}
+
+test_that(".onLoad() does not locate EnergyPlus", {
+    with_clean_eplus_cache({
+        get(".onLoad", envir = asNamespace("eplusr"))("", "eplusr")
+
+        expect_identical(.globals$eplus, list())
+        expect_false(.globals$eplus_scanned)
+    })
+})
+
+test_that("EnergyPlus can be lazily located from eplusr.eplus_dirs", {
+    with_clean_eplus_cache({
+        root <- tempfile()
+        fake <- fake_eplus_install(root)
+        options(eplusr.eplus_dirs = root)
+
+        cfg <- eplus_config(LATEST_EPLUS_VER)
+
+        expect_identical(cfg$dir, normalizePath(fake))
+        expect_false(.globals$eplus_scanned)
+    })
+})
+
+test_that("avail_eplus() performs full lazy discovery once", {
+    with_clean_eplus_cache({
+        root <- tempfile()
+        fake_eplus_install(root)
+        options(eplusr.eplus_dirs = root)
+
+        expect_true(numeric_version(LATEST_EPLUS_VER) %in% avail_eplus())
+        expect_true(.globals$eplus_scanned)
+    })
+})
+
+test_that("locate_eplus() accepts extra parent and exact installation dirs", {
+    with_clean_eplus_cache({
+        root <- tempfile()
+        fake <- fake_eplus_install(root)
+
+        expect_true(numeric_version(LATEST_EPLUS_VER) %in% locate_eplus(dirs = root))
+
+        .globals$eplus <- list()
+        .globals$eplus_scanned <- FALSE
+
+        expect_true(numeric_version(LATEST_EPLUS_VER) %in% locate_eplus(dirs = fake))
+    })
+})
+
+test_that("locate_eplus() preserves existing custom EnergyPlus paths", {
+    with_clean_eplus_cache({
+        custom <- fake_eplus_install(tempfile(), name = "custom-eplus")
+        root <- tempfile()
+        fake_eplus_install(root)
+
+        suppressMessages(use_eplus(custom))
+        locate_eplus(dirs = root)
+
+        expect_identical(eplus_config(LATEST_EPLUS_VER)$dir, normalizePath(custom))
+    })
+})
+
+test_that("invalid extra EnergyPlus dirs are ignored quietly", {
+    with_clean_eplus_cache({
+        expect_silent(locate_eplus(dirs = file.path(tempdir(), "missing-eplus-dir")))
+    })
+})
+
 test_that("Install EnergyPlus v9.0 and below", {
     skip_on_cran()
     skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_INSTALL_OLD_") != "")


### PR DESCRIPTION
Closes #609.

This delays EnergyPlus installation discovery until eplusr needs local EnergyPlus configuration instead of scanning during package load. It removes the duplicate load/attach discovery path, adds lazy targeted discovery for configuration and IDD/run lookups, and lets users provide extra search roots with `locate_eplus(dirs = ...)` or `options(eplusr.eplus_dirs = ...)`.

The change also updates the generated documentation and NEWS entry for the new discovery behavior.