### PR TITLE
feat(idf): make class matching case-insensitive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.3.9005
+Version: 0.16.3.9006
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Add support for EnergyPlus v26.1.0 (#607, #612).
 
+* Class name matching is now case-insensitive across `Idd` and `Idf` class
+  lookup, `$add()`, and class-wide `$set()` inputs (#152).
+
 * Add support for EnergyPlus v25.2.0 (#605, #606).
 
 * Add support for EnergyPlus v25.1.0 (#600, #604).

--- a/R/idd.R
+++ b/R/idd.R
@@ -391,8 +391,9 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
         #' contains valid class names in the context of current `Idd`, and
         #' `FALSE`s otherwise.
         #'
-        #' Note that case-sensitive matching is performed, which means that
-        #' `"Version"` is a valid class name but `"version"` is not.
+        #' Class name matching is **case-insensitive**. For convenience,
+        #' underscore-style class names are also allowed, e.g. `Site_Location`
+        #' is equivalent to `Site:Location`.
         #'
         #' @param class A character vector to check.
         #'
@@ -418,10 +419,8 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
         #' `$object()` returns an [IddObject] object specified by a class ID
         #' or name.
         #'
-        #' Note that case-sensitive matching is performed, which means that
-        #' `"Version"` is a valid class name but `"version"` is not.
-        #'
-        #' For convenience, underscore-style names are allowed, e.g.
+        #' Class name matching is **case-insensitive**. For convenience,
+        #' underscore-style names are allowed, e.g.
         #' `Site_Location` is equivalent to `Site:Location`.
         #'
         #' @param class A single integer specifying the class index or a single
@@ -448,10 +447,8 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
         #' `$objects()` returns a named list of [IddObject] objects using class
         #' indices or names. The returned list is named using class names.
         #'
-        #' Note that case-sensitive matching is performed, which means that
-        #' `"Version"` is a valid class name but `"version"` is not.
-        #'
-        #' For convenience, underscore-style names are allowed, e.g.
+        #' Class name matching is **case-insensitive**. For convenience,
+        #' underscore-style names are allowed, e.g.
         #' `Site_Location` is equivalent to `Site:Location`.
         #'
         #' @param class An integer vector specifying class indices or a character
@@ -798,7 +795,8 @@ idd_is_valid_group_name <- function(self, private, group) {
 # }}}
 # idd_is_valid_class_name {{{
 idd_is_valid_class_name <- function(self, private, class) {
-    class %chin% private$m_idd_env$class$class_name
+    normalize_idd_class_name_us(private$m_idd_env)
+    lower_name(class) %chin% private$m_idd_env$class$class_name_us
 }
 # }}}
 # idd_obj {{{
@@ -902,8 +900,9 @@ idd_print <- function(self, private) {
     if (i %chin% ls(x)) return(NextMethod())
 
     private <- get_priv_env(x)
+    normalize_idd_class_name_us(private$m_idd_env)
 
-    cls_id <- chmatch(i, private$m_idd_env$class$class_name)
+    cls_id <- chmatch(lower_name(i), private$m_idd_env$class$class_name_us)
 
     # skip if not a valid IDD class name
     if (is.na(cls_id)) return(NextMethod())
@@ -919,8 +918,9 @@ idd_print <- function(self, private) {
     if (i %chin% ls(x)) return(NextMethod())
 
     private <- get_priv_env(x)
+    normalize_idd_class_name_us(private$m_idd_env)
 
-    cls_id <- chmatch(underscore_name(i), private$m_idd_env$class$class_name_us)
+    cls_id <- chmatch(lower_name(i), private$m_idd_env$class$class_name_us)
 
     # skip if not a valid IDD class name
     if (is.na(cls_id)) return(NextMethod())

--- a/R/idf.R
+++ b/R/idf.R
@@ -309,8 +309,9 @@ Idf <- R6::R6Class(classname = "Idf",
         #' `all` is `FALSE`) or current underlying [Idd] (when `all` is `TRUE`),
         #' and `FALSE`s otherwise.
         #'
-        #' Note that case-sensitive matching is performed, which means that
-        #' `"Version"` is a valid class name but `"version"` is not.
+        #' Class name matching is **case-insensitive**. For convenience,
+        #' underscore-style class names are also allowed, e.g. `Site_Location`
+        #' is equivalent to `Site:Location`.
         #'
         #' @param class A character vector to check.
         #' @param all If `FALSE`, check if input characters are valid class names
@@ -1033,6 +1034,10 @@ Idf <- R6::R6Class(classname = "Idf",
         #' `idf$add(Building = .())` is equivalent to
         #' `idf$add(Building = list())`.
         #'
+        #' Class name matching is **case-insensitive**. For convenience,
+        #' underscore-style class names are also allowed, e.g. `runperiod` is
+        #' equivalent to `RunPeriod`.
+        #'
         #' Field name matching is **case-insensitive**. For convenience,
         #' underscore-style field names are also allowed, e.g. `eNd_MoNtH` is
         #' equivalent to `End Month`. This behavior is consistent among all
@@ -1148,6 +1153,10 @@ Idf <- R6::R6Class(classname = "Idf",
         #'
         #' New fields that currently do not exist in that object can also be
         #' set. They will be automatically added on the fly.
+        #'
+        #' Class name matching in `:=` is **case-insensitive**. For convenience,
+        #' underscore-style class names are also allowed, e.g. `material_nomass`
+        #' is equivalent to `Material:NoMass`.
         #'
         #' Field name matching is **case-insensitive**. For convenience,
         #' underscore-style field names are also allowed, e.g. `eNd_MoNtH` is
@@ -2803,7 +2812,7 @@ idf_is_valid_group_name <- function(self, private, group, all = FALSE) {
 #' @importFrom checkmate assert_character
 idf_is_valid_class_name <- function(self, private, class, all = FALSE) {
     assert_valid_type(class, "Class Name", type = "name")
-    class %in% idf_class_name(self, private, all, FALSE)
+    lower_name(class) %chin% lower_name(idf_class_name(self, private, all, FALSE))
 }
 # }}}
 # idf_is_valid_object_id {{{
@@ -3776,9 +3785,9 @@ replace_objects_in_class <- function(self, private, class, value, unique_object 
     if (i %chin% ls(x)) return(NextMethod())
 
     private <- get_priv_env(x)
+    normalize_idd_class_name_us(private$idd_env())
 
-    cls_id <- chmatch(i, private$idd_env()$class$class_name_us)
-    if (is.na(cls_id)) cls_id <- chmatch(i, private$idd_env()$class$class_name)
+    cls_id <- chmatch(lower_name(i), private$idd_env()$class$class_name_us)
 
     # skip if not a valid IDD class name
     if (is.na(cls_id)) return(NextMethod())
@@ -3803,8 +3812,9 @@ replace_objects_in_class <- function(self, private, class, value, unique_object 
     if (i %chin% ls(x)) return(NextMethod())
 
     private <- get_priv_env(x)
+    normalize_idd_class_name_us(private$idd_env())
 
-    cls_id <- chmatch(i, private$idd_env()$class$class_name)
+    cls_id <- chmatch(lower_name(i), private$idd_env()$class$class_name_us)
 
     # skip if not a valid IDD class name
     if (is.na(cls_id)) return(NextMethod())
@@ -3829,10 +3839,10 @@ replace_objects_in_class <- function(self, private, class, value, unique_object 
 
     self <- get_self_env(x)
     private <- get_priv_env(x)
+    normalize_idd_class_name_us(private$idd_env())
 
     # match both normal and underscore class names
-    cls_id <- chmatch(name, private$idd_env()$class$class_name)
-    if (is.na(cls_id)) cls_id <- chmatch(name, private$idd_env()$class$class_name_us)
+    cls_id <- chmatch(lower_name(name), private$idd_env()$class$class_name_us)
 
     # skip if not a valid IDD class name
     if (is.na(cls_id)) return(NextMethod())
@@ -3857,9 +3867,10 @@ replace_objects_in_class <- function(self, private, class, value, unique_object 
 
     self <- get_self_env(x)
     private <- get_priv_env(x)
+    normalize_idd_class_name_us(private$idd_env())
 
-    # match only normal class names
-    cls_id <- chmatch(name, private$idd_env()$class$class_name)
+    # match both normal and underscore class names
+    cls_id <- chmatch(lower_name(name), private$idd_env()$class$class_name_us)
 
     # skip if not a valid IDD class name
     if (is.na(cls_id)) return(NextMethod())

--- a/R/impl-idd.R
+++ b/R/impl-idd.R
@@ -33,6 +33,20 @@ get_idd_group_name <- function(idd_env, group = NULL) {
 # }}}
 
 # CLASS
+# normalize_idd_class_name_us {{{
+normalize_idd_class_name_us <- function(idd_env) {
+    if (!all(c("class_name", "class_name_us") %chin% names(idd_env$class))) {
+        return(invisible(idd_env))
+    }
+
+    key <- lower_name(idd_env$class$class_name)
+    if (!identical(idd_env$class$class_name_us, key)) {
+        set(idd_env$class, NULL, "class_name_us", key)
+    }
+
+    invisible(idd_env)
+}
+# }}}
 # get_idd_class {{{
 #' Get class data
 #'
@@ -50,6 +64,8 @@ get_idd_group_name <- function(idd_env, group = NULL) {
 #' @keywords internal
 #' @export
 get_idd_class <- function(idd_env, class = NULL, property = NULL, underscore = FALSE) {
+    normalize_idd_class_name_us(idd_env)
+
     cols <- setdiff(CLASS_COLS$index, "class_name_us")
 
     if (is.null(class)) {

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -37,6 +37,8 @@ NULL
 #' @export
 get_idf_object <- function(idd_env, idf_env, class = NULL, object = NULL, property = NULL,
                             underscore = FALSE, ignore_case = FALSE) {
+    normalize_idd_class_name_us(idd_env)
+
     # if no object is specified
     if (is.null(object)) {
         # if no class is specified
@@ -61,7 +63,7 @@ get_idf_object <- function(idd_env, idf_env, class = NULL, object = NULL, proper
                     idd_env$class[, .SD, .SDcols = c("group_id", "class_id", unique(c("class_name", col_on)))],
                     cls_in, "group_id"
                 )
-                set(cls_in, NULL, "group_id", NULL)
+                set(cls_in, NULL, intersect(names(cls_in), c("group_id", "class_name_us")), NULL)
                 col_on <- "class_id"
             }
 
@@ -98,7 +100,7 @@ get_idf_object <- function(idd_env, idf_env, class = NULL, object = NULL, proper
                     idd_env$class[, .SD, .SDcols = c("group_id", "class_id", unique(c("class_name", names(cls_in)[[1L]])))],
                     cls_in, "group_id"
                 )
-                set(cls_in, NULL, "group_id", NULL)
+                set(cls_in, NULL, intersect(names(cls_in), c("group_id", "class_name_us")), NULL)
             }
 
             # add property if necessary
@@ -194,14 +196,7 @@ get_idf_object_name <- function(idd_env, idf_env, class = NULL, simplify = FALSE
 get_idf_object_num <- function(idd_env, idf_env, class = NULL) {
     if (is.null(class)) return(nrow(idf_env$object))
 
-    cls_in <- recognize_input(class, "class")
-    col_on <- names(cls_in)[[1L]]
-    if (any(!cls_in[[col_on]] %in% idd_env$class[[col_on]])) {
-        col_key <- if (col_on == "class_id") "class index" else "class name"
-        abort_bad_key(col_key, idd_env$class[cls_in, on = col_on][is.na(group_id), .SD, .SDcols = col_on][[col_on]])
-    }
-
-    if (col_on == "class_name") cls_in <- add_class_id(idd_env, cls_in)
+    cls_in <- fast_subset(get_idd_class(idd_env, class), c("rleid", "class_id"))
 
     idf_env$object[cls_in, on = "class_id", allow.cartesian = TRUE][
         , .N, by = list(rleid, found = !is.na(object_id))][found == FALSE, N := 0L]$N
@@ -1571,7 +1566,7 @@ expand_idf_dots_value <- function(idd_env, idf_env, ...,
             add_rleid(cls_in, "class")
             cls_obj <- get_idf_object(idd_env, idf_env, cls_in$class_name, underscore = TRUE)
             add_joined_cols(cls_in, cls_obj, c("rleid" = "class_rleid"), "rleid")
-            set(cls_obj, NULL, "class_name_us", NULL)
+            if ("class_name_us" %chin% names(cls_obj)) set(cls_obj, NULL, "class_name_us", NULL)
 
             # update class id and class name
             add_joined_cols(

--- a/R/impl.R
+++ b/R/impl.R
@@ -21,7 +21,10 @@ recognize_input <- function(input, type = "class", underscore = FALSE, lower = F
         col_on <- paste0(type, "_id")
         col_key <- paste0(type, " index")
     } else {
-        if (underscore) {
+        if (type == "class") {
+            input <- lower_name(input)
+            col_on <- "class_name_us"
+        } else if (underscore) {
             input <- underscore_name(input)
             col_on <- paste0(type, "_name_us")
             # always trans to lower case for field names

--- a/R/parse.R
+++ b/R/parse.R
@@ -808,8 +808,8 @@ parse_class_property <- function(dt, ref) {
         num_extensible_group = (num_fields - first_extensible + 1L) %/% num_extensible
     )]
 
-    # add underscore class names
-    set(dt, NULL, "class_name_us", underscore_name(dt$class_name))
+    # add normalized class names
+    set(dt, NULL, "class_name_us", lower_name(dt$class_name))
 
     # only keep useful columns
     ignore <- setdiff(names(dt), unlist(CLASS_COLS, use.names = FALSE))

--- a/man/Idd.Rd
+++ b/man/Idd.Rd
@@ -808,8 +808,9 @@ Check if elements in input character vector are valid class names.
 contains valid class names in the context of current \code{Idd}, and
 \code{FALSE}s otherwise.
 
-Note that case-sensitive matching is performed, which means that
-\code{"Version"} is a valid class name but \code{"version"} is not.
+Class name matching is \strong{case-insensitive}. For convenience,
+underscore-style class names are also allowed, e.g. \code{Site_Location}
+is equivalent to \code{Site:Location}.
 }
 
 \subsection{Returns}{
@@ -849,10 +850,8 @@ string specifying the class name.}
 \verb{$object()} returns an \link{IddObject} object specified by a class ID
 or name.
 
-Note that case-sensitive matching is performed, which means that
-\code{"Version"} is a valid class name but \code{"version"} is not.
-
-For convenience, underscore-style names are allowed, e.g.
+Class name matching is \strong{case-insensitive}. For convenience,
+underscore-style names are allowed, e.g.
 \code{Site_Location} is equivalent to \code{Site:Location}.
 }
 
@@ -894,10 +893,8 @@ vector specifying class names.}
 \verb{$objects()} returns a named list of \link{IddObject} objects using class
 indices or names. The returned list is named using class names.
 
-Note that case-sensitive matching is performed, which means that
-\code{"Version"} is a valid class name but \code{"version"} is not.
-
-For convenience, underscore-style names are allowed, e.g.
+Class name matching is \strong{case-insensitive}. For convenience,
+underscore-style names are allowed, e.g.
 \code{Site_Location} is equivalent to \code{Site:Location}.
 }
 

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -1249,8 +1249,9 @@ contains valid class names in the context of current \code{Idf} (when
 \code{all} is \code{FALSE}) or current underlying \link{Idd} (when \code{all} is \code{TRUE}),
 and \code{FALSE}s otherwise.
 
-Note that case-sensitive matching is performed, which means that
-\code{"Version"} is a valid class name but \code{"version"} is not.
+Class name matching is \strong{case-insensitive}. For convenience,
+underscore-style class names are also allowed, e.g. \code{Site_Location}
+is equivalent to \code{Site:Location}.
 }
 
 \subsection{Returns}{
@@ -2250,6 +2251,10 @@ Note that \code{.()} can be used as an alias as \code{list()}, e.g.
 \code{idf$add(Building = .())} is equivalent to
 \code{idf$add(Building = list())}.
 
+Class name matching is \strong{case-insensitive}. For convenience,
+underscore-style class names are also allowed, e.g. \code{runperiod} is
+equivalent to \code{RunPeriod}.
+
 Field name matching is \strong{case-insensitive}. For convenience,
 underscore-style field names are also allowed, e.g. \code{eNd_MoNtH} is
 equivalent to \verb{End Month}. This behavior is consistent among all
@@ -2382,6 +2387,10 @@ empty fields by setting \code{.empty} to \code{TRUE}.
 
 New fields that currently do not exist in that object can also be
 set. They will be automatically added on the fly.
+
+Class name matching in \verb{:=} is \strong{case-insensitive}. For convenience,
+underscore-style class names are also allowed, e.g. \code{material_nomass}
+is equivalent to \code{Material:NoMass}.
 
 Field name matching is \strong{case-insensitive}. For convenience,
 underscore-style field names are also allowed, e.g. \code{eNd_MoNtH} is

--- a/tests/testthat/test-idd.R
+++ b/tests/testthat/test-idd.R
@@ -141,6 +141,7 @@ test_that("Idd class", {
 
     # can get group name of one class
     expect_equal(idd$from_group("TestSimple"), "TestGroup1")
+    expect_equal(idd$from_group("testsimple"), "TestGroup1")
 
     # can return when multiple class names are given
     expect_equal(idd$from_group(c("TestSlash", "TestSimple")),
@@ -167,6 +168,7 @@ test_that("Idd class", {
 
     # can return an index of a single class
     expect_equal(idd$class_index("TestSlash"), 2L)
+    expect_equal(idd$class_index("testslash"), 2L)
 
     # can return multiple class indexes
     expect_equal(idd$class_index(c("TestSlash", "TestSimple", "TestSimple")),
@@ -193,6 +195,7 @@ test_that("Idd class", {
 
     # can return a single IddObject using class name
     expect_s3_class(idd$object("TestSimple"), "IddObject")
+    expect_s3_class(idd$object("testsimple"), "IddObject")
 
     # can stop when invalid class names are given
     expect_error(idd$object("WrongClass"), class = "eplusr_error_invalid_class_name")
@@ -226,6 +229,11 @@ test_that("Idd class", {
     # can check if input is a valid class
     expect_false(idd$is_valid_class("WrongClass"))
     expect_true(idd$is_valid_class("TestSlash"))
+    expect_true(idd$is_valid_class("testslash"))
+
+    # can access classes case-insensitively
+    expect_s3_class(idd$testslash, "IddObject")
+    expect_s3_class(idd[["testslash"]], "IddObject")
 
     # can export IDD data in data.table format
     expect_equal(idd$to_table("TestSlash", all = TRUE),

--- a/tests/testthat/test-idf.R
+++ b/tests/testthat/test-idf.R
@@ -157,7 +157,10 @@ test_that("$is_valid_class()", {
 
     # can check invalid class name
     expect_true(idf$is_valid_class("Version"))
-    expect_false(idf$is_valid_class("version"))
+    expect_true(idf$is_valid_class("version"))
+    expect_true(idf$is_valid_class("simulationcontrol", all = TRUE))
+    expect_false(idf$is_valid_class("wrongclass"))
+    expect_s3_class(idf$definition("version"), "IddObject")
 })
 # }}}
 
@@ -299,7 +302,7 @@ test_that("$objects_in_class()", {
     expect_s3_class(idf <- read_idf(idftext("idf", LATEST_EPLUS_VER)), "Idf")
 
     # can get all objects in a class
-    expect_error(idf$objects_in_class("version"), class = "eplusr_error_invalid_class_name")
+    expect_type(idf$objects_in_class("version"), "list")
     expect_type(idf$objects_in_class("Version"), "list")
 })
 # }}}
@@ -493,6 +496,14 @@ test_that("$add()", {
     expect_equal(idf$objects("rp_test_3")[[1]]$value(simplify = TRUE),
         c("rp_test_3", "3", "1", NA, "4", "1", NA)
     )
+    expect_silent(idf$add(runperiod = list(
+        name = "rp_test_4",
+        begin_month = 5,
+        begin_day_of_month = 1,
+        end_month = 5,
+        end_day_of_month = 31
+    )))
+    expect_equal(idf$object("rp_test_4")$class_name(), "RunPeriod")
 
     # can stop adding objects if trying to add a object with same name
     expect_error(idf$add(RunPeriod = list("rp_test_1", 1, 1, 2, 1)), class = "eplusr_error_validity_check")
@@ -542,8 +553,8 @@ test_that("$set()", {
     # can set all values in a class
     expect_type(type = "list",
         idf$set(
-            RunPeriod := list(treat_weather_as_actual = NULL),
-            Material_NoMass := list(roughness = "Rough")
+            runperiod := list(treat_weather_as_actual = NULL),
+            material_nomass := list(roughness = "Rough")
         )
     )
     expect_equal(idf$Material_NoMass$R13LAYER$Roughness, "Rough")
@@ -1286,6 +1297,8 @@ test_that("[[.Idf and $.Idf", {
 
     expect_equal(names(idf[["Material"]]), c("WD01", "WD02"))
     expect_equal(names(idf$Material), c("WD01", "WD02"))
+    expect_equal(names(idf[["material"]]), c("WD01", "WD02"))
+    expect_equal(names(idf$material), c("WD01", "WD02"))
 
     expect_null(idf$Wrong)
     expect_null(idf[["Wrong"]])

--- a/tests/testthat/test-impl.R
+++ b/tests/testthat/test-impl.R
@@ -16,7 +16,7 @@ test_that("Basic Table Implementation", {
     expect_equal(
     ignore_attr = TRUE,
         recognize_input("Class:Name", type = "class", underscore = TRUE),
-        data.table(class_name_us = "Class_Name", rleid = 1L, original = "Class:Name")
+        data.table(class_name_us = "class_name", rleid = 1L, original = "Class:Name")
     )
 
     expect_equal(


### PR DESCRIPTION
Closes #152.

Makes class-name lookup case-insensitive for `Idd` and `Idf` class APIs, including `$add()` and class-wide `$set()` inputs, while preserving canonical class names in returned objects.

Updates docs, NEWS, and focused tests for lower-case class-name inputs.
