### PR TITLE
feat(job): store prepared model snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.3.9007
+Version: 0.16.3.9008
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",
@@ -78,6 +78,7 @@ Collate:
     'install.R'
     'standalone-schema.R'
     'job-json.R'
+    'job-store.R'
     'job.R'
     'options.R'
     'param.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New features
 
+* Store prepared job model snapshots instead of keeping `Idf` objects alive
+  inside `EplusJob`, `EplusGroupJob`, and `ParametricJob`, reducing memory use
+  for large simulation sets. `ParametricJob$seed(new = ...)` can replace the
+  seed model and invalidates existing generated models until they are
+  regenerated (#615).
+
 * Add support for EnergyPlus v26.1.0 (#607, #612).
 
 * Class name matching is now case-insensitive across `Idd` and `Idf` class

--- a/R/group.R
+++ b/R/group.R
@@ -58,11 +58,11 @@ EplusGroupJob <- R6::R6Class(classname = "EplusGroupJob", cloneable = FALSE,
             # add Output:SQLite and Output:VariableDictionary if necessary
             input <- get_epgroup_input(idfs, epws, sql = TRUE, dict = TRUE)
 
-            private$m_idfs <- input$idfs
+            private$m_model_store <- input$store
             private$m_epws_path <- input$epws
             # log if the input idf has been changed
             private$m_log <- new.env(hash = FALSE, parent = emptyenv())
-            private$m_log$unsaved <- input$sql | input$dict
+            private$m_log$unsaved <- rep(FALSE, private$m_model_store$case_count())
 
             # save uuid
             private$log_idf_uuid()
@@ -877,7 +877,7 @@ EplusGroupJob <- R6::R6Class(classname = "EplusGroupJob", cloneable = FALSE,
 
     private = list(
         # PRIVATE FIELDS {{{
-        m_idfs = NULL,
+        m_model_store = NULL,
         m_epws_path = NULL,
         m_job = NULL,
         m_log = NULL,
@@ -887,11 +887,11 @@ EplusGroupJob <- R6::R6Class(classname = "EplusGroupJob", cloneable = FALSE,
         log_new_uuid = function() log_new_uuid(private$m_log),
 
         idf_uuid = function(which = NULL) {
-            idfs <- if (is.null(which)) private$m_idfs else private$m_idfs[which]
-            vcapply(idfs, function(idf) get_priv_env(idf)$uuid())
+            sig <- private$m_model_store$case_signatures()
+            if (is.null(which)) sig else sig[which]
         },
         log_idf_uuid = function(which = NULL) {
-            if (is.null(which)) which <- seq_along(private$m_idfs)
+            if (is.null(which)) which <- seq_len(private$m_model_store$case_count())
             private$m_log$idf_uuid[which] <- private$idf_uuid(which)
         },
         cached_idf_uuid = function(which = NULL) {
@@ -933,17 +933,7 @@ group_job <- function(idfs, epws) {
 epgroup_run <- function(self, private, output_dir = NULL, wait = TRUE,
                          force = FALSE, copy_external = FALSE, echo = wait,
                          separate = TRUE, readvars = TRUE) {
-    # check if generated models have been modified outside
-    uuid <- private$idf_uuid()
-    if (any(i <- uuid != private$cached_idf_uuid())) {
-        warn(paste0(
-            "Some of the grouped models have been modified. ",
-            "Running these models will result in simulation outputs that may be not reproducible. ",
-            paste0(" # ", seq_along(uuid)[i], " | ", names(uuid)[i], collapse = "\n")
-        ), "group_model_modified")
-        private$log_unsaved(which(i))
-    }
-
+    private$m_model_store$assert_cases_valid()
     private$log_new_uuid()
 
     epgroup_run_models(self, private, output_dir, wait, force, copy_external, echo, separate, readvars)
@@ -959,11 +949,15 @@ epgroup_run_models <- function(self, private, output_dir = NULL, wait = TRUE,
     assert_flag(separate)
     assert_flag(readvars)
 
-    path_idf <- vcapply(private$m_idfs, function(idf) idf$path())
+    store <- private$m_model_store
+    store$assert_cases_valid()
 
-    if (checkmate::test_names(names(private$m_idfs))) {
+    path_idf <- store$case_source_paths()
+    path_idf[is.na(path_idf)] <- store$case_model_paths()[is.na(path_idf)]
+
+    if (store$case_has_names()) {
         # for parametric job
-        nms <- paste0(make_filename(names(private$m_idfs)), ".idf")
+        nms <- paste0(make_filename(store$case_names()), ".idf")
     } else {
         nms <- basename(path_idf)
     }
@@ -1022,22 +1016,17 @@ epgroup_run_models <- function(self, private, output_dir = NULL, wait = TRUE,
         path_group <- normalizePath(file.path(output_dir, nms), mustWork = FALSE)
     }
 
-    if (any(to_save <- path_group != path_idf | private$is_unsaved())) {
-        # remove duplications
-        dup <- duplicated(path_group)
-        apply2(private$m_idfs[to_save & !dup], path_group[to_save & !dup],
-            function(x, y) x$save(y, overwrite = TRUE, copy_external = copy_external)
-        )
-        private$log_idf_uuid(which(to_save))
-        private$log_saved(which(to_save))
-    }
+    materialized <- store$materialize_cases(path_group, copy_external = copy_external)
+    path_group <- materialized$paths
+    private$log_idf_uuid()
+    private$log_saved()
 
     # reset status
     private$m_log$start_time <- current()
     private$m_log$killed <- NULL
     private$m_job <- NULL
 
-    ver <- vcapply(private$m_idfs, function(idf) as.character(idf$version()))
+    ver <- store$case_versions()
 
     # init job table
     jobs <- pre_job_inputs(path_group, path_epw, NULL, design_day, FALSE, ver)
@@ -1045,12 +1034,7 @@ epgroup_run_models <- function(self, private, output_dir = NULL, wait = TRUE,
         set(jobs, NULL, "resources", list())
     } else {
         # check if external file dependencies are found
-        resrc <- lapply(private$m_idfs, function(idf) {
-            deps <- idf$external_deps()
-            if (!length(deps)) deps <- NULL
-            deps
-        })
-        set(jobs, NULL, "resources", resrc)
+        set(jobs, NULL, "resources", materialized$resources)
     }
 
     options <- list(num_parallel = eplusr_option("num_parallel"), echo = echo,
@@ -1119,11 +1103,15 @@ epgroup_status <- function(self, private) {
     proc <- private$m_job
 
     if (is.null(private$m_job)) {
-        if (!is.null(private$m_idfs)) {
+        if (!is.null(private$m_model_store) && private$m_model_store$case_count()) {
             status$job_status <- data.table(
-                index = seq_along(private$m_idfs),
+                index = seq_len(private$m_model_store$case_count()),
                 status = "idle",
-                idf = vcapply(private$m_idfs, function(idf) idf$path())
+                idf = {
+                    paths <- private$m_model_store$case_source_paths()
+                    paths[is.na(paths)] <- private$m_model_store$case_model_paths()[is.na(paths)]
+                    paths
+                }
             )
             if (is.null(private$m_epws_path)) {
                 epw <- NA_character_
@@ -1144,16 +1132,7 @@ epgroup_status <- function(self, private) {
         status$terminated <- FALSE
     }
 
-    status$changed_after <- FALSE
-    uuid <- private$idf_uuid()
-    if (any(private$cached_idf_uuid() != uuid)) {
-        status$changed_after <- TRUE
-    }
-
-    # for parametric job
-    if (is_idf(private$m_seed) && !identical(private$seed_uuid(), get_priv_env(private$m_seed)$uuid())) {
-        status$changed_after <- TRUE
-    }
+    status$changed_after <- !private$m_model_store$cases_valid()
 
     if (inherits(proc, "r_process")) {
         if (proc$is_alive()) {
@@ -1352,7 +1331,7 @@ epgroup_tabular_data <- function(self, private, which = NULL, report_name = NULL
 # epgroup_print {{{
 epgroup_print <- function(self, private) {
     cli::cat_rule("EnergPlus Group Simulation Job", col = "green")
-    cli::cat_line(paste0("Grouped Jobs [", length(private$m_idfs), "]: "))
+    cli::cat_line(paste0("Grouped Jobs [", private$m_model_store$case_count(), "]: "))
 
     epgroup_print_status(self, private)
 }
@@ -1362,30 +1341,34 @@ epgroup_print <- function(self, private) {
 # get_epgroup_input {{{
 get_epgroup_input <- function(idfs, epws, sql = TRUE, dict = TRUE) {
     # check idf {{{
+    store <- JobModelStore$new()
     if (is_idf(idfs)) {
-        idfs <- list(get_init_idf(idfs, sql = sql, dict = dict))
+        idfs <- list(idfs)
     } else {
-        init_idf <- function(...) {
-            tryCatch(get_init_idf(...),
-                eplusr_error_idf_not_local = function(e) e,
-                eplusr_error_idf_path_not_exist = function(e) e,
-                eplusr_error_idf_not_saved = function(e) e
-            )
-        }
-        idfs <- lapply(idfs, init_idf, sql = sql, dict = dict)
+        idfs <- as.list(idfs)
     }
 
+    init_idf <- function(idf) {
+        tryCatch(store$add_input_model(idf, role = "input", sql = sql, dict = dict),
+            eplusr_error_idf_not_local = function(e) e,
+            eplusr_error_idf_path_not_exist = function(e) e,
+            eplusr_error_idf_not_saved = function(e) e
+        )
+    }
+    model_ids <- lapply(idfs, init_idf)
+
     err <- c("eplusr_error_idf_not_local", "eplusr_error_idf_path_not_exist", "eplusr_error_idf_not_saved")
-    if (any(invld <- vlapply(idfs, inherits, err))) {
+    if (any(invld <- vlapply(model_ids, inherits, err))) {
         abort(paste0("Invalid IDF input found:\n",
-            paste0(lpad(paste0("  #", which(invld))), ": ", vcapply(idfs[invld], conditionMessage),
+            paste0(lpad(paste0("  #", which(invld))), ": ", vcapply(model_ids[invld], conditionMessage),
                 collapse = "\n"
             )
         ))
     }
 
-    sql <- vlapply(idfs, attr, "sql")
-    dict <- vlapply(idfs, attr, "sql")
+    model_ids <- as.integer(unlist(model_ids, use.names = FALSE))
+    case_names <- names(idfs)
+    if (!checkmate::test_names(case_names)) case_names <- NULL
     # }}}
 
     # check epw paths {{{
@@ -1416,14 +1399,15 @@ get_epgroup_input <- function(idfs, epws, sql = TRUE, dict = TRUE) {
         epws <- vcapply(epws, `%||%`, NA_character_)
         if (length(epws) == 1L) epws <- replicate(length(idfs), epws)
         if (length(idfs) == 1L) {
-            idfs <- replicate(length(epws), idfs[[1L]]$clone())
-            sql <- rep(sql, length(epws))
-            dict <- rep(dict, length(epws))
+            model_ids <- rep(model_ids, length(epws))
+            case_names <- NULL
         }
-        assert_same_len(idfs, epws)
+        assert_same_len(model_ids, epws)
     }
 
-    list(idfs = idfs, epws = epws, sql = sql, dict = dict)
+    store$set_cases(model_ids, case_names)
+
+    list(store = store, epws = epws)
 }
 # }}}
 # epgroup_retrieve_data {{{
@@ -1508,11 +1492,7 @@ epgroup_job_from_which <- function(self, private, which, keep_unsucess = FALSE) 
 # epgroup_case_from_which {{{
 #' @importFrom checkmate test_names
 epgroup_case_from_which <- function(self, private, which = NULL, name = FALSE) {
-    if (checkmate::test_named(private$m_idfs)) {
-        nms <- names(private$m_idfs)
-    } else {
-        nms <- vcapply(private$m_idfs, function(idf) tools::file_path_sans_ext(basename(idf$path())))
-    }
+    nms <- private$m_model_store$case_names()
 
     if (is.null(which)) {
         if (name) return(nms) else return(seq_along(nms))
@@ -1570,18 +1550,21 @@ epgroup_print_status <- function(self, private, epw = TRUE) {
     status <- epgroup_status(self, private)
     epgroup_retrieve_data(self, private, status)
 
-    if (!is.null(names(private$m_idfs))) {
-        nm_idf <- paste0(names(private$m_idfs), ".idf")
+    n_case <- private$m_model_store$case_count()
+    if (private$m_model_store$case_has_names()) {
+        nm_idf <- paste0(private$m_model_store$case_names(), ".idf")
     } else {
-        nm_idf <- vcapply(private$m_idfs, function(x) basename(x$path()))
+        paths <- private$m_model_store$case_source_paths()
+        paths[is.na(paths)] <- private$m_model_store$case_model_paths()[is.na(paths)]
+        nm_idf <- basename(paths)
     }
     if (!epw) {
         nm <- cli::ansi_strtrim(paste0(
-            "[", lpad(seq_along(private$m_idfs), 0), "]: ", surround(nm_idf)
+            "[", lpad(seq_len(n_case), 0), "]: ", surround(nm_idf)
         ))
     } else {
         nm_idf <- cli::ansi_strtrim(paste0(
-            "[", lpad(seq_along(private$m_idfs), 0), "]: ",
+            "[", lpad(seq_len(n_case), 0), "]: ",
             paste0("[IDF] ", surround(nm_idf))
         ))
 
@@ -1619,7 +1602,7 @@ epgroup_print_status <- function(self, private, epw = TRUE) {
             job_status <- job_status[J(seq_along(nm)), on = "index"]
             # for models that are idle
             job_status[J(NA_character_), on = "V2", V2 := paste0(
-                "IDLE       --> [IDF]", surround(names(private$m_idfs)[index]))]
+                "IDLE       --> [IDF]", surround(private$m_model_store$case_names()[index]))]
             stderr <- paste0(lpad(job_status$index, "0"), "|" ,job_status$V2)
             safe_width <- getOption("width") - 2L
             stderr_trunc <- vcapply(stderr, function(l) {

--- a/R/job-json.R
+++ b/R/job-json.R
@@ -16,13 +16,11 @@ NULL
 #' not prevent `read_job()` from restoring the job object if files have been
 #' removed.
 #'
-#' @section Parametric jobs:
-#' For [ParametricJob], the manifest stores the seed model, weather file,
-#' generated model files, case data, and available run results. If generated
-#' models only exist in memory, `save_job()` snapshots them into a
-#' `<manifest>_files` directory next to the JSON file. Arbitrary R measure
-#' functions passed to `$apply_measure()` are not serialized; the restored job
-#' uses the generated model snapshots and stored case data.
+#' @section Model snapshots:
+#' The manifest stores a prepared model snapshot store for [EplusJob],
+#' [EplusGroupJob], and [ParametricJob]. For [ParametricJob], arbitrary R
+#' measure functions passed to `$apply_measure()` are not serialized; the
+#' restored job uses the generated model snapshots and stored case data.
 #'
 #' @param x An [EplusJob], [EplusGroupJob], or [ParametricJob].
 #' @param path A JSON file path. If `NULL`, a default file name is used in the
@@ -139,13 +137,13 @@ read_job <- function(path, validate = TRUE, verify = c("warn", "error", "ignore"
 }
 
 JOB_JSON_FORMAT <- "eplusr-job"
-JOB_JSON_MANIFEST_VERSION <- 1L
+JOB_JSON_MANIFEST_VERSION <- 2L
 
 SCHEMA_EPLUS_JOB_MANIFEST <- schema_flatten(schema_read('{
   "version": "1.0.0",
   "$defs": {
     "nullable_string": {
-      "check": { "kind": "string", "min.chars": 1, "null.ok": true }
+      "check": { "kind": "string", "min.chars": 1, "null.ok": true, "na.ok": true }
     },
     "string_vector": {
       "any": [
@@ -182,6 +180,82 @@ SCHEMA_EPLUS_JOB_MANIFEST <- schema_flatten(schema_read('{
     "result_file": {
       "check": { "kind": "list", "null.ok": true },
       "rest": { "$ref": "#/$defs/text_or_array" }
+    },
+    "model_store_model": {
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": [
+          "model_id", "role", "name", "source_path", "prepared_path",
+          "version", "sql", "dict", "signature", "size", "mtime"
+        ],
+        "subset.of": [
+          "model_id", "role", "name", "source_path", "prepared_path",
+          "version", "sql", "dict", "signature", "size", "mtime"
+        ]
+      },
+      "fields": {
+        "model_id": { "check": { "kind": "int", "lower": 1 } },
+        "role": {
+          "check": {
+            "kind": "choice",
+            "choices": ["input", "seed", "case"]
+          }
+        },
+        "name": { "$ref": "#/$defs/nullable_string" },
+        "source_path": { "$ref": "#/$defs/nullable_string" },
+        "prepared_path": { "check": { "kind": "string", "min.chars": 1 } },
+        "version": { "check": { "kind": "string", "min.chars": 1 } },
+        "sql": { "check": { "kind": "flag" } },
+        "dict": { "check": { "kind": "flag" } },
+        "signature": { "check": { "kind": "string", "min.chars": 1 } },
+        "size": { "check": { "kind": "number", "lower": 0 } },
+        "mtime": { "$ref": "#/$defs/nullable_string" }
+      }
+    },
+    "model_store_case": {
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": ["case_index", "model_id", "name", "run_path"],
+        "subset.of": ["case_index", "model_id", "name", "run_path"]
+      },
+      "fields": {
+        "case_index": { "check": { "kind": "int", "lower": 1 } },
+        "model_id": { "check": { "kind": "int", "lower": 1 } },
+        "name": { "$ref": "#/$defs/nullable_string" },
+        "run_path": { "$ref": "#/$defs/nullable_string" }
+      }
+    },
+    "model_store": {
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": [
+          "version", "seed_model_id", "cases_valid", "invalid_reason",
+          "models", "cases"
+        ],
+        "subset.of": [
+          "version", "seed_model_id", "cases_valid", "invalid_reason",
+          "models", "cases"
+        ]
+      },
+      "fields": {
+        "version": { "check": { "kind": "int", "lower": 1, "upper": 1 } },
+        "seed_model_id": { "check": { "kind": "int", "lower": 1, "null.ok": true } },
+        "cases_valid": { "check": { "kind": "flag" } },
+        "invalid_reason": { "$ref": "#/$defs/nullable_string" },
+        "models": {
+          "check": { "kind": "list", "min.len": 1 },
+          "keys": { "type": "unnamed" },
+          "rest": { "$ref": "#/$defs/model_store_model" }
+        },
+        "cases": {
+          "check": { "kind": "list" },
+          "keys": { "type": "unnamed" },
+          "rest": { "$ref": "#/$defs/model_store_case" }
+        }
+      }
     },
     "result_file_record": {
       "check": { "kind": "list" },
@@ -276,20 +350,14 @@ SCHEMA_EPLUS_JOB_MANIFEST <- schema_flatten(schema_read('{
       "keys": {
         "type": "unique",
         "subset.of": [
-          "idf", "epw", "idfs", "idf_names", "epws",
-          "seed", "weather", "models", "model_names"
+          "model_store", "epw", "epws", "weather"
         ]
       },
       "fields": {
-        "idf": { "$ref": "#/$defs/nullable_string" },
+        "model_store": { "$ref": "#/$defs/model_store" },
         "epw": { "$ref": "#/$defs/nullable_string" },
-        "idfs": { "$ref": "#/$defs/string_vector" },
-        "idf_names": { "$ref": "#/$defs/string_vector" },
         "epws": { "$ref": "#/$defs/string_vector" },
-        "seed": { "$ref": "#/$defs/nullable_string" },
-        "weather": { "$ref": "#/$defs/nullable_string" },
-        "models": { "$ref": "#/$defs/string_vector" },
-        "model_names": { "$ref": "#/$defs/string_vector" }
+        "weather": { "$ref": "#/$defs/nullable_string" }
       }
     },
     "log": {
@@ -362,6 +430,7 @@ job_json_validate_manifest <- function(x) {
     }
 
     job_json_validate_manifest_kind(x)
+    job_json_validate_manifest_model_store(x)
 
     invisible(x)
 }
@@ -370,20 +439,20 @@ job_json_validate_manifest_kind <- function(x) {
     kind <- job_json_scalar_character(x$kind)
     specs <- switch(kind,
         EplusJob = list(
-            inputs = c("idf", "epw"),
+            inputs = c("model_store", "epw"),
             log = c("uuid", "seed_uuid", "unsaved", "start_time", "end_time", "killed"),
             run = c("version", "energyplus", "start_time", "end_time",
                 "exit_status", "output_dir", "file", "file_info", "run"),
             parametric = NULL
         ),
         EplusGroupJob = list(
-            inputs = c("idfs", "idf_names", "epws"),
+            inputs = c("model_store", "epws"),
             log = c("uuid", "idf_uuid", "unsaved", "start_time", "end_time", "killed"),
             run = c("options", "jobs"),
             parametric = NULL
         ),
         ParametricJob = list(
-            inputs = c("seed", "weather", "models", "model_names"),
+            inputs = c("model_store", "weather"),
             log = c("uuid", "idf_uuid", "seed_uuid", "unsaved", "start_time",
                 "end_time", "killed"),
             run = c("options", "jobs"),
@@ -418,6 +487,56 @@ job_json_validate_manifest_kind <- function(x) {
         }
         job_json_assert_manifest_keys(x$parametric, specs$parametric, specs$parametric,
             sprintf("%s parametric", kind))
+    }
+
+    invisible(x)
+}
+
+job_json_validate_manifest_model_store <- function(x) {
+    kind <- job_json_scalar_character(x$kind)
+    store <- x$inputs$model_store
+    models <- store$models
+
+    if (is.null(models) || !length(models)) {
+        abort("Job manifest model store must contain at least one model.",
+            "job_json_model_store")
+    }
+
+    model_ids <- viapply(models, function(row) job_json_scalar_integer(row$model_id))
+    if (anyDuplicated(model_ids)) {
+        abort("Job manifest model store contains duplicate model ids.",
+            "job_json_model_store")
+    }
+
+    seed_id <- job_json_scalar_integer(store$seed_model_id, default = NULL)
+    if (identical(kind, "ParametricJob") && is.null(seed_id)) {
+        abort("ParametricJob manifest model store must include a seed model id.",
+            "job_json_model_store")
+    }
+    if (!is.null(seed_id) && !(seed_id %in% model_ids)) {
+        abort("Job manifest model store seed model id does not match any stored model.",
+            "job_json_model_store")
+    }
+
+    cases <- store$cases
+    if (kind %in% c("EplusJob", "EplusGroupJob") && (is.null(cases) || !length(cases))) {
+        abort(sprintf("%s manifest model store must contain at least one case.", kind),
+            "job_json_model_store")
+    }
+
+    if (is.null(cases) || !length(cases)) return(invisible(x))
+
+    case_indices <- viapply(cases, function(row) job_json_scalar_integer(row$case_index))
+    if (anyDuplicated(case_indices)) {
+        abort("Job manifest model store contains duplicate case indices.",
+            "job_json_model_store")
+    }
+
+    case_model_ids <- viapply(cases, function(row) job_json_scalar_integer(row$model_id))
+    missing <- setdiff(case_model_ids, model_ids)
+    if (length(missing)) {
+        abort("Job manifest model store cases reference unknown model ids.",
+            "job_json_model_store")
     }
 
     invisible(x)
@@ -603,9 +722,9 @@ job_json_default_path <- function(x) {
     kind <- job_json_kind(x)
 
     dir <- switch(kind,
-        EplusJob = dirname(priv$m_idf$path()),
-        EplusGroupJob = dirname(priv$m_idfs[[1L]]$path()),
-        ParametricJob = dirname(priv$m_seed$path())
+        EplusJob = priv$m_model_store$default_dir(),
+        EplusGroupJob = priv$m_model_store$default_dir(),
+        ParametricJob = priv$m_model_store$default_dir(seed = TRUE)
     )
 
     file <- switch(kind,
@@ -630,8 +749,8 @@ job_json_manifest <- function(x, path, overwrite, relative, hash) {
         created_at = job_json_format_time(current()),
         paths_relative_to = if (relative) "." else NULL,
         inputs = switch(kind,
-            EplusJob = job_json_eplus_inputs(priv, base, relative),
-            EplusGroupJob = job_json_group_inputs(priv, base, relative),
+            EplusJob = job_json_eplus_inputs(priv, path, overwrite, relative),
+            EplusGroupJob = job_json_group_inputs(priv, path, overwrite, relative),
             ParametricJob = job_json_parametric_inputs(priv, path, overwrite, relative)
         ),
         log = switch(kind,
@@ -653,64 +772,61 @@ job_json_manifest <- function(x, path, overwrite, relative, hash) {
     out
 }
 
-job_json_eplus_inputs <- function(private, base, relative) {
+job_json_eplus_inputs <- function(private, path, overwrite, relative) {
+    base <- dirname(path)
     list(
-        idf = job_json_encode_path(private$m_idf$path(), base, relative),
+        model_store = job_json_encode_model_store(private$m_model_store, base, relative,
+            path = path, overwrite = overwrite),
         epw = job_json_encode_path(private$m_epw_path, base, relative)
     )
 }
 
-job_json_group_inputs <- function(private, base, relative) {
+job_json_group_inputs <- function(private, path, overwrite, relative) {
+    base <- dirname(path)
     list(
-        idfs = job_json_encode_path(vcapply(private$m_idfs, function(idf) idf$path()), base, relative),
-        idf_names = names(private$m_idfs),
+        model_store = job_json_encode_model_store(private$m_model_store, base, relative,
+            path = path, overwrite = overwrite),
         epws = job_json_encode_path(private$m_epws_path, base, relative)
     )
 }
 
 job_json_parametric_inputs <- function(private, path, overwrite, relative) {
-    base <- dirname(path)
-
-    models <- NULL
-    model_names <- NULL
-    if (!is.null(private$m_idfs)) {
-        models <- job_json_snapshot_parametric_models(private, path, overwrite, relative)
-        model_names <- names(private$m_idfs)
-    }
-
     list(
-        seed = job_json_encode_path(private$m_seed$path(), base, relative),
-        weather = job_json_encode_path(private$m_epws_path, base, relative),
-        models = models,
-        model_names = model_names
+        model_store = job_json_encode_model_store(private$m_model_store, dirname(path), relative,
+            path = path, overwrite = overwrite),
+        weather = job_json_encode_path(private$m_epws_path, dirname(path), relative)
     )
 }
 
-job_json_snapshot_parametric_models <- function(private, path, overwrite, relative) {
-    base <- dirname(path)
+job_json_encode_model_store <- function(store, base, relative, path, overwrite) {
     stem <- tools::file_path_sans_ext(basename(path))
-    dir <- normalizePath(file.path(base, paste0(stem, "_files")), mustWork = FALSE)
+    dir <- normalizePath(file.path(base, paste0(stem, "_files"), "model_store"),
+        mustWork = FALSE)
+    snapshot <- store$snapshot(dir, overwrite = overwrite)
 
-    if (dir.exists(dir) && length(list.files(dir, all.files = TRUE, no.. = TRUE)) && !overwrite) {
-        abort(sprintf("Parametric job snapshot directory already exists: %s", surround(dir)),
-            "job_json_file_exists")
-    }
-    if (!dir.exists(dir) && !dir.create(dir, recursive = TRUE, showWarnings = FALSE)) {
-        abort(sprintf("Failed to create parametric job snapshot directory: %s", surround(dir)),
-            "job_json_dir")
-    }
-
-    nms <- names(private$m_idfs)
-    if (is.null(nms)) nms <- paste0("model_", seq_along(private$m_idfs))
-    nms <- make.unique(make_filename(nms), sep = "_")
-
-    paths <- normalizePath(file.path(dir, paste0(nms, ".idf")), mustWork = FALSE)
-    for (i in seq_along(private$m_idfs)) {
-        idf <- private$m_idfs[[i]]$clone(deep = TRUE)
-        idf$save(paths[[i]], overwrite = TRUE)
+    models <- snapshot$models
+    if (nrow(models)) {
+        set(models, NULL, "source_path",
+            job_json_encode_path(models$source_path, base, relative))
+        set(models, NULL, "prepared_path",
+            job_json_encode_path(models$prepared_path, base, relative))
+        set(models, NULL, "mtime", job_json_format_time(models$mtime))
     }
 
-    job_json_encode_path(paths, base, relative)
+    cases <- snapshot$cases
+    if (nrow(cases)) {
+        set(cases, NULL, "run_path",
+            job_json_encode_path(cases$run_path, base, relative))
+    }
+
+    list(
+        version = 1L,
+        seed_model_id = job_json_scalar_or_null(snapshot$seed_model_id),
+        cases_valid = isTRUE(snapshot$cases_valid),
+        invalid_reason = snapshot$invalid_reason,
+        models = job_json_encode_table(models),
+        cases = job_json_encode_table(cases)
+    )
 }
 
 job_json_eplus_log <- function(private) {
@@ -749,13 +865,17 @@ job_json_parametric_state <- function(private) {
     params <- job_json_env_get(log, "params")
 
     list(
-        applied = !is.null(private$m_idfs),
+        applied = private$m_model_store$has_cases(),
         simple = job_json_env_get(log, "simple"),
         replayable = isTRUE(job_json_env_get(log, "simple")),
         measure_name = job_json_env_get(log, "measure_name"),
         bare = job_json_env_get(log, "bare"),
         params = job_json_encode_table(params),
-        cases = if (is.null(params)) NULL else job_json_encode_table(param_cases(NULL, private))
+        cases = if (is.null(params) || !private$m_model_store$cases_valid()) {
+            NULL
+        } else {
+            job_json_encode_table(param_cases(NULL, private))
+        }
     )
 }
 
@@ -953,14 +1073,49 @@ job_json_encode_value <- function(x) {
     x
 }
 
+job_json_decode_model_store <- function(x, base) {
+    models <- job_json_decode_table(x$models)
+    if (nrow(models)) {
+        set(models, NULL, "model_id", as.integer(models$model_id))
+        set(models, NULL, "source_path",
+            job_json_decode_path_vector(models$source_path, base))
+        set(models, NULL, "prepared_path",
+            job_json_decode_path_vector(models$prepared_path, base))
+        set(models, NULL, "sql", as.logical(models$sql))
+        set(models, NULL, "dict", as.logical(models$dict))
+        set(models, NULL, "size", as.numeric(models$size))
+        set(models, NULL, "mtime", job_json_parse_time(models$mtime))
+    }
+
+    cases <- job_json_decode_table(x$cases)
+    if (nrow(cases)) {
+        set(cases, NULL, "case_index", as.integer(cases$case_index))
+        set(cases, NULL, "model_id", as.integer(cases$model_id))
+        set(cases, NULL, "run_path",
+            job_json_decode_path_vector(cases$run_path, base))
+    }
+
+    JobModelStore$new(
+        models = models,
+        cases = cases,
+        seed_model_id = job_json_scalar_integer(x$seed_model_id, default = NULL),
+        cases_valid = job_json_scalar_logical(x$cases_valid, default = TRUE),
+        invalid_reason = job_json_scalar_character(x$invalid_reason)
+    )
+}
+
 job_json_restore_eplus_job <- function(manifest, base) {
     inputs <- manifest$inputs
+    store <- job_json_decode_model_store(inputs$model_store, base)
+    epw <- job_json_decode_path_nullable(inputs$epw, base)
     job <- eplus_job(
-        job_json_decode_path(inputs$idf, base),
-        job_json_decode_path_nullable(inputs$epw, base)
+        store$first_prepared_path(),
+        epw
     )
 
     private <- get_priv_env(job)
+    private$m_model_store <- store
+    private$m_epw_path <- epw
     job_json_restore_eplus_log(private, manifest$log)
     private$m_job <- job_json_decode_energyplus_result(manifest$run, base)
 
@@ -969,14 +1124,18 @@ job_json_restore_eplus_job <- function(manifest, base) {
 
 job_json_restore_group_job <- function(manifest, base) {
     inputs <- manifest$inputs
-    idfs <- job_json_decode_path_vector(inputs$idfs, base)
     epws <- job_json_decode_epws(inputs$epws, base)
+    store <- job_json_decode_model_store(inputs$model_store, base)
 
-    job <- group_job(idfs, epws)
+    first_epw <- if (length(epws)) epws[[1L]] else NULL
+    job <- group_job(store$first_prepared_path(), first_epw)
     private <- get_priv_env(job)
-
-    nms <- job_json_decode_optional_character(inputs$idf_names)
-    if (!is.null(nms)) names(private$m_idfs) <- nms
+    private$m_model_store <- store
+    private$m_epws_path <- if (length(epws)) {
+        vcapply(epws, function(epw) epw %||% NA_character_)
+    } else {
+        NULL
+    }
 
     job_json_restore_group_log(private, manifest$log)
     private$m_job <- job_json_decode_group_run(manifest$run, base)
@@ -986,20 +1145,16 @@ job_json_restore_group_job <- function(manifest, base) {
 
 job_json_restore_parametric_job <- function(manifest, base) {
     inputs <- manifest$inputs
+    store <- job_json_decode_model_store(inputs$model_store, base)
+    weather <- job_json_decode_path_nullable(inputs$weather, base)
     job <- param_job(
-        job_json_decode_path(inputs$seed, base),
-        job_json_decode_path_nullable(inputs$weather, base)
+        store$model_prepared_path(store$seed_model_id()),
+        weather
     )
 
     private <- get_priv_env(job)
-
-    models <- job_json_decode_path_vector(inputs$models, base, null.ok = TRUE)
-    if (!is.null(models)) {
-        private$m_idfs <- lapply(models, get_init_idf, sql = TRUE, dict = TRUE)
-        nms <- job_json_decode_optional_character(inputs$model_names)
-        if (!is.null(nms)) names(private$m_idfs) <- nms
-        private$log_idf_uuid()
-    }
+    private$m_model_store <- store
+    private$m_epws_path <- weather
 
     job_json_restore_parametric_log(private, manifest$log, manifest$parametric)
     private$m_job <- job_json_decode_group_run(manifest$run, base)
@@ -1019,7 +1174,7 @@ job_json_restore_group_log <- function(private, log) {
 
 job_json_restore_parametric_log <- function(private, log, parametric) {
     private$log_seed_uuid()
-    if (!is.null(private$m_idfs)) private$log_idf_uuid()
+    if (private$m_model_store$has_cases()) private$log_idf_uuid()
     job_json_restore_common_log(private$m_log, log)
 
     if (!is.null(parametric)) {
@@ -1032,6 +1187,8 @@ job_json_restore_parametric_log <- function(private, log, parametric) {
 
 job_json_restore_common_log <- function(log_env, log) {
     if (!is.null(log$uuid)) log_env$uuid <- job_json_scalar_character(log$uuid)
+    if (!is.null(log$seed_uuid)) log_env$seed_uuid <- job_json_scalar_character(log$seed_uuid)
+    if (!is.null(log$idf_uuid)) log_env$idf_uuid <- job_json_decode_character_vector(log$idf_uuid)
     if (!is.null(log$unsaved)) log_env$unsaved <- job_json_decode_value(log$unsaved)
 
     start <- job_json_parse_time(log$start_time)

--- a/R/job-store.R
+++ b/R/job-store.R
@@ -1,0 +1,443 @@
+#' @importFrom R6 R6Class
+#' @importFrom data.table data.table rbindlist set setDT
+NULL
+
+JobModelStore <- R6::R6Class(classname = "JobModelStore", cloneable = FALSE,
+    public = list(
+        initialize = function(root = NULL, models = NULL, cases = NULL,
+                              seed_model_id = NULL, cases_valid = TRUE,
+                              invalid_reason = NULL) {
+            private$m_root <- normalizePath(root %||% tempfile("eplusr-job-model-store-"),
+                mustWork = FALSE)
+            private$m_model_dir <- file.path(private$m_root, "models")
+            if (!dir.exists(private$m_model_dir)) {
+                dir.create(private$m_model_dir, recursive = TRUE, showWarnings = FALSE)
+            }
+
+            private$m_models <- job_model_store_models(models)
+            private$m_cases <- job_model_store_cases(cases)
+            private$m_seed_model_id <- seed_model_id
+            private$m_cases_valid <- isTRUE(cases_valid)
+            private$m_invalid_reason <- invalid_reason
+
+            if (nrow(private$m_models)) {
+                private$m_next_model_id <- max(private$m_models$model_id) + 1L
+            }
+        },
+
+        add_input_model = function(idf, role = "input", name = NULL, sql = TRUE, dict = TRUE) {
+            idf <- get_init_idf(idf, sql = sql, dict = dict)
+            self$add_model(idf, role = role, name = name, source_path = idf$path(),
+                sql = isTRUE(attr(idf, "sql")), dict = isTRUE(attr(idf, "dict")))
+        },
+
+        add_model = function(idf, role = "input", name = NULL, source_path = NULL,
+                             sql = FALSE, dict = FALSE) {
+            if (!is_idf(idf)) abort("'idf' must be an Idf object.", "job_model_store")
+
+            model_id <- private$m_next_model_id
+            private$m_next_model_id <- private$m_next_model_id + 1L
+
+            source_path <- job_model_store_path(source_path)
+            file_name <- job_model_store_filename(name, source_path, idf$path(), model_id)
+            model_dir <- file.path(private$m_model_dir, sprintf("%04d", model_id))
+            if (!dir.exists(model_dir)) {
+                dir.create(model_dir, recursive = TRUE, showWarnings = FALSE)
+            }
+            prepared_path <- normalizePath(file.path(model_dir, file_name), mustWork = FALSE)
+            prepared_path <- idf$save(prepared_path, overwrite = TRUE, copy_external = FALSE)
+
+            sig <- job_model_store_file_signature(prepared_path)
+            private$m_models <- rbindlist(list(private$m_models, data.table(
+                model_id = model_id,
+                role = role,
+                name = job_model_store_scalar(name),
+                source_path = source_path,
+                prepared_path = prepared_path,
+                version = as.character(idf$version()),
+                sql = isTRUE(sql),
+                dict = isTRUE(dict),
+                signature = sig$hash,
+                size = sig$size,
+                mtime = sig$mtime
+            )), fill = TRUE)
+
+            model_id
+        },
+
+        set_seed = function(idf) {
+            had_cases <- nrow(private$m_cases) > 0L
+            private$m_seed_model_id <- self$add_input_model(idf, role = "seed",
+                sql = TRUE, dict = TRUE)
+            if (had_cases) {
+                self$invalidate_cases("The seed model has been replaced. Regenerate parametric models before running or saving them.")
+            }
+            invisible(private$m_seed_model_id)
+        },
+
+        seed_model_id = function() {
+            private$m_seed_model_id
+        },
+
+        set_cases = function(model_ids, names = NULL) {
+            model_ids <- as.integer(model_ids)
+            if (!length(model_ids)) {
+                private$m_cases <- job_model_store_cases()
+                private$m_cases_valid <- TRUE
+                private$m_invalid_reason <- NULL
+                return(invisible(self))
+            }
+
+            if (any(!model_ids %in% private$m_models$model_id)) {
+                abort("Unknown model id found when setting job cases.", "job_model_store")
+            }
+
+            if (!is.null(names)) {
+                assert_character(names, any.missing = FALSE)
+                assert_same_len(model_ids, names)
+                names <- as.character(names)
+            } else {
+                names <- rep(NA_character_, length(model_ids))
+            }
+
+            private$m_cases <- data.table(
+                case_index = seq_along(model_ids),
+                model_id = model_ids,
+                name = names,
+                run_path = rep(NA_character_, length(model_ids))
+            )
+            private$m_cases_valid <- TRUE
+            private$m_invalid_reason <- NULL
+            invisible(self)
+        },
+
+        invalidate_cases = function(reason) {
+            private$m_cases_valid <- FALSE
+            private$m_invalid_reason <- reason
+            invisible(self)
+        },
+
+        assert_cases_valid = function() {
+            if (!private$m_cases_valid) {
+                abort(private$m_invalid_reason %||%
+                    "Parametric models are stale. Regenerate them before running or saving.",
+                    "param_models_stale")
+            }
+            invisible(TRUE)
+        },
+
+        cases_valid = function() {
+            private$m_cases_valid
+        },
+
+        invalid_reason = function() {
+            private$m_invalid_reason
+        },
+
+        has_cases = function() {
+            nrow(private$m_cases) > 0L
+        },
+
+        case_count = function() {
+            nrow(private$m_cases)
+        },
+
+        case_has_names = function() {
+            nrow(private$m_cases) && all(!is.na(private$m_cases$name) & nzchar(private$m_cases$name))
+        },
+
+        case_names = function() {
+            if (!nrow(private$m_cases)) return(character())
+            nms <- private$m_cases$name
+            miss <- is.na(nms) | !nzchar(nms)
+            if (any(miss)) {
+                paths <- self$case_source_paths()
+                paths[is.na(paths)] <- self$case_model_paths()[is.na(paths)]
+                nms[miss] <- tools::file_path_sans_ext(basename(paths[miss]))
+            }
+            nms
+        },
+
+        rename_cases = function(names) {
+            self$assert_cases_valid()
+            assert_character(names, any.missing = FALSE, min.len = 1L)
+
+            n <- nrow(private$m_cases)
+            if (length(names) == 1L && n > 1L) {
+                names <- paste0(names, "_", lpad(seq_len(n), "0"))
+            } else if (length(names) != n) {
+                abort(paste(
+                    "Invalid parametric model names found.",
+                    n, "models created but", length(names), "new names given"
+                ), "param_names")
+            }
+
+            set(private$m_cases, NULL, "name", make.unique(names, sep = "_"))
+            invisible(self)
+        },
+
+        load_model = function(model_id) {
+            row <- private$model_row(model_id)
+            read_idf(row$prepared_path)
+        },
+
+        load_seed = function() {
+            if (is.null(private$m_seed_model_id)) {
+                abort("No seed model has been stored.", "job_model_store")
+            }
+            self$load_model(private$m_seed_model_id)
+        },
+
+        load_cases = function() {
+            self$assert_cases_valid()
+            if (!nrow(private$m_cases)) return(NULL)
+
+            out <- lapply(private$m_cases$model_id, self$load_model)
+            names(out) <- self$case_names()
+            out
+        },
+
+        model_source_path = function(model_id) {
+            private$model_row(model_id)$source_path
+        },
+
+        model_prepared_path = function(model_id) {
+            private$model_row(model_id)$prepared_path
+        },
+
+        model_version = function(model_id) {
+            numeric_version(private$model_row(model_id)$version)
+        },
+
+        model_signature = function(model_id) {
+            private$model_row(model_id)$signature
+        },
+
+        model_has_design_day = function(model_id) {
+            self$load_model(model_id)$is_valid_class("SizingPeriod:DesignDay")
+        },
+
+        case_model_ids = function() {
+            private$m_cases$model_id
+        },
+
+        case_source_paths = function() {
+            private$case_model_field("source_path")
+        },
+
+        case_model_paths = function() {
+            private$case_model_field("prepared_path")
+        },
+
+        case_versions = function() {
+            private$case_model_field("version")
+        },
+
+        case_signatures = function() {
+            sig <- private$case_model_field("signature")
+            names(sig) <- self$case_names()
+            sig
+        },
+
+        case_run_paths = function() {
+            private$m_cases$run_path
+        },
+
+        default_dir = function(seed = FALSE) {
+            if (seed && !is.null(private$m_seed_model_id)) {
+                path <- self$model_source_path(private$m_seed_model_id)
+                if (is.na(path)) path <- self$model_prepared_path(private$m_seed_model_id)
+                return(dirname(path))
+            }
+
+            if (nrow(private$m_cases)) {
+                paths <- self$case_source_paths()
+                paths[is.na(paths)] <- self$case_model_paths()[is.na(paths)]
+                return(dirname(paths[[1L]]))
+            }
+
+            if (!is.null(private$m_seed_model_id)) {
+                path <- self$model_source_path(private$m_seed_model_id)
+                if (is.na(path)) path <- self$model_prepared_path(private$m_seed_model_id)
+                return(dirname(path))
+            }
+
+            private$m_root
+        },
+
+        materialize_cases = function(paths, copy_external = FALSE) {
+            self$assert_cases_valid()
+            assert_character(paths, any.missing = FALSE)
+            assert_same_len(paths, private$m_cases$model_id)
+
+            paths <- normalizePath(paths, mustWork = FALSE)
+            resources <- vector("list", length(paths))
+            done <- character()
+
+            for (i in seq_along(paths)) {
+                dir <- dirname(paths[[i]])
+                if (!dir.exists(dir)) {
+                    dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+                }
+
+                if (paths[[i]] %in% done) next
+                model_id <- private$m_cases$model_id[[i]]
+
+                if (copy_external) {
+                    idf <- self$load_model(model_id)
+                    idf$save(paths[[i]], overwrite = TRUE, copy_external = TRUE)
+                    deps <- idf$external_deps()
+                    resources[[i]] <- if (length(deps)) deps else NULL
+                } else {
+                    file_copy(self$model_prepared_path(model_id), paths[[i]])
+                }
+                done <- c(done, paths[[i]])
+            }
+
+            set(private$m_cases, NULL, "run_path", paths)
+            list(paths = paths, resources = resources)
+        },
+
+        snapshot = function(dir, overwrite = FALSE) {
+            dir <- normalizePath(dir, mustWork = FALSE)
+            if (dir.exists(dir) && length(list.files(dir, all.files = TRUE, no.. = TRUE)) && !overwrite) {
+                abort(sprintf("Job model snapshot directory already exists: %s", surround(dir)),
+                    "job_json_file_exists")
+            }
+            if (!dir.exists(dir) && !dir.create(dir, recursive = TRUE, showWarnings = FALSE)) {
+                abort(sprintf("Failed to create job model snapshot directory: %s", surround(dir)),
+                    "job_json_dir")
+            }
+
+            models <- data.table::copy(private$m_models)
+            for (i in seq_len(nrow(models))) {
+                src <- models$prepared_path[[i]]
+                dest_dir <- file.path(dir, "models", sprintf("%04d", models$model_id[[i]]))
+                if (!dir.exists(dest_dir)) {
+                    dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
+                }
+                dest <- normalizePath(file.path(dest_dir, basename(src)), mustWork = FALSE)
+                file_copy(src, dest)
+                sig <- job_model_store_file_signature(dest)
+                models$prepared_path[[i]] <- dest
+                models$signature[[i]] <- sig$hash
+                models$size[[i]] <- sig$size
+                models$mtime[[i]] <- sig$mtime
+            }
+
+            list(
+                seed_model_id = private$m_seed_model_id,
+                cases_valid = private$m_cases_valid,
+                invalid_reason = private$m_invalid_reason,
+                models = models,
+                cases = data.table::copy(private$m_cases)
+            )
+        },
+
+        first_prepared_path = function() {
+            if (nrow(private$m_cases)) return(self$case_model_paths()[[1L]])
+            if (!is.null(private$m_seed_model_id)) return(self$model_prepared_path(private$m_seed_model_id))
+            private$m_models$prepared_path[[1L]]
+        },
+
+        models_table = function() {
+            data.table::copy(private$m_models)
+        },
+
+        cases_table = function() {
+            data.table::copy(private$m_cases)
+        }
+    ),
+
+    private = list(
+        m_root = NULL,
+        m_model_dir = NULL,
+        m_next_model_id = 1L,
+        m_models = NULL,
+        m_cases = NULL,
+        m_seed_model_id = NULL,
+        m_cases_valid = TRUE,
+        m_invalid_reason = NULL,
+
+        model_row = function(model_id) {
+            id <- as.integer(model_id)
+            row <- private$m_models[private$m_models$model_id == id]
+            if (!nrow(row)) abort("Unknown model id.", "job_model_store")
+            row[1L]
+        },
+
+        case_model_field = function(field) {
+            if (!nrow(private$m_cases)) return(character())
+            private$m_models[match(private$m_cases$model_id, private$m_models$model_id)][[field]]
+        }
+    )
+)
+
+job_model_store_models <- function(x = NULL) {
+    if (is.null(x)) {
+        return(data.table(
+            model_id = integer(),
+            role = character(),
+            name = character(),
+            source_path = character(),
+            prepared_path = character(),
+            version = character(),
+            sql = logical(),
+            dict = logical(),
+            signature = character(),
+            size = numeric(),
+            mtime = as.POSIXct(character(), tz = "UTC")
+        ))
+    }
+
+    x <- setDT(x)
+    if (!"mtime" %in% names(x)) set(x, NULL, "mtime", as.POSIXct(NA))
+    x
+}
+
+job_model_store_cases <- function(x = NULL) {
+    if (is.null(x)) {
+        return(data.table(
+            case_index = integer(),
+            model_id = integer(),
+            name = character(),
+            run_path = character()
+        ))
+    }
+
+    x <- setDT(x)
+    if (!"run_path" %in% names(x)) set(x, NULL, "run_path", NA_character_)
+    x
+}
+
+job_model_store_path <- function(path) {
+    if (is.null(path) || is.na(path)) return(NA_character_)
+    normalizePath(path, mustWork = FALSE)
+}
+
+job_model_store_scalar <- function(x) {
+    if (is.null(x) || !length(x) || is.na(x[[1L]])) return(NA_character_)
+    as.character(x[[1L]])
+}
+
+job_model_store_filename <- function(name, source_path, idf_path, model_id) {
+    if (!is.null(name) && length(name) && !is.na(name[[1L]]) && nzchar(name[[1L]])) {
+        stem <- make_filename(as.character(name[[1L]]), unique = FALSE)
+        return(paste0(stem, ".idf"))
+    }
+
+    path <- source_path
+    if (is.na(path)) path <- job_model_store_path(idf_path)
+    if (!is.na(path)) return(basename(path))
+
+    sprintf("model_%s.idf", lpad(model_id, "0"))
+}
+
+job_model_store_file_signature <- function(path) {
+    info <- file.info(path)
+    list(
+        hash = unname(tools::md5sum(path)),
+        size = as.numeric(info$size),
+        mtime = as.POSIXct(info$mtime, tz = "UTC")
+    )
+}

--- a/R/job.R
+++ b/R/job.R
@@ -839,7 +839,7 @@ EplusJob <- R6::R6Class(classname = "EplusJob", cloneable = FALSE,
 
     private = list(
         # PRIVATE FIELDS {{{
-        m_idf = NULL,
+        m_model_store = NULL,
         m_epw_path = NULL,
         m_job = NULL,
         m_log = NULL,
@@ -849,8 +849,8 @@ EplusJob <- R6::R6Class(classname = "EplusJob", cloneable = FALSE,
         uuid = function() private$m_log$uuid,
         log_new_uuid = function() log_new_uuid(private$m_log),
 
-        seed_uuid = function() get_priv_env(private$m_idf)$m_log$uuid,
-        log_seed_uuid = function() private$m_log$seed_uuid <- get_priv_env(private$m_idf)$m_log$uuid,
+        seed_uuid = function() private$m_model_store$case_signatures()[[1L]],
+        log_seed_uuid = function() private$m_log$seed_uuid <- private$seed_uuid(),
         cached_seed_uuid = function() private$m_log$seed_uuid,
 
         is_unsaved = function() private$m_log$unsaved,
@@ -883,22 +883,25 @@ eplus_job <- function(idf, epw) {
 
 # job_initialize {{{
 job_initialize <- function(self, private, idf, epw) {
-    # add Output:SQLite and Output:VariableDictionary if necessary
-    private$m_idf <- get_init_idf(idf)
+    store <- JobModelStore$new()
+    model_id <- store$add_input_model(idf, role = "input")
+    store$set_cases(model_id)
+    private$m_model_store <- store
+
     if (!is.null(epw)) private$m_epw_path <- get_init_epw(epw)
 
     # log if the input idf has been changed
     private$m_log <- new.env(hash = FALSE, parent = emptyenv())
-    private$m_log$unsaved <- attr(private$m_idf, "sql") || attr(private$m_idf, "dict")
+    private$m_log$unsaved <- FALSE
 
     # save uuid
-    private$log_seed_uuid()
+    private$m_log$seed_uuid <- if (is_idf(idf)) get_priv_env(idf)$uuid() else private$seed_uuid()
     private$log_new_uuid()
 }
 # }}}
 # job_version {{{
 job_version <- function(self, private) {
-    private$m_idf$version()
+    private$m_model_store$model_version(private$m_model_store$case_model_ids()[[1L]])
 }
 # }}}
 # job_path {{{
@@ -906,23 +909,17 @@ job_path <- function(self, private, type = c("all", "idf", "epw")) {
     type <- match.arg(type)
 
     path_epw <- if (is.null(private$m_epw_path)) NA_character_ else private$m_epw_path
+    path_idf <- private$m_model_store$case_source_paths()[[1L]]
+    if (is.na(path_idf)) path_idf <- private$m_model_store$case_model_paths()[[1L]]
     switch(type,
-        all = c(idf = private$m_idf$path(), epw = path_epw),
-        idf = private$m_idf$path(), epw = path_epw
+        all = c(idf = path_idf, epw = path_epw),
+        idf = path_idf, epw = path_epw
     )
 }
 # }}}
 # job_run {{{
 job_run <- function(self, private, epw, dir = NULL, wait = TRUE, force = FALSE,
                      echo = wait, copy_external = FALSE, readvars = TRUE) {
-    # stop if idf object has been changed accidentally
-    if (!identical(private$seed_uuid(), private$cached_seed_uuid())) {
-        abort(paste0("The Idf has been modified after job was created. ",
-            "Running this Idf will result in simulation outputs that may be not reproducible.",
-            "Please recreate the job using new Idf and then run it."
-        ))
-    }
-
     if (missing(epw)) epw <- private$m_epw_path
 
     if (is.null(epw)) {
@@ -933,24 +930,24 @@ job_run <- function(self, private, epw, dir = NULL, wait = TRUE, force = FALSE,
         path_epw <- private$m_epw_path
     }
 
-    path_idf <- private$m_idf$path()
+    model_id <- private$m_model_store$case_model_ids()[[1L]]
+    path_idf <- private$m_model_store$case_source_paths()[[1L]]
+    if (is.na(path_idf)) path_idf <- private$m_model_store$case_model_paths()[[1L]]
     if (is.null(dir)) {
         run_dir <- dirname(path_idf)
     } else {
         run_dir <- dir
-        path_idf <- normalizePath(file.path(run_dir, basename(path_idf)), mustWork = FALSE)
     }
+    path_idf <- normalizePath(file.path(run_dir, basename(path_idf)), mustWork = FALSE)
 
-    # if necessary, resave the model
-    if (private$is_unsaved() || !is.null(dir)) {
-        path_idf <- private$m_idf$save(path_idf, overwrite = TRUE, copy_external = copy_external)
-        private$log_seed_uuid()
-        private$log_saved()
-    }
+    materialized <- private$m_model_store$materialize_cases(path_idf,
+        copy_external = copy_external)
+    path_idf <- materialized$paths[[1L]]
+    private$log_saved()
 
     # when no epw is given, at least one design day object should exists
     if (is.null(private$m_epw_path)) {
-        if (!private$m_idf$is_valid_class("SizingPeriod:DesignDay")) {
+        if (!private$m_model_store$model_has_design_day(model_id)) {
             abort(paste0("When no weather file is given, input IDF should contain ",
                 "at least one 'SizingPeriod:DesignDay' object to enable ",
                 "Design-Day-only simulation."
@@ -980,17 +977,13 @@ job_run <- function(self, private, epw, dir = NULL, wait = TRUE, force = FALSE,
     private$m_log$start_time <- current()
     private$m_log$killed <- NULL
 
-    resrc <- NULL
-    if (copy_external) {
-        # check if external file dependencies are found
-        resrc <- private$m_idf$external_deps()
-        if (!length(resrc)) resrc <- NULL
-    }
+    resrc <- if (copy_external) materialized$resources[[1L]] else NULL
 
     private$m_job <- energyplus(
         model = path_idf, weather = path_epw, design_day = is.null(private$m_epw_path),
-        eso_to_ip = FALSE, readvars = readvars, echo = echo, wait = wait,
-        eplus = private$m_idf$version(), resources = resrc
+        output_dir = run_dir, eso_to_ip = FALSE, readvars = readvars, echo = echo,
+        wait = wait, eplus = private$m_model_store$model_version(model_id),
+        resources = resrc
     )
 
     private$log_new_uuid()
@@ -1040,8 +1033,9 @@ job_status <- function(self, private) {
 
     # if the model has not been run before
     if (is.null(proc)) {
-        if (!file.exists(private$m_idf$path())) {
-            warn(sprintf("Could not find local idf file '%s'.", surround(private$m_idf$path())))
+        path_idf <- private$m_model_store$case_source_paths()[[1L]]
+        if (!is.na(path_idf) && !file.exists(path_idf)) {
+            warn(sprintf("Could not find local idf file '%s'.", surround(path_idf)))
         }
         return(status)
     }
@@ -1078,16 +1072,18 @@ job_status <- function(self, private) {
     }
 
     status$changed_after <- FALSE
-    if (!identical(private$cached_seed_uuid(), private$seed_uuid())) {
-        status$changed_after <- TRUE
-    }
 
     status
 }
 # }}}
 # job_output_dir {{{
 job_output_dir <- function(self, private, open = FALSE) {
-    dir <- normalizePath(dirname(private$m_idf$path()), mustWork = FALSE)
+    if (!is.null(private$m_job) && !inherits(private$m_job, "process")) {
+        dir <- normalizePath(private$m_job$output_dir, mustWork = FALSE)
+    } else {
+        dir <- private$m_model_store$default_dir()
+        dir <- normalizePath(dir, mustWork = FALSE)
+    }
     if (!open) return(dir)
     if (open) {
         if (is.null(dir)) {
@@ -1155,7 +1151,12 @@ job_list_files <- function(self, private, simplify = FALSE, full = FALSE) {
 # }}}
 # job_locate_output {{{
 job_locate_output <- function(self, private, suffix = ".err", strict = TRUE, must_exist = TRUE) {
-    out <- paste0(tools::file_path_sans_ext(private$m_idf$path()), suffix)
+    path_idf <- private$m_model_store$case_run_paths()[[1L]]
+    if (is.na(path_idf)) {
+        path_idf <- private$m_model_store$case_source_paths()[[1L]]
+        if (is.na(path_idf)) path_idf <- private$m_model_store$case_model_paths()[[1L]]
+    }
+    out <- paste0(tools::file_path_sans_ext(path_idf), suffix)
 
     if (strict) {
         status <- job_status(self, private)
@@ -1273,10 +1274,12 @@ job_tabular_data <- function(self, private, report_name = NULL, report_for = NUL
 # job_print {{{
 job_print <- function(self, private) {
     path_epw <- if (is.null(private$m_epw_path)) NULL else private$m_epw_path
+    path_idf <- private$m_model_store$case_source_paths()[[1L]]
+    if (is.na(path_idf)) path_idf <- private$m_model_store$case_model_paths()[[1L]]
     print_job_header(title = "EnergPlus Simulation Job",
-        path_idf = private$m_idf$path(),
+        path_idf = path_idf,
         path_epw = path_epw,
-        eplus_ver = private$m_idf$version(),
+        eplus_ver = job_version(self, private),
         name_idf = "Model", name_epw = "Weather"
     )
     status <- job_status(self, private)

--- a/R/param.R
+++ b/R/param.R
@@ -9,11 +9,11 @@ NULL
 #' `ParametricJob` class provides a prototype of conducting parametric analysis
 #' of EnergyPlus simulations.
 #'
-#' Basically, it is a collection of multiple `EplusJob` objects. However, the
-#' model is first parsed and the [Idf] object is stored internally, instead of
-#' storing only the path of Idf like in [EplusJob] class. Also, an object in
-#' `Output:SQLite` with `Option Type` value of `SimpleAndTabular` will be
-#' automatically created if it does not exists, like [Idf] class does.
+#' Basically, it is a collection of multiple `EplusJob` objects. The seed model
+#' and generated models are stored internally as prepared model snapshots and
+#' parsed as [Idf] objects only when needed. Also, an object in `Output:SQLite`
+#' with `Option Type` value of `SimpleAndTabular` will be automatically created
+#' if it does not exists, like [Idf] class does.
 #'
 #' @docType class
 #' @name ParametricJob
@@ -54,14 +54,12 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
         #' }
         #'
         initialize = function(idf, epw) {
-            # add Output:SQLite and Output:VariableDictionary if necessary
-            idf <- get_init_idf(idf, sql = TRUE, dict = TRUE)
-
-            private$m_seed <- idf
+            private$m_model_store <- JobModelStore$new()
+            private$m_model_store$set_seed(idf)
 
             # log if the input idf has been changed
             private$m_log <- new.env(hash = FALSE, parent = emptyenv())
-            private$m_log$unsaved <- attr(idf, "sql") || attr(idf, "dict")
+            private$m_log$unsaved <- logical()
 
             if (!is.null(epw)) private$m_epws_path <- get_init_epw(epw)
 
@@ -92,18 +90,25 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
 
         # seed {{{
         #' @description
-        #' Get the seed [Idf] object
+        #' Get or replace the seed [Idf] object
         #'
         #' @details
-        #' `$seed()` returns the parsed input seed [Idf] object.
+        #' `$seed()` returns the parsed input seed [Idf] object. `$seed(new)`
+        #' replaces the seed model. If parametric models have already been
+        #' generated, they become stale and cannot be run or saved until
+        #' `$param()` or `$apply_measure()` is called again.
+        #'
+        #' @param new A path to an EnergyPlus IDF file or an [Idf] object used
+        #'   to replace the current seed. If missing, the current seed is
+        #'   returned.
         #'
         #' @examples
         #' \dontrun{
         #' param$seed()
         #' }
         #'
-        seed = function()
-            param_seed(self, private),
+        seed = function(new)
+            param_seed(self, private, new),
         # }}}
 
         # weather {{{
@@ -308,13 +313,10 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
         #' method. Model names are assigned in the same way as the `.names`
         #' argument in
         #' \href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}}.
-        #' If no measure has been applied, `NULL` is returned. Note that it is
-        #' not recommended to conduct any extra modification on those models
-        #' directly, after they were created using
-        #' \href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}},
-        #' as this may lead to an un-reproducible process. A warning message
-        #' will be issued if any of those models has been modified when running
-        #' simulations.
+        #' If no measure has been applied, `NULL` is returned. Returned [Idf]
+        #' objects are detached copies of the internally stored prepared
+        #' snapshots. Modifying them will not change the models that are used
+        #' for `$run()` or `$save()`.
         #'
         #' @param names A character vector of new names for parametric models.
         #'        If a single string, it will be used as a prefix and all models
@@ -490,11 +492,8 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
     ),
 
     private = list(
-        # PRIVATE FIELDS {{{
-        m_seed = NULL,
-        # }}}
         # PRIVATE FUNCTIONS {{{
-        seed_uuid = function() get_priv_env(private$m_seed)$m_log$uuid,
+        seed_uuid = function() private$m_model_store$model_signature(private$m_model_store$seed_model_id()),
         log_seed_uuid = function() private$m_log$seed_uuid <- private$seed_uuid(),
         cached_seed_uuid = function() private$m_log$seed_uuid
         # }}}
@@ -524,18 +523,26 @@ param_job <- function(idf, epw) {
 
 # param_version {{{
 param_version <- function(self, private) {
-    private$m_seed$version()
+    private$m_model_store$model_version(private$m_model_store$seed_model_id())
 }
 # }}}
 # param_seed {{{
-param_seed <- function(self, private) {
-    private$m_seed
+param_seed <- function(self, private, new) {
+    if (missing(new)) {
+        return(private$m_model_store$load_seed())
+    }
+
+    private$m_model_store$set_seed(new)
+    private$m_log$unsaved <- rep(FALSE, private$m_model_store$case_count())
+    private$log_seed_uuid()
+    private$log_new_uuid()
+    invisible(self)
 }
 # }}}
 # param_models {{{
 param_models <- function(self, private, names = NULL) {
     assert_character(names, any.missing = FALSE, null.ok = TRUE, min.len = 1L)
-    if (!length(private$m_idfs)) {
+    if (!private$m_model_store$has_cases()) {
         verbose_info("No parametric models have been created.")
         if (!is.null(names)) {
             verbose_info("Nothing to rename.")
@@ -543,20 +550,13 @@ param_models <- function(self, private, names = NULL) {
         return(NULL)
     }
 
-    if (!length(names)) return(private$m_idfs)
+    private$m_model_store$assert_cases_valid()
 
-    if (length(names) == 1L && length(private$m_idfs) > 1L) {
-        names <- paste0(names, sep = "_", lpad(seq_along(private$m_idfs), "0"))
-    } else if (length(names) != length(private$m_idfs)) {
-        abort(paste(
-            "Invalid parametric model names found.",
-            length(private$m_idfs), "models created but", length(names), "new names given"
-        ), "param_names")
+    if (length(names)) {
+        private$m_model_store$rename_cases(names)
     }
 
-    setattr(private$m_idfs, "names", names)
-
-    private$m_idfs
+    private$m_model_store$load_cases()
 }
 # }}}
 # param_weather {{{
@@ -566,19 +566,26 @@ param_weather <- function(self, private) {
 # }}}
 # param_cases {{{
 param_cases <- function(self, private, param = NULL) {
-    if (is.null(private$m_idfs)) {
+    if (!private$m_model_store$has_cases()) {
         verbose_info("No parametric models have been created.")
         return(NULL)
     }
+    private$m_model_store$assert_cases_valid()
 
     cases <- copy(private$m_log$params)
 
-    if (!private$m_log$simple) return(cases)
+    if (!private$m_log$simple) {
+        if ("case" %in% names(cases)) {
+            set(cases, NULL, "case", private$m_model_store$case_names())
+        }
+        return(cases)
+    }
 
     # remove duplicates
     cases <- unique(cases, by = c("case_index", "param_index"))
     # add field type
-    add_field_property(get_priv_env(private$m_seed)$idd_env(), cases, "type_enum")
+    seed <- private$m_model_store$load_seed()
+    add_field_property(get_priv_env(seed)$idd_env(), cases, "type_enum")
     # get value list
     set(cases, NULL, "value", get_value_list(cases))
     # change to wide
@@ -587,7 +594,7 @@ param_cases <- function(self, private, param = NULL) {
         set(cases, NULL, col, unlist(cases[[col]], FALSE, FALSE))
     }
     setnames(cases, "case_index", "index")
-    set(cases, NULL, "case", names(private$m_idfs))
+    set(cases, NULL, "case", private$m_model_store$case_names())
     setcolorder(cases, c("index", "case"))
 
     cases[]
@@ -598,8 +605,9 @@ param_param <- function(self, private, ..., .names = NULL, .cross = FALSE, .env 
     assert_flag(.cross)
     assert_character(.names, null.ok = TRUE, any.missing = FALSE)
 
+    seed <- private$m_model_store$load_seed()
     l <- expand_idf_dots_value(
-        get_priv_env(private$m_seed)$idd_env(), get_priv_env(private$m_seed)$idf_env(),
+        get_priv_env(seed)$idd_env(), get_priv_env(seed)$idf_env(),
         ..., .type = "object", .complete = FALSE, .unique = TRUE, .empty = FALSE,
         .default = FALSE, .scalar = FALSE, .pair = FALSE, .env = .env)
 
@@ -732,6 +740,8 @@ param_apply_measure <- function(self, private, measure, ..., .names = NULL, .env
     private$m_log$measure_name <- mea_nm
     private$m_log$bare <- bare
 
+    seed <- private$m_model_store$load_seed()
+
     # progress bar
     progress_bar <- cli::cli_progress_bar(
         total = max(viapply(list(...), length)), clear = TRUE,
@@ -741,7 +751,7 @@ param_apply_measure <- function(self, private, measure, ..., .names = NULL, .env
     # create models
     out <- mapply(measure_wrapper, ...,
         MoreArgs = list(
-            idf = private$m_seed,
+            idf = seed,
             .__PROGRESS_BAR__ = list(id = progress_bar, env = environment())
         ),
         SIMPLIFY = FALSE, USE.NAMES = FALSE
@@ -776,12 +786,16 @@ param_apply_measure <- function(self, private, measure, ..., .names = NULL, .env
     private$m_log$params <- cases
     private$m_log$simple <- FALSE
 
-    private$m_idfs <- out
+    model_ids <- viapply(seq_along(out), function(i) {
+        private$m_model_store$add_model(out[[i]], role = "case",
+            name = nms[[i]], source_path = NULL, sql = TRUE, dict = TRUE)
+    })
+    private$m_model_store$set_cases(model_ids, nms)
 
     # log unique ids
     private$log_idf_uuid()
     private$log_new_uuid()
-    private$m_log$unsaved <- rep(TRUE, length(out))
+    private$m_log$unsaved <- rep(FALSE, length(out))
 
     if (bare) {
         mea_nm <- "function"
@@ -800,27 +814,13 @@ param_apply_measure <- function(self, private, measure, ..., .names = NULL, .env
 param_run <- function(self, private, output_dir = NULL, wait = TRUE,
                        force = FALSE, copy_external = FALSE, echo = wait,
                        separate = TRUE, readvars = TRUE) {
-    if (is.null(private$m_idfs)) {
+    if (!private$m_model_store$has_cases()) {
         abort("No measure has been applied.")
     }
-
-    # check if generated models have been modified outside
-    uuid <- private$idf_uuid()
-    if (any(i <- uuid != private$cached_idf_uuid())) {
-        warn(paste0(
-                "Some of the parametric models have been modified after created using `$apply_measure()`. ",
-                "Running these models will result in simulation outputs that may be not reproducible. ",
-                "It is recommended to re-apply your original measure using `$apply_measure()` and call `$run()` again. ",
-                "Models that have been modified are listed below:\n",
-                paste0(" #", lpad(seq_along(uuid)[i], "0"), " | ", names(uuid)[i], collapse = "\n")
-            ),
-            "param_model_modified"
-        )
-        private$log_unsaved(which(i))
-    }
+    private$m_model_store$assert_cases_valid()
 
     private$log_new_uuid()
-    if (is.null(output_dir)) output_dir <- dirname(private$m_seed$path())
+    if (is.null(output_dir)) output_dir <- private$m_model_store$default_dir(seed = TRUE)
     epgroup_run_models(self, private, output_dir, wait, force, copy_external, echo, separate, readvars)
 }
 # }}}
@@ -828,16 +828,12 @@ param_run <- function(self, private, output_dir = NULL, wait = TRUE,
 #' @importFrom checkmate assert_string
 param_save <- function(self, private, dir = NULL, separate = TRUE, copy_external = FALSE) {
     assert_string(dir, null.ok = TRUE)
-    if (is.null(private$m_idfs)) {
+    if (!private$m_model_store$has_cases()) {
         abort("No parametric models found since no measure has been applied.")
     }
+    private$m_model_store$assert_cases_valid()
 
-    # restore uuid
-    uuid <- private$idf_uuid()
-
-    path_idf <- normalizePath(private$m_seed$path(), mustWork = TRUE)
-
-    if (is.null(dir)) dir <- dirname(path_idf)
+    if (is.null(dir)) dir <- private$m_model_store$default_dir(seed = TRUE)
 
     if (!dir.exists(dir)) {
         # nocov start
@@ -850,7 +846,7 @@ param_save <- function(self, private, dir = NULL, separate = TRUE, copy_external
         # nocov end
     }
 
-    filename <- make_filename(names(private$m_idfs))
+    filename <- make_filename(private$m_model_store$case_names())
 
     if (separate) {
         path_param <- file.path(dir, filename, paste0(filename, ".idf"))
@@ -860,9 +856,8 @@ param_save <- function(self, private, dir = NULL, separate = TRUE, copy_external
     }
 
     # save model
-    path_param <- apply2_chr(private$m_idfs, path_param,
-        function(x, y) x$save(y, overwrite = TRUE, copy_external = copy_external)
-    )
+    path_param <- private$m_model_store$materialize_cases(path_param,
+        copy_external = copy_external)$paths
     # copy weather
     path_epw <- private$m_epws_path
     if (!is.null(path_epw)) {
@@ -874,29 +869,31 @@ param_save <- function(self, private, dir = NULL, separate = TRUE, copy_external
         path_epw <- NA_character_
     }
 
-    # assign original uuid in case it is updated when saving
-    # if not assign original here, the model modification checkings in `$run()`
-    # may be incorrect.
-    for (i in seq_along(uuid)) {
-        log <- get_priv_env(private$m_idfs[[i]])$m_log
-        log$uuid <- uuid[[i]]
-    }
-
     data.table(model = path_param, weather = path_epw)
 }
 # }}}
 # param_print {{{
 param_print <- function(self, private) {
+    path_idf <- private$m_model_store$model_source_path(private$m_model_store$seed_model_id())
+    if (is.na(path_idf)) {
+        path_idf <- private$m_model_store$model_prepared_path(private$m_model_store$seed_model_id())
+    }
     print_job_header(title = "EnergPlus Parametric Simulation Job",
-        path_idf = private$m_seed$path(),
+        path_idf = path_idf,
         path_epw = private$m_epws_path,
-        eplus_ver = private$m_seed$version(),
+        eplus_ver = param_version(self, private),
         name_idf = "Seed", name_epw = "Weather"
     )
 
-    if (is.null(private$m_idfs)) {
+    if (!private$m_model_store$has_cases()) {
         cli::cat_line("<< No measure has been applied >>",
             col = "white", background_col = "blue")
+        return(invisible(self))
+    }
+
+    if (!private$m_model_store$cases_valid()) {
+        cli::cat_line("<< Parametric models are stale. Regenerate them before running or saving. >>",
+            col = "white", background_col = "red")
         return(invisible(self))
     }
 
@@ -904,7 +901,7 @@ param_print <- function(self, private) {
         cli::cat_line(paste0("Applied Measure: ", surround(private$m_log$measure_name)))
     }
 
-    cli::cat_line(paste0("Parametric Models [", length(private$m_idfs), "]: "))
+    cli::cat_line(paste0("Parametric Models [", private$m_model_store$case_count(), "]: "))
 
     epgroup_print_status(self, private, epw = FALSE)
 }

--- a/R/reload.R
+++ b/R/reload.R
@@ -85,12 +85,11 @@ reload.Epw <- function (x, ...) {
 #' @export
 reload.EplusJob <- function (x, ...) {
     priv <- get_priv_env(x)
-    reload.Idf(priv$m_idf)
 
-    if (!is.null(priv$m_job$file)) {
+    if (!is.null(priv$m_job) && !is.null(priv$m_job$file)) {
         priv$m_job$file <- setDT(priv$m_job$file)
     }
-    if (!is.null(priv$m_job$run)) {
+    if (!is.null(priv$m_job) && !is.null(priv$m_job$run)) {
         priv$m_job$run <- setDT(priv$m_job$run)
     }
 
@@ -100,9 +99,8 @@ reload.EplusJob <- function (x, ...) {
 #' @export
 reload.EplusGroupJob <- function (x, ...) {
     priv <- get_priv_env(x)
-    for (idf in priv$m_idfs) reload.Idf(idf, ...)
 
-    if (inherits(priv$m_job$jobs, "data.table")) {
+    if (!is.null(priv$m_job) && inherits(priv$m_job$jobs, "data.table")) {
         priv$m_job$jobs <- setDT(priv$m_job$jobs)
     }
 
@@ -112,10 +110,8 @@ reload.EplusGroupJob <- function (x, ...) {
 #' @export
 reload.ParametricJob <- function (x, ...) {
     priv <- get_priv_env(x)
-    reload.Idf(priv$m_seed)
-    if (!is.null(priv$m_idfs)) for (idf in priv$m_idfs) reload.Idf(idf, ...)
 
-    if (inherits(priv$m_job$jobs, "data.table")) {
+    if (!is.null(priv$m_job) && inherits(priv$m_job$jobs, "data.table")) {
         priv$m_job$jobs <- setDT(priv$m_job$jobs)
     }
     x

--- a/man/ParametricJob.Rd
+++ b/man/ParametricJob.Rd
@@ -27,11 +27,11 @@ of EnergyPlus simulations.
 For details on \code{ParametricJob}, please see \link{ParametricJob} class.
 }
 \details{
-Basically, it is a collection of multiple \code{EplusJob} objects. However, the
-model is first parsed and the \link{Idf} object is stored internally, instead of
-storing only the path of Idf like in \link{EplusJob} class. Also, an object in
-\code{Output:SQLite} with \verb{Option Type} value of \code{SimpleAndTabular} will be
-automatically created if it does not exists, like \link{Idf} class does.
+Basically, it is a collection of multiple \code{EplusJob} objects. The seed model
+and generated models are stored internally as prepared model snapshots and
+parsed as \link{Idf} objects only when needed. Also, an object in \code{Output:SQLite}
+with \verb{Option Type} value of \code{SimpleAndTabular} will be automatically created
+if it does not exists, like \link{Idf} class does.
 }
 \examples{
 
@@ -352,13 +352,25 @@ param$version()
 \if{html}{\out{<a id="method-ParametricJob-seed"></a>}}
 \if{latex}{\out{\hypertarget{method-ParametricJob-seed}{}}}
 \subsection{Method \code{seed()}}{
-Get the seed \link{Idf} object
+Get or replace the seed \link{Idf} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$seed()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$seed(new)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{new}}{A path to an EnergyPlus IDF file or an \link{Idf} object used
+to replace the current seed. If missing, the current seed is
+returned.}
+}
+\if{html}{\out{</div>}}
+}
 \subsection{Details}{
-\verb{$seed()} returns the parsed input seed \link{Idf} object.
+\verb{$seed()} returns the parsed input seed \link{Idf} object. \verb{$seed(new)}
+replaces the seed model. If parametric models have already been
+generated, they become stale and cannot be run or saved until
+\verb{$param()} or \verb{$apply_measure()} is called again.
 }
 
 \subsection{Examples}{
@@ -634,13 +646,10 @@ returned. Default: \code{NULL}.}
 method. Model names are assigned in the same way as the \code{.names}
 argument in
 \href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}}.
-If no measure has been applied, \code{NULL} is returned. Note that it is
-not recommended to conduct any extra modification on those models
-directly, after they were created using
-\href{../../eplusr/html/ParametricJob.html#method-apply_measure}{\code{$apply_measure()}},
-as this may lead to an un-reproducible process. A warning message
-will be issued if any of those models has been modified when running
-simulations.
+If no measure has been applied, \code{NULL} is returned. Returned \link{Idf}
+objects are detached copies of the internally stored prepared
+snapshots. Modifying them will not change the models that are used
+for \verb{$run()} or \verb{$save()}.
 }
 
 \subsection{Examples}{

--- a/man/save_job.Rd
+++ b/man/save_job.Rd
@@ -50,14 +50,12 @@ and a checksum when available. These file metadata are informational and do
 not prevent \code{read_job()} from restoring the job object if files have been
 removed.
 }
-\section{Parametric jobs}{
+\section{Model snapshots}{
 
-For \link{ParametricJob}, the manifest stores the seed model, weather file,
-generated model files, case data, and available run results. If generated
-models only exist in memory, \code{save_job()} snapshots them into a
-\verb{<manifest>_files} directory next to the JSON file. Arbitrary R measure
-functions passed to \verb{$apply_measure()} are not serialized; the restored job
-uses the generated model snapshots and stored case data.
+The manifest stores a prepared model snapshot store for \link{EplusJob},
+\link{EplusGroupJob}, and \link{ParametricJob}. For \link{ParametricJob}, arbitrary R
+measure functions passed to \verb{$apply_measure()} are not serialized; the
+restored job uses the generated model snapshots and stored case data.
 }
 
 \examples{

--- a/tests/testthat/test-idd.R
+++ b/tests/testthat/test-idd.R
@@ -26,6 +26,7 @@ test_that("can read IDD", {
     expect_error(use_idd(""), class = "eplusr_error_read_lines")
 
     # can directly download from EnergyPlus GitHub repo
+    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_DOWNLOAD_IDD_") != "")
     expect_s3_class(idd <- use_idd("8.4", download = TRUE), "Idd")
 
     # can directly return if input is an Idd

--- a/tests/testthat/test-job-json.R
+++ b/tests/testthat/test-job-json.R
@@ -37,6 +37,9 @@ test_that("save_job() and read_job() round-trip job manifests", {
 
     expect_equal(save_job(job, path), path)
     expect_true(jsonlite::validate(paste(readLines(path), collapse = "\n")))
+    manifest <- jsonlite::fromJSON(path,
+        simplifyVector = FALSE, simplifyDataFrame = FALSE, simplifyMatrix = FALSE)
+    expect_named(manifest$inputs, c("model_store", "epw"))
 
     restored <- read_job(path)
     expect_s3_class(restored, "EplusJob")
@@ -49,10 +52,22 @@ test_that("save_job() and read_job() round-trip job manifests", {
 
     invalid_kind <- jsonlite::fromJSON(path,
         simplifyVector = FALSE, simplifyDataFrame = FALSE, simplifyMatrix = FALSE)
-    invalid_kind$inputs$idfs <- invalid_kind$inputs$idf
+    invalid_kind$inputs$idfs <- "unexpected.idf"
     invalid <- tempfile(fileext = ".json")
     write_job_manifest(invalid_kind, invalid)
-    expect_error(read_job(invalid), class = "eplusr_error_job_json_kind")
+    expect_error(read_job(invalid), "job manifest\\$inputs")
+
+    invalid_store <- manifest
+    invalid_store$inputs$model_store$models[[1L]]$prepared_path <- NULL
+    invalid <- tempfile(fileext = ".json")
+    write_job_manifest(invalid_store, invalid)
+    expect_error(read_job(invalid), "job manifest\\$inputs\\$model_store")
+
+    invalid_ref <- manifest
+    invalid_ref$inputs$model_store$cases[[1L]]$model_id <- 999L
+    invalid <- tempfile(fileext = ".json")
+    write_job_manifest(invalid_ref, invalid)
+    expect_error(read_job(invalid), class = "eplusr_error_job_json_model_store")
 })
 
 test_that("completed EplusJob results can be restored from JSON", {
@@ -151,9 +166,9 @@ test_that("ParametricJob generated models are snapshotted and restored", {
     save_job(param, path)
 
     snap_dir <- file.path(dirname(path),
-        paste0(tools::file_path_sans_ext(basename(path)), "_files"))
+        paste0(tools::file_path_sans_ext(basename(path)), "_files"), "model_store")
     expect_true(dir.exists(snap_dir))
-    expect_length(list.files(snap_dir, "\\.idf$", full.names = TRUE), 2L)
+    expect_length(list.files(snap_dir, "\\.idf$", full.names = TRUE, recursive = TRUE), 3L)
 
     invalid_kind <- jsonlite::fromJSON(path,
         simplifyVector = FALSE, simplifyDataFrame = FALSE, simplifyMatrix = FALSE)

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -14,6 +14,7 @@ test_that("Parametric methods", {
 
     # $seed()
     expect_s3_class(param$seed(), "Idf")
+    expect_s3_class(param$seed(new = path_idf), "ParametricJob")
 
     # $weather()
     expect_s3_class(param$weather(), "Epw")
@@ -101,6 +102,10 @@ test_that("$models()", {
 
     expect_equal(names(param$models(names = "model")), c("model_1", "model_2"))
     expect_error(names(param$models(names = c("a", "b", "c"))), "names")
+
+    models <- param$models()
+    models[[1L]]$set(Material := list(thickness = 0.05))
+    expect_false(param$models()[[1L]]$is_unsaved())
 })
 
 test_that("$cases()", {
@@ -157,12 +162,29 @@ test_that("$run()", {
 
     param$apply_measure(function(idf, num) idf, num = 1:2)
     param$models()[[1L]]$set(Material := list(thickness = 0.05))
-    expect_warning(param$run())
+    expect_s3_class(param$run(), "ParametricJob")
 
     path_epw <- path_eplus_weather(LATEST_EPLUS_VER, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")
     param <- param_job(path, path_epw)
     param$apply_measure(function(idf, num) idf, num = 1:2)
     expect_s3_class(param$run(), "ParametricJob")
+})
+
+test_that("$seed(new=) invalidates generated parametric models", {
+    skip_on_cran()
+
+    path <- copy_eplus_example(LATEST_EPLUS_VER, "5Zone_Transformer.idf")
+    param <- param_job(path, NULL)
+    param$apply_measure(function(idf, num) idf, num = 1:2)
+
+    expect_s3_class(param$seed(new = path), "ParametricJob")
+    expect_error(param$models(), class = "eplusr_error_param_models_stale")
+    expect_error(param$cases(), class = "eplusr_error_param_models_stale")
+    expect_error(param$save(), class = "eplusr_error_param_models_stale")
+    expect_error(param$run(), class = "eplusr_error_param_models_stale")
+
+    expect_s3_class(param$apply_measure(function(idf, num) idf, num = 1:2), "ParametricJob")
+    expect_equal(names(param$models()), c("case_1", "case_2"))
 })
 
 test_that("$save()", {

--- a/tests/testthat/test-reload.R
+++ b/tests/testthat/test-reload.R
@@ -78,10 +78,10 @@ test_that("Reload", {
 
     expect_idf_reloaded(idf)
     expect_idf_reloaded(epw)
-    expect_idf_reloaded(get_priv_env(job)$m_idf)
-    expect_idf_reloaded(get_priv_env(par)$m_seed)
-    lapply(get_priv_env(grp)$m_idfs, expect_idf_reloaded)
-    lapply(get_priv_env(par)$m_idfs, expect_idf_reloaded)
+    expect_idf_reloaded(get_priv_env(job)$m_model_store$load_cases()[[1L]])
+    expect_idf_reloaded(get_priv_env(par)$m_model_store$load_seed())
+    lapply(get_priv_env(grp)$m_model_store$load_cases(), expect_idf_reloaded)
+    lapply(get_priv_env(par)$m_model_store$load_cases(), expect_idf_reloaded)
     expect_true(data.table::truelength(get_priv_env(grp)$m_job$jobs) > 0L)
     expect_true(data.table::truelength(get_priv_env(par)$m_job$jobs) > 0L)
 


### PR DESCRIPTION
Closes #615.

Stores prepared IDF snapshots in an internal `JobModelStore` for `EplusJob`, `EplusGroupJob`, and `ParametricJob` instead of keeping live `Idf` objects. Parametric models are generated only through the existing measure path; `models()` returns detached copies; `seed(new = ...)` invalidates existing generated cases and blocks save/run until regenerated.

Updates job JSON manifests to persist the model_store schema and validate model/case references.