### PR TITLE
feat(param): support multiple weather cases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.3.9008
+Version: 0.16.3.9009
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New features
 
+* `ParametricJob` can now combine one seed IDF with multiple EPW weather cases
+  using `$weathers()`. `$cases(type = "run")` reports the actual simulation
+  cases while `$cases()` keeps the existing parameter-case behavior (#617).
+
 * Store prepared job model snapshots instead of keeping `Idf` objects alive
   inside `EplusJob`, `EplusGroupJob`, and `ParametricJob`, reducing memory use
   for large simulation sets. `ParametricJob$seed(new = ...)` can replace the

--- a/R/job-json.R
+++ b/R/job-json.R
@@ -139,177 +139,333 @@ read_job <- function(path, validate = TRUE, verify = c("warn", "error", "ignore"
 JOB_JSON_FORMAT <- "eplusr-job"
 JOB_JSON_MANIFEST_VERSION <- 2L
 
-SCHEMA_EPLUS_JOB_MANIFEST <- schema_flatten(schema_read('{
-  "version": "1.0.0",
-  "$defs": {
-    "nullable_string": {
-      "check": { "kind": "string", "min.chars": 1, "null.ok": true, "na.ok": true }
+job_json_schema <- function(root) {
+    schema_flatten(schema_read(paste0(
+        '{"version":"1.0.0","$defs":', JOB_JSON_SCHEMA_DEFS, ',', root, '}'
+    )))
+}
+
+JOB_JSON_SCHEMA_DEFS <- '{
+  "nullable_string": {
+    "check": { "kind": "string", "min.chars": 1, "null.ok": true, "na.ok": true }
+  },
+  "string_vector": {
+    "any": [
+      { "check": { "kind": "character", "any.missing": true, "null.ok": true } },
+      {
+        "check": { "kind": "list", "null.ok": true },
+        "keys": { "type": "unnamed" },
+        "rest": { "$ref": "#/$defs/nullable_string" }
+      }
+    ]
+  },
+  "flag_or_null": {
+    "check": { "kind": "flag", "null.ok": true }
+  },
+  "logical_vector": {
+    "any": [
+      { "check": { "kind": "logical", "null.ok": true } },
+      {
+        "check": { "kind": "list", "null.ok": true },
+        "keys": { "type": "unnamed" },
+        "rest": { "$ref": "#/$defs/flag_or_null" }
+      }
+    ]
+  },
+  "text_or_array": {
+    "any": [
+      { "check": { "kind": "character", "any.missing": true, "null.ok": true } },
+      { "check": { "kind": "list", "null.ok": true } }
+    ]
+  },
+  "generic_rows": {
+    "check": { "kind": "list", "null.ok": true }
+  },
+  "weather_case_row": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": ["weather_index", "weather_case", "epw"],
+      "subset.of": ["weather_index", "weather_case", "epw"]
     },
-    "string_vector": {
-      "any": [
-        { "check": { "kind": "character", "any.missing": true, "null.ok": true } },
-        {
-          "check": { "kind": "list", "null.ok": true },
-          "keys": { "type": "unnamed" },
-          "rest": { "$ref": "#/$defs/nullable_string" }
-        }
+    "fields": {
+      "weather_index": { "check": { "kind": "int", "lower": 1 } },
+      "weather_case": { "check": { "kind": "string", "min.chars": 1 } },
+      "epw": { "$ref": "#/$defs/nullable_string" }
+    }
+  },
+  "weather_cases": {
+    "check": { "kind": "list", "null.ok": true },
+    "keys": { "type": "unnamed" },
+    "rest": { "$ref": "#/$defs/weather_case_row" }
+  },
+  "parametric_model_case_row": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": ["model_index", "model_id", "model_case"],
+      "subset.of": ["model_index", "model_id", "model_case"]
+    },
+    "fields": {
+      "model_index": { "check": { "kind": "int", "lower": 1 } },
+      "model_id": { "check": { "kind": "int", "lower": 1 } },
+      "model_case": { "check": { "kind": "string", "min.chars": 1 } }
+    }
+  },
+  "parametric_model_cases": {
+    "check": { "kind": "list", "null.ok": true },
+    "keys": { "type": "unnamed" },
+    "rest": { "$ref": "#/$defs/parametric_model_case_row" }
+  },
+  "parametric_run_case_row": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": [
+        "index", "case", "model_index", "model_case",
+        "weather_index", "weather_case", "epw"
       ]
     },
-    "flag_or_null": {
-      "check": { "kind": "flag", "null.ok": true }
-    },
-    "logical_vector": {
-      "any": [
-        { "check": { "kind": "logical", "null.ok": true } },
-        {
-          "check": { "kind": "list", "null.ok": true },
-          "keys": { "type": "unnamed" },
-          "rest": { "$ref": "#/$defs/flag_or_null" }
-        }
+    "fields": {
+      "index": { "check": { "kind": "int", "lower": 1 } },
+      "case": { "check": { "kind": "string", "min.chars": 1 } },
+      "model_index": { "check": { "kind": "int", "lower": 1 } },
+      "model_case": { "check": { "kind": "string", "min.chars": 1 } },
+      "weather_index": { "check": { "kind": "int", "lower": 1 } },
+      "weather_case": { "check": { "kind": "string", "min.chars": 1 } },
+      "epw": { "$ref": "#/$defs/nullable_string" }
+    }
+  },
+  "parametric_run_cases": {
+    "check": { "kind": "list", "null.ok": true },
+    "keys": { "type": "unnamed" },
+    "rest": { "$ref": "#/$defs/parametric_run_case_row" }
+  },
+  "result_file": {
+    "check": { "kind": "list", "null.ok": true },
+    "rest": { "$ref": "#/$defs/text_or_array" }
+  },
+  "model_store_model": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": [
+        "model_id", "role", "name", "source_path", "prepared_path",
+        "version", "sql", "dict", "signature", "size", "mtime"
+      ],
+      "subset.of": [
+        "model_id", "role", "name", "source_path", "prepared_path",
+        "version", "sql", "dict", "signature", "size", "mtime"
       ]
     },
-    "text_or_array": {
-      "any": [
-        { "check": { "kind": "character", "any.missing": true, "null.ok": true } },
-        { "check": { "kind": "list", "null.ok": true } }
+    "fields": {
+      "model_id": { "check": { "kind": "int", "lower": 1 } },
+      "role": {
+        "check": {
+          "kind": "choice",
+          "choices": ["input", "seed", "case"]
+        }
+      },
+      "name": { "$ref": "#/$defs/nullable_string" },
+      "source_path": { "$ref": "#/$defs/nullable_string" },
+      "prepared_path": { "check": { "kind": "string", "min.chars": 1 } },
+      "version": { "check": { "kind": "string", "min.chars": 1 } },
+      "sql": { "check": { "kind": "flag" } },
+      "dict": { "check": { "kind": "flag" } },
+      "signature": { "check": { "kind": "string", "min.chars": 1 } },
+      "size": { "check": { "kind": "number", "lower": 0 } },
+      "mtime": { "$ref": "#/$defs/nullable_string" }
+    }
+  },
+  "model_store_case": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": ["case_index", "model_id", "name", "run_path"],
+      "subset.of": ["case_index", "model_id", "name", "run_path"]
+    },
+    "fields": {
+      "case_index": { "check": { "kind": "int", "lower": 1 } },
+      "model_id": { "check": { "kind": "int", "lower": 1 } },
+      "name": { "$ref": "#/$defs/nullable_string" },
+      "run_path": { "$ref": "#/$defs/nullable_string" }
+    }
+  },
+  "model_store": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": [
+        "version", "seed_model_id", "cases_valid", "invalid_reason",
+        "models", "cases"
+      ],
+      "subset.of": [
+        "version", "seed_model_id", "cases_valid", "invalid_reason",
+        "models", "cases"
       ]
     },
-    "generic_rows": {
-      "check": { "kind": "list", "null.ok": true }
-    },
-    "result_file": {
-      "check": { "kind": "list", "null.ok": true },
-      "rest": { "$ref": "#/$defs/text_or_array" }
-    },
-    "model_store_model": {
-      "check": { "kind": "list" },
-      "keys": {
-        "type": "unique",
-        "must.include": [
-          "model_id", "role", "name", "source_path", "prepared_path",
-          "version", "sql", "dict", "signature", "size", "mtime"
-        ],
-        "subset.of": [
-          "model_id", "role", "name", "source_path", "prepared_path",
-          "version", "sql", "dict", "signature", "size", "mtime"
-        ]
+    "fields": {
+      "version": { "check": { "kind": "int", "lower": 1, "upper": 1 } },
+      "seed_model_id": { "check": { "kind": "int", "lower": 1, "null.ok": true } },
+      "cases_valid": { "check": { "kind": "flag" } },
+      "invalid_reason": { "$ref": "#/$defs/nullable_string" },
+      "models": {
+        "check": { "kind": "list", "min.len": 1 },
+        "keys": { "type": "unnamed" },
+        "rest": { "$ref": "#/$defs/model_store_model" }
       },
-      "fields": {
-        "model_id": { "check": { "kind": "int", "lower": 1 } },
-        "role": {
-          "check": {
-            "kind": "choice",
-            "choices": ["input", "seed", "case"]
-          }
-        },
-        "name": { "$ref": "#/$defs/nullable_string" },
-        "source_path": { "$ref": "#/$defs/nullable_string" },
-        "prepared_path": { "check": { "kind": "string", "min.chars": 1 } },
-        "version": { "check": { "kind": "string", "min.chars": 1 } },
-        "sql": { "check": { "kind": "flag" } },
-        "dict": { "check": { "kind": "flag" } },
-        "signature": { "check": { "kind": "string", "min.chars": 1 } },
-        "size": { "check": { "kind": "number", "lower": 0 } },
-        "mtime": { "$ref": "#/$defs/nullable_string" }
-      }
-    },
-    "model_store_case": {
-      "check": { "kind": "list" },
-      "keys": {
-        "type": "unique",
-        "must.include": ["case_index", "model_id", "name", "run_path"],
-        "subset.of": ["case_index", "model_id", "name", "run_path"]
-      },
-      "fields": {
-        "case_index": { "check": { "kind": "int", "lower": 1 } },
-        "model_id": { "check": { "kind": "int", "lower": 1 } },
-        "name": { "$ref": "#/$defs/nullable_string" },
-        "run_path": { "$ref": "#/$defs/nullable_string" }
-      }
-    },
-    "model_store": {
-      "check": { "kind": "list" },
-      "keys": {
-        "type": "unique",
-        "must.include": [
-          "version", "seed_model_id", "cases_valid", "invalid_reason",
-          "models", "cases"
-        ],
-        "subset.of": [
-          "version", "seed_model_id", "cases_valid", "invalid_reason",
-          "models", "cases"
-        ]
-      },
-      "fields": {
-        "version": { "check": { "kind": "int", "lower": 1, "upper": 1 } },
-        "seed_model_id": { "check": { "kind": "int", "lower": 1, "null.ok": true } },
-        "cases_valid": { "check": { "kind": "flag" } },
-        "invalid_reason": { "$ref": "#/$defs/nullable_string" },
-        "models": {
-          "check": { "kind": "list", "min.len": 1 },
-          "keys": { "type": "unnamed" },
-          "rest": { "$ref": "#/$defs/model_store_model" }
-        },
-        "cases": {
-          "check": { "kind": "list" },
-          "keys": { "type": "unnamed" },
-          "rest": { "$ref": "#/$defs/model_store_case" }
-        }
-      }
-    },
-    "result_file_record": {
-      "check": { "kind": "list" },
-      "fields": {
-        "type": { "$ref": "#/$defs/nullable_string" },
-        "index": { "check": { "kind": "int", "lower": 1, "null.ok": true } },
-        "path": { "$ref": "#/$defs/nullable_string" },
-        "exists": { "check": { "kind": "flag" } },
-        "size": { "check": { "kind": "number", "lower": 0, "null.ok": true } },
-        "mtime": { "$ref": "#/$defs/nullable_string" },
-        "hash_algorithm": { "$ref": "#/$defs/nullable_string" },
-        "hash": { "$ref": "#/$defs/nullable_string" }
-      }
-    },
-    "result_file_info": {
-      "check": { "kind": "list", "null.ok": true },
-      "keys": { "type": "unnamed" },
-      "rest": { "$ref": "#/$defs/result_file_record" }
-    },
-    "energyplus_result": {
-      "check": { "kind": "list", "null.ok": true },
-      "fields": {
-        "version": { "$ref": "#/$defs/nullable_string" },
-        "energyplus": { "$ref": "#/$defs/nullable_string" },
-        "start_time": { "$ref": "#/$defs/nullable_string" },
-        "end_time": { "$ref": "#/$defs/nullable_string" },
-        "exit_status": { "check": { "kind": "int", "null.ok": true } },
-        "output_dir": { "$ref": "#/$defs/nullable_string" },
-        "file": { "$ref": "#/$defs/result_file" },
-        "file_info": { "$ref": "#/$defs/result_file_info" },
-        "run": { "$ref": "#/$defs/generic_rows" }
-      }
-    },
-    "job_row": {
-      "check": { "kind": "list" },
-      "fields": {
-        "index": { "check": { "kind": "int", "lower": 1 } },
-        "status": { "$ref": "#/$defs/nullable_string" },
-        "model": { "$ref": "#/$defs/nullable_string" },
-        "weather": { "$ref": "#/$defs/nullable_string" },
-        "output_dir": { "$ref": "#/$defs/nullable_string" },
-        "energyplus_exe": { "$ref": "#/$defs/nullable_string" },
-        "annual": { "check": { "kind": "flag" } },
-        "design_day": { "check": { "kind": "flag" } },
-        "resources": { "$ref": "#/$defs/string_vector" },
-        "exit_status": { "check": { "kind": "int", "null.ok": true } },
-        "start_time": { "$ref": "#/$defs/nullable_string" },
-        "end_time": { "$ref": "#/$defs/nullable_string" },
-        "stdout": { "$ref": "#/$defs/text_or_array" },
-        "stderr": { "$ref": "#/$defs/text_or_array" },
-        "result": { "$ref": "#/$defs/energyplus_result" }
+      "cases": {
+        "check": { "kind": "list" },
+        "keys": { "type": "unnamed" },
+        "rest": { "$ref": "#/$defs/model_store_case" }
       }
     }
   },
+  "model_store_with_cases": {
+    "all": [
+      { "$ref": "#/$defs/model_store" },
+      {
+        "check": { "kind": "list" },
+        "fields": {
+          "cases": {
+            "check": { "kind": "list", "min.len": 1 },
+            "keys": { "type": "unnamed" },
+            "rest": { "$ref": "#/$defs/model_store_case" }
+          }
+        }
+      }
+    ]
+  },
+  "model_store_seeded": {
+    "all": [
+      { "$ref": "#/$defs/model_store" },
+      {
+        "check": { "kind": "list" },
+        "fields": {
+          "seed_model_id": { "check": { "kind": "int", "lower": 1 } }
+        }
+      }
+    ]
+  },
+  "result_file_record": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": [
+        "type", "index", "path", "exists", "size", "mtime",
+        "hash_algorithm", "hash"
+      ],
+      "subset.of": [
+        "type", "index", "path", "exists", "size", "mtime",
+        "hash_algorithm", "hash"
+      ]
+    },
+    "fields": {
+      "type": { "$ref": "#/$defs/nullable_string" },
+      "index": { "check": { "kind": "int", "lower": 1, "null.ok": true } },
+      "path": { "$ref": "#/$defs/nullable_string" },
+      "exists": { "check": { "kind": "flag" } },
+      "size": { "check": { "kind": "number", "lower": 0, "null.ok": true } },
+      "mtime": { "$ref": "#/$defs/nullable_string" },
+      "hash_algorithm": { "$ref": "#/$defs/nullable_string" },
+      "hash": { "$ref": "#/$defs/nullable_string" }
+    }
+  },
+  "result_file_info": {
+    "check": { "kind": "list", "null.ok": true },
+    "keys": { "type": "unnamed" },
+    "rest": { "$ref": "#/$defs/result_file_record" }
+  },
+  "energyplus_result": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": [
+        "version", "energyplus", "start_time", "end_time",
+        "exit_status", "output_dir", "file", "file_info", "run"
+      ],
+      "subset.of": [
+        "version", "energyplus", "start_time", "end_time",
+        "exit_status", "output_dir", "file", "file_info", "run"
+      ]
+    },
+    "fields": {
+      "version": { "$ref": "#/$defs/nullable_string" },
+      "energyplus": { "$ref": "#/$defs/nullable_string" },
+      "start_time": { "$ref": "#/$defs/nullable_string" },
+      "end_time": { "$ref": "#/$defs/nullable_string" },
+      "exit_status": { "check": { "kind": "int", "null.ok": true } },
+      "output_dir": { "$ref": "#/$defs/nullable_string" },
+      "file": { "$ref": "#/$defs/result_file" },
+      "file_info": { "$ref": "#/$defs/result_file_info" },
+      "run": { "$ref": "#/$defs/generic_rows" }
+    }
+  },
+  "energyplus_result_nullable": {
+    "any": [
+      { "check": { "kind": "null" } },
+      { "$ref": "#/$defs/energyplus_result" }
+    ]
+  },
+  "job_row": {
+    "check": { "kind": "list" },
+    "keys": {
+      "type": "unique",
+      "must.include": [
+        "index", "status", "model", "weather", "output_dir",
+        "energyplus_exe", "annual", "design_day", "resources",
+        "exit_status", "start_time", "end_time", "stdout", "stderr",
+        "result"
+      ],
+      "subset.of": [
+        "index", "status", "model", "weather", "output_dir",
+        "energyplus_exe", "annual", "design_day", "resources",
+        "exit_status", "start_time", "end_time", "stdout", "stderr",
+        "result"
+      ]
+    },
+    "fields": {
+      "index": { "check": { "kind": "int", "lower": 1 } },
+      "status": { "$ref": "#/$defs/nullable_string" },
+      "model": { "$ref": "#/$defs/nullable_string" },
+      "weather": { "$ref": "#/$defs/nullable_string" },
+      "output_dir": { "$ref": "#/$defs/nullable_string" },
+      "energyplus_exe": { "$ref": "#/$defs/nullable_string" },
+      "annual": { "check": { "kind": "flag" } },
+      "design_day": { "check": { "kind": "flag" } },
+      "resources": { "$ref": "#/$defs/string_vector" },
+      "exit_status": { "check": { "kind": "int", "null.ok": true } },
+      "start_time": { "$ref": "#/$defs/nullable_string" },
+      "end_time": { "$ref": "#/$defs/nullable_string" },
+      "stdout": { "$ref": "#/$defs/text_or_array" },
+      "stderr": { "$ref": "#/$defs/text_or_array" },
+      "result": { "$ref": "#/$defs/energyplus_result_nullable" }
+    }
+  },
+  "group_run": {
+    "any": [
+      { "check": { "kind": "null" } },
+      {
+        "check": { "kind": "list" },
+        "keys": {
+          "type": "unique",
+          "must.include": ["options", "jobs"],
+          "subset.of": ["options", "jobs"]
+        },
+        "fields": {
+          "options": { "check": { "kind": "list", "null.ok": true } },
+          "jobs": {
+            "check": { "kind": "list", "null.ok": true },
+            "keys": { "type": "unnamed" },
+            "rest": { "$ref": "#/$defs/job_row" }
+          }
+        }
+      }
+    ]
+  }
+}'
+
+SCHEMA_EPLUS_JOB_MANIFEST <- job_json_schema('
   "check": { "kind": "list" },
   "keys": {
     "type": "unique",
@@ -345,33 +501,109 @@ SCHEMA_EPLUS_JOB_MANIFEST <- schema_flatten(schema_read('{
     "paths_relative_to": {
       "check": { "kind": "string", "min.chars": 1, "null.ok": true }
     },
+    "inputs": { "check": { "kind": "list" } },
+    "log": { "check": { "kind": "list" } },
+    "run": {
+      "any": [
+        { "check": { "kind": "null" } },
+        { "check": { "kind": "list" } }
+      ]
+    },
+    "parametric": { "check": { "kind": "list", "null.ok": true } }
+  }
+')
+
+SCHEMA_EPLUS_JOB_MANIFEST_EPLUS <- job_json_schema('
+  "check": { "kind": "list" },
+  "keys": {
+    "type": "unique",
+    "must.include": [
+      "format", "manifest_version", "kind", "package_version",
+      "created_at", "paths_relative_to", "inputs", "log", "run"
+    ],
+    "subset.of": [
+      "format", "manifest_version", "kind", "package_version",
+      "created_at", "paths_relative_to", "inputs", "log", "run"
+    ]
+  },
+  "fields": {
+    "kind": { "check": { "kind": "choice", "choices": ["EplusJob"] } },
     "inputs": {
       "check": { "kind": "list" },
       "keys": {
         "type": "unique",
-        "subset.of": [
-          "model_store", "epw", "epws", "weather"
-        ]
+        "must.include": ["model_store", "epw"],
+        "subset.of": ["model_store", "epw"]
       },
       "fields": {
-        "model_store": { "$ref": "#/$defs/model_store" },
-        "epw": { "$ref": "#/$defs/nullable_string" },
-        "epws": { "$ref": "#/$defs/string_vector" },
-        "weather": { "$ref": "#/$defs/nullable_string" }
+        "model_store": { "$ref": "#/$defs/model_store_with_cases" },
+        "epw": { "$ref": "#/$defs/nullable_string" }
       }
     },
     "log": {
       "check": { "kind": "list" },
       "keys": {
         "type": "unique",
+        "must.include": [
+          "uuid", "seed_uuid", "unsaved", "start_time", "end_time", "killed"
+        ],
         "subset.of": [
-          "uuid", "seed_uuid", "idf_uuid", "unsaved", "start_time",
-          "end_time", "killed"
+          "uuid", "seed_uuid", "unsaved", "start_time", "end_time", "killed"
         ]
       },
       "fields": {
         "uuid": { "$ref": "#/$defs/nullable_string" },
         "seed_uuid": { "$ref": "#/$defs/nullable_string" },
+        "unsaved": { "$ref": "#/$defs/logical_vector" },
+        "start_time": { "$ref": "#/$defs/nullable_string" },
+        "end_time": { "$ref": "#/$defs/nullable_string" },
+        "killed": { "$ref": "#/$defs/flag_or_null" }
+      }
+    },
+    "run": { "$ref": "#/$defs/energyplus_result_nullable" }
+  }
+')
+
+SCHEMA_EPLUS_JOB_MANIFEST_GROUP <- job_json_schema('
+  "check": { "kind": "list" },
+  "keys": {
+    "type": "unique",
+    "must.include": [
+      "format", "manifest_version", "kind", "package_version",
+      "created_at", "paths_relative_to", "inputs", "log", "run"
+    ],
+    "subset.of": [
+      "format", "manifest_version", "kind", "package_version",
+      "created_at", "paths_relative_to", "inputs", "log", "run"
+    ]
+  },
+  "fields": {
+    "kind": { "check": { "kind": "choice", "choices": ["EplusGroupJob"] } },
+    "inputs": {
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": ["model_store", "epws"],
+        "subset.of": ["model_store", "epws"]
+      },
+      "fields": {
+        "model_store": { "$ref": "#/$defs/model_store_with_cases" },
+        "epws": { "$ref": "#/$defs/string_vector" }
+      }
+    },
+    "log": {
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": [
+          "uuid", "idf_uuid", "unsaved", "start_time", "end_time", "killed"
+        ],
+        "subset.of": [
+          "uuid", "idf_uuid", "unsaved", "start_time", "end_time", "killed"
+        ]
+      },
+      "fields": {
+        "uuid": { "$ref": "#/$defs/nullable_string" },
         "idf_uuid": { "$ref": "#/$defs/string_vector" },
         "unsaved": { "$ref": "#/$defs/logical_vector" },
         "start_time": { "$ref": "#/$defs/nullable_string" },
@@ -379,28 +611,77 @@ SCHEMA_EPLUS_JOB_MANIFEST <- schema_flatten(schema_read('{
         "killed": { "$ref": "#/$defs/flag_or_null" }
       }
     },
-    "run": {
-      "check": { "kind": "list", "null.ok": true },
+    "run": { "$ref": "#/$defs/group_run" }
+  }
+')
+
+SCHEMA_EPLUS_JOB_MANIFEST_PARAMETRIC <- job_json_schema('
+  "check": { "kind": "list" },
+  "keys": {
+    "type": "unique",
+    "must.include": [
+      "format", "manifest_version", "kind", "package_version",
+      "created_at", "paths_relative_to", "inputs", "log", "run",
+      "parametric"
+    ],
+    "subset.of": [
+      "format", "manifest_version", "kind", "package_version",
+      "created_at", "paths_relative_to", "inputs", "log", "run",
+      "parametric"
+    ]
+  },
+  "fields": {
+    "kind": { "check": { "kind": "choice", "choices": ["ParametricJob"] } },
+    "inputs": {
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": ["model_store", "weather"],
+        "subset.of": ["model_store", "weather", "weather_cases"]
+      },
       "fields": {
-        "version": { "$ref": "#/$defs/nullable_string" },
-        "energyplus": { "$ref": "#/$defs/nullable_string" },
-        "start_time": { "$ref": "#/$defs/nullable_string" },
-        "end_time": { "$ref": "#/$defs/nullable_string" },
-        "exit_status": { "check": { "kind": "int", "null.ok": true } },
-        "output_dir": { "$ref": "#/$defs/nullable_string" },
-        "file": { "$ref": "#/$defs/result_file" },
-        "file_info": { "$ref": "#/$defs/result_file_info" },
-        "run": { "$ref": "#/$defs/generic_rows" },
-        "options": { "check": { "kind": "list", "null.ok": true } },
-        "jobs": {
-          "check": { "kind": "list", "null.ok": true },
-          "keys": { "type": "unnamed" },
-          "rest": { "$ref": "#/$defs/job_row" }
-        }
+        "model_store": { "$ref": "#/$defs/model_store_seeded" },
+        "weather": { "$ref": "#/$defs/nullable_string" },
+        "weather_cases": { "$ref": "#/$defs/weather_cases" }
       }
     },
+    "log": {
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": [
+          "uuid", "idf_uuid", "seed_uuid", "unsaved", "start_time",
+          "end_time", "killed"
+        ],
+        "subset.of": [
+          "uuid", "idf_uuid", "seed_uuid", "unsaved", "start_time",
+          "end_time", "killed"
+        ]
+      },
+      "fields": {
+        "uuid": { "$ref": "#/$defs/nullable_string" },
+        "idf_uuid": { "$ref": "#/$defs/string_vector" },
+        "seed_uuid": { "$ref": "#/$defs/nullable_string" },
+        "unsaved": { "$ref": "#/$defs/logical_vector" },
+        "start_time": { "$ref": "#/$defs/nullable_string" },
+        "end_time": { "$ref": "#/$defs/nullable_string" },
+        "killed": { "$ref": "#/$defs/flag_or_null" }
+      }
+    },
+    "run": { "$ref": "#/$defs/group_run" },
     "parametric": {
-      "check": { "kind": "list", "null.ok": true },
+      "check": { "kind": "list" },
+      "keys": {
+        "type": "unique",
+        "must.include": [
+          "applied", "simple", "replayable", "measure_name",
+          "bare", "params", "cases"
+        ],
+        "subset.of": [
+          "applied", "simple", "replayable", "measure_name",
+          "bare", "params", "cases", "model_cases", "run_cases"
+        ]
+      },
       "fields": {
         "applied": { "check": { "kind": "flag" } },
         "simple": { "$ref": "#/$defs/flag_or_null" },
@@ -408,11 +689,13 @@ SCHEMA_EPLUS_JOB_MANIFEST <- schema_flatten(schema_read('{
         "measure_name": { "$ref": "#/$defs/nullable_string" },
         "bare": { "$ref": "#/$defs/flag_or_null" },
         "params": { "$ref": "#/$defs/generic_rows" },
-        "cases": { "$ref": "#/$defs/generic_rows" }
+        "cases": { "$ref": "#/$defs/generic_rows" },
+        "model_cases": { "$ref": "#/$defs/parametric_model_cases" },
+        "run_cases": { "$ref": "#/$defs/parametric_run_cases" }
       }
     }
   }
-}'))
+')
 
 job_json_validate_manifest <- function(x) {
     schema_validate(SCHEMA_EPLUS_JOB_MANIFEST, x, mode = "assert", name = "job manifest")
@@ -429,65 +712,26 @@ job_json_validate_manifest <- function(x) {
         ), "job_json_version")
     }
 
-    job_json_validate_manifest_kind(x)
+    job_json_validate_manifest_object(x)
     job_json_validate_manifest_model_store(x)
 
     invisible(x)
 }
 
-job_json_validate_manifest_kind <- function(x) {
+job_json_validate_manifest_object <- function(x) {
     kind <- job_json_scalar_character(x$kind)
-    specs <- switch(kind,
-        EplusJob = list(
-            inputs = c("model_store", "epw"),
-            log = c("uuid", "seed_uuid", "unsaved", "start_time", "end_time", "killed"),
-            run = c("version", "energyplus", "start_time", "end_time",
-                "exit_status", "output_dir", "file", "file_info", "run"),
-            parametric = NULL
-        ),
-        EplusGroupJob = list(
-            inputs = c("model_store", "epws"),
-            log = c("uuid", "idf_uuid", "unsaved", "start_time", "end_time", "killed"),
-            run = c("options", "jobs"),
-            parametric = NULL
-        ),
-        ParametricJob = list(
-            inputs = c("model_store", "weather"),
-            log = c("uuid", "idf_uuid", "seed_uuid", "unsaved", "start_time",
-                "end_time", "killed"),
-            run = c("options", "jobs"),
-            parametric = c("applied", "simple", "replayable", "measure_name",
-                "bare", "params", "cases")
-        ),
+    schema <- switch(kind,
+        EplusJob = SCHEMA_EPLUS_JOB_MANIFEST_EPLUS,
+        EplusGroupJob = SCHEMA_EPLUS_JOB_MANIFEST_GROUP,
+        ParametricJob = SCHEMA_EPLUS_JOB_MANIFEST_PARAMETRIC,
         abort(sprintf("Unsupported job manifest kind: %s", surround(kind)),
             "job_json_kind")
     )
 
-    job_json_assert_manifest_keys(x$inputs, specs$inputs, specs$inputs,
-        sprintf("%s inputs", kind))
-    job_json_assert_manifest_keys(x$log, specs$log, specs$log,
-        sprintf("%s log", kind))
-
-    if (is.null(x$run)) {
-        # Unrun jobs have no run state to validate.
-    } else {
-        job_json_assert_manifest_keys(x$run, specs$run, specs$run,
-            sprintf("%s run", kind))
-    }
-
-    if (is.null(specs$parametric)) {
-        if ("parametric" %in% names(x)) {
-            abort(sprintf("Field 'parametric' is only valid for ParametricJob manifests, not %s.",
-                surround(kind)), "job_json_kind")
-        }
-    } else {
-        if (!("parametric" %in% names(x)) || is.null(x$parametric)) {
-            abort("ParametricJob manifests must include field 'parametric'.",
-                "job_json_kind")
-        }
-        job_json_assert_manifest_keys(x$parametric, specs$parametric, specs$parametric,
-            sprintf("%s parametric", kind))
-    }
+    tryCatch(
+        schema_validate(schema, x, mode = "assert", name = "job manifest"),
+        error = function(e) abort(conditionMessage(e), "job_json_kind")
+    )
 
     invisible(x)
 }
@@ -540,23 +784,6 @@ job_json_validate_manifest_model_store <- function(x) {
     }
 
     invisible(x)
-}
-
-job_json_assert_manifest_keys <- function(x, required, allowed, context) {
-    keys <- names(x)
-    missing <- setdiff(required, keys)
-    extra <- setdiff(keys, allowed)
-    if (!length(missing) && !length(extra)) return(invisible(x))
-
-    msg <- sprintf("Job manifest fields are not valid for %s.", context)
-    if (length(missing)) {
-        msg <- paste0(msg, "\nMissing fields: ", collapse(surround(missing)), ".")
-    }
-    if (length(extra)) {
-        msg <- paste0(msg, "\nUnexpected fields: ", collapse(surround(extra)), ".")
-    }
-
-    abort(msg, "job_json_kind")
 }
 
 job_json_verify_files <- function(manifest, base, action) {
@@ -791,11 +1018,29 @@ job_json_group_inputs <- function(private, path, overwrite, relative) {
 }
 
 job_json_parametric_inputs <- function(private, path, overwrite, relative) {
+    base <- dirname(path)
+    weather_cases <- job_json_encode_weather_cases(private$m_weather_cases, base, relative)
+    legacy_weather <- NULL
+    if (!is.null(private$m_weather_cases) && nrow(private$m_weather_cases) == 1L &&
+        !is.na(private$m_weather_cases$epw[[1L]])) {
+        legacy_weather <- private$m_weather_cases$epw[[1L]]
+    }
+
     list(
-        model_store = job_json_encode_model_store(private$m_model_store, dirname(path), relative,
+        model_store = job_json_encode_model_store(private$m_model_store, base, relative,
             path = path, overwrite = overwrite),
-        weather = job_json_encode_path(private$m_epws_path, dirname(path), relative)
+        weather = job_json_encode_path(legacy_weather, base, relative),
+        weather_cases = weather_cases
     )
+}
+
+job_json_encode_weather_cases <- function(weather, base, relative) {
+    if (is.null(weather)) return(NULL)
+    weather <- data.table::copy(weather)
+    if (nrow(weather)) {
+        set(weather, NULL, "epw", job_json_encode_path(weather$epw, base, relative))
+    }
+    job_json_encode_table(weather)
 }
 
 job_json_encode_model_store <- function(store, base, relative, path, overwrite) {
@@ -874,8 +1119,10 @@ job_json_parametric_state <- function(private) {
         cases = if (is.null(params) || !private$m_model_store$cases_valid()) {
             NULL
         } else {
-            job_json_encode_table(param_cases(NULL, private))
-        }
+            job_json_encode_table(param_cases(NULL, private, "model"))
+        },
+        model_cases = job_json_encode_table(param_model_case_table(private)),
+        run_cases = job_json_encode_table(private$m_run_cases)
     )
 }
 
@@ -1104,6 +1351,42 @@ job_json_decode_model_store <- function(x, base) {
     )
 }
 
+job_json_decode_weather_cases <- function(rows, legacy_weather = NULL, base) {
+    if (is.null(rows)) {
+        return(param_weather_cases(job_json_decode_path_nullable(legacy_weather, base)))
+    }
+
+    weather <- job_json_decode_table(rows)
+    if (!nrow(weather)) return(param_weather_cases(NULL))
+
+    set(weather, NULL, "weather_index", as.integer(weather$weather_index))
+    set(weather, NULL, "epw", job_json_decode_path_vector(weather$epw, base))
+    weather[]
+}
+
+job_json_decode_model_cases <- function(rows) {
+    cases <- job_json_decode_table(rows)
+    if (!nrow(cases)) return(data.table(model_index = integer(), model_id = integer(), model_case = character()))
+
+    set(cases, NULL, "model_index", as.integer(cases$model_index))
+    set(cases, NULL, "model_id", as.integer(cases$model_id))
+    cases[]
+}
+
+job_json_decode_param_run_cases <- function(rows, base) {
+    cases <- job_json_decode_table(rows)
+    if (!nrow(cases)) return(data.table())
+
+    int_cols <- c("index", "model_index", "weather_index")
+    for (col in intersect(int_cols, names(cases))) {
+        set(cases, NULL, col, as.integer(cases[[col]]))
+    }
+    if ("epw" %in% names(cases)) {
+        set(cases, NULL, "epw", job_json_decode_path_vector(cases$epw, base))
+    }
+    cases[]
+}
+
 job_json_restore_eplus_job <- function(manifest, base) {
     inputs <- manifest$inputs
     store <- job_json_decode_model_store(inputs$model_store, base)
@@ -1146,16 +1429,32 @@ job_json_restore_group_job <- function(manifest, base) {
 job_json_restore_parametric_job <- function(manifest, base) {
     inputs <- manifest$inputs
     store <- job_json_decode_model_store(inputs$model_store, base)
-    weather <- job_json_decode_path_nullable(inputs$weather, base)
     job <- param_job(
         store$model_prepared_path(store$seed_model_id()),
-        weather
+        NULL
     )
 
     private <- get_priv_env(job)
     private$m_model_store <- store
-    private$m_epws_path <- weather
+    private$m_weather_cases <- job_json_decode_weather_cases(inputs$weather_cases,
+        inputs$weather, base)
 
+    model_cases <- job_json_decode_model_cases(manifest$parametric$model_cases)
+    if (!nrow(model_cases) && store$has_cases()) {
+        model_cases <- data.table(
+            model_index = seq_len(store$case_count()),
+            model_id = store$case_model_ids(),
+            model_case = store$case_names()
+        )
+    }
+    private$m_model_case_ids <- model_cases$model_id
+    private$m_model_case_names <- model_cases$model_case
+
+    if (private$m_model_store$cases_valid()) {
+        param_refresh_run_cases(private)
+    } else {
+        private$m_run_cases <- job_json_decode_param_run_cases(manifest$parametric$run_cases, base)
+    }
     job_json_restore_parametric_log(private, manifest$log, manifest$parametric)
     private$m_job <- job_json_decode_group_run(manifest$run, base)
 

--- a/R/param.R
+++ b/R/param.R
@@ -61,7 +61,8 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
             private$m_log <- new.env(hash = FALSE, parent = emptyenv())
             private$m_log$unsaved <- logical()
 
-            if (!is.null(epw)) private$m_epws_path <- get_init_epw(epw)
+            private$m_weather_cases <- param_weather_cases(epw)
+            param_refresh_run_cases(private)
 
             # save uuid
             private$log_seed_uuid()
@@ -126,6 +127,36 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
         #'
         weather = function()
             param_weather(self, private),
+        # }}}
+
+        # weathers {{{
+        #' @description
+        #' Get or set weather cases
+        #'
+        #' @details
+        #' `$weathers()` returns the current weather case table. `$weathers(epws)`
+        #' replaces the weather cases and rebuilds the actual run cases used by
+        #' `$run()`, `$save()` and `$cases(type = "run")`. Existing generated
+        #' parametric models are kept.
+        #'
+        #' @param epws A path, a character vector of paths, an [Epw] object, or a
+        #'   list of paths and [Epw] objects. `NULL` or `NA` entries indicate
+        #'   design-day-only weather cases. If missing, the current weather case
+        #'   table is returned.
+        #' @param names Optional weather case names. If `NULL`, names are taken
+        #'   from `epws`, file names, or `"design_day"`.
+        #'
+        #' @return If `epws` is missing, a [data.table::data.table()]. Otherwise,
+        #'   the modified `ParametricJob` object invisibly.
+        #'
+        #' @examples
+        #' \dontrun{
+        #' param$weathers()
+        #' param$weathers(c(sf = "USA_CA_San.Francisco.epw", golden = "USA_CO_Golden.epw"))
+        #' }
+        #'
+        weathers = function(epws, names = NULL)
+            param_weathers(self, private, epws, names),
         # }}}
 
         # param {{{
@@ -335,13 +366,15 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
 
         # cases {{{
         #' @description
-        #' Get a summary of parametric models and parameters
+        #' Get a summary of parametric or run cases
         #'
         #' @details
         #' `$cases()` returns a [data.table][data.table::data.table()] giving a
-        #' summary of parametric models and parameter values.
+        #' summary of parametric models and parameter values. With
+        #' `type = "run"`, it returns the actual simulation case table created
+        #' from parametric model cases and weather cases.
         #'
-        #' The returned `data.table` has the following columns:
+        #' The model case `data.table` has the following columns:
         #'
         #' * `index`: Integer type. The indices of parameter models
         #' * `case`: Character type. The names of parameter models
@@ -352,16 +385,31 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
         #'   `ParametricJob$apply_measure()`, this will be the argument names of
         #'   the measure functions.
         #'
-        #' @return If no parametric models have been created, `NULL` is
-        #' returned. Otherwise, a [data.table][data.table::data.table()].
+        #' The run case `data.table` has the following columns:
+        #'
+        #' * `index`: Integer type. The indices of actual simulations
+        #' * `case`: Character type. The names of actual simulations
+        #' * `model_index`: Integer type. The indices of parameter models
+        #' * `model_case`: Character type. The names of parameter models
+        #' * `weather_index`: Integer type. The indices of weather cases
+        #' * `weather_case`: Character type. The names of weather cases
+        #' * `epw`: Character type. The paths of weather files. `NA` means
+        #'   design-day-only simulation.
+        #'
+        #' @param type `"model"` returns parameter model cases and preserves the
+        #'   historical `$cases()` behavior. `"run"` returns the actual simulation
+        #'   cases. Default: `"model"`.
+        #'
+        #' @return If no corresponding cases exist, `NULL` is returned.
+        #'   Otherwise, a [data.table][data.table::data.table()].
         #'
         #' @examples
         #' \dontrun{
         #' param$cases()
         #' }
         #'
-        cases = function()
-            param_cases(self, private),
+        cases = function(type = c("model", "run"))
+            param_cases(self, private, type),
         # }}}
 
         # save {{{
@@ -492,6 +540,13 @@ ParametricJob <- R6::R6Class(classname = "ParametricJob", cloneable = FALSE,
     ),
 
     private = list(
+        # PRIVATE FIELDS {{{
+        m_model_case_ids = integer(),
+        m_model_case_names = character(),
+        m_weather_cases = NULL,
+        m_run_cases = NULL,
+        # }}}
+
         # PRIVATE FUNCTIONS {{{
         seed_uuid = function() private$m_model_store$model_signature(private$m_model_store$seed_model_id()),
         log_seed_uuid = function() private$m_log$seed_uuid <- private$seed_uuid(),
@@ -532,8 +587,14 @@ param_seed <- function(self, private, new) {
         return(private$m_model_store$load_seed())
     }
 
+    param_assert_not_running(private)
     private$m_model_store$set_seed(new)
-    private$m_log$unsaved <- rep(FALSE, private$m_model_store$case_count())
+    if (!length(private$m_model_case_ids)) {
+        param_refresh_run_cases(private)
+    } else {
+        private$m_run_cases <- NULL
+    }
+    param_clear_run_state(private, new_uuid = FALSE)
     private$log_seed_uuid()
     private$log_new_uuid()
     invisible(self)
@@ -542,7 +603,7 @@ param_seed <- function(self, private, new) {
 # param_models {{{
 param_models <- function(self, private, names = NULL) {
     assert_character(names, any.missing = FALSE, null.ok = TRUE, min.len = 1L)
-    if (!private$m_model_store$has_cases()) {
+    if (!length(private$m_model_case_ids)) {
         verbose_info("No parametric models have been created.")
         if (!is.null(names)) {
             verbose_info("Nothing to rename.")
@@ -553,20 +614,63 @@ param_models <- function(self, private, names = NULL) {
     private$m_model_store$assert_cases_valid()
 
     if (length(names)) {
-        private$m_model_store$rename_cases(names)
+        private$m_model_case_names <- param_normalize_case_names(
+            names, length(private$m_model_case_ids), "parametric model"
+        )
+        param_refresh_run_cases(private)
+        param_clear_run_state(private)
     }
 
-    private$m_model_store$load_cases()
+    out <- lapply(private$m_model_case_ids, private$m_model_store$load_model)
+    names(out) <- private$m_model_case_names
+    out
 }
 # }}}
 # param_weather {{{
 param_weather <- function(self, private) {
-    if (is.null(private$m_epws_path)) NULL else read_epw(private$m_epws_path)
+    weather <- private$m_weather_cases
+    if (is.null(weather) || !nrow(weather)) return(NULL)
+    has_epw <- !is.na(weather$epw)
+    if (!any(has_epw)) return(NULL)
+
+    paths <- weather$epw[has_epw]
+    if (length(paths) == 1L && nrow(weather) == 1L) return(read_epw(paths[[1L]]))
+
+    out <- lapply(weather$epw, function(path) {
+        if (is.na(path)) NULL else read_epw(path)
+    })
+    names(out) <- weather$weather_case
+    out
+}
+# }}}
+# param_weathers {{{
+param_weathers <- function(self, private, epws, names = NULL) {
+    if (missing(epws)) {
+        return(data.table::copy(private$m_weather_cases))
+    }
+
+    param_assert_not_running(private)
+    private$m_weather_cases <- param_weather_cases(epws, names)
+    param_refresh_run_cases(private)
+    param_clear_run_state(private)
+
+    invisible(self)
 }
 # }}}
 # param_cases {{{
-param_cases <- function(self, private, param = NULL) {
-    if (!private$m_model_store$has_cases()) {
+param_cases <- function(self, private, type = c("model", "run")) {
+    type <- match.arg(type)
+
+    if (identical(type, "run")) {
+        return(param_run_cases(self, private))
+    }
+
+    param_model_cases(self, private)
+}
+# }}}
+# param_model_cases {{{
+param_model_cases <- function(self, private) {
+    if (!length(private$m_model_case_ids)) {
         verbose_info("No parametric models have been created.")
         return(NULL)
     }
@@ -576,7 +680,7 @@ param_cases <- function(self, private, param = NULL) {
 
     if (!private$m_log$simple) {
         if ("case" %in% names(cases)) {
-            set(cases, NULL, "case", private$m_model_store$case_names())
+            set(cases, NULL, "case", private$m_model_case_names)
         }
         return(cases)
     }
@@ -594,10 +698,44 @@ param_cases <- function(self, private, param = NULL) {
         set(cases, NULL, col, unlist(cases[[col]], FALSE, FALSE))
     }
     setnames(cases, "case_index", "index")
-    set(cases, NULL, "case", private$m_model_store$case_names())
+    set(cases, NULL, "case", private$m_model_case_names)
     setcolorder(cases, c("index", "case"))
 
     cases[]
+}
+# }}}
+# param_run_cases {{{
+param_run_cases <- function(self, private) {
+    run <- private$m_run_cases
+    if (is.null(run) || !nrow(run)) {
+        verbose_info("No run cases have been created.")
+        return(NULL)
+    }
+    private$m_model_store$assert_cases_valid()
+
+    out <- data.table::copy(run)
+    model <- suppressMessages(param_model_cases(self, private))
+    if (!is.null(model)) {
+        setnames(model, c("index", "case"), c("model_index", "model_case"))
+        out <- model[out, on = c("model_index", "model_case")]
+        setcolorder(out, c("index", "case", "model_index", "model_case",
+            "weather_index", "weather_case", "epw"))
+    }
+
+    out[]
+}
+# }}}
+# param_model_case_table {{{
+param_model_case_table <- function(private) {
+    if (!length(private$m_model_case_ids)) {
+        return(data.table(model_index = integer(), model_id = integer(), model_case = character()))
+    }
+
+    data.table(
+        model_index = seq_along(private$m_model_case_ids),
+        model_id = private$m_model_case_ids,
+        model_case = private$m_model_case_names
+    )
 }
 # }}}
 # param_param {{{
@@ -790,12 +928,15 @@ param_apply_measure <- function(self, private, measure, ..., .names = NULL, .env
         private$m_model_store$add_model(out[[i]], role = "case",
             name = nms[[i]], source_path = NULL, sql = TRUE, dict = TRUE)
     })
-    private$m_model_store$set_cases(model_ids, nms)
+    private$m_model_store$set_cases(integer())
+    private$m_model_case_ids <- model_ids
+    private$m_model_case_names <- nms
+    param_refresh_run_cases(private)
 
     # log unique ids
     private$log_idf_uuid()
     private$log_new_uuid()
-    private$m_log$unsaved <- rep(FALSE, length(out))
+    private$m_log$unsaved <- rep(FALSE, private$m_model_store$case_count())
 
     if (bare) {
         mea_nm <- "function"
@@ -858,16 +999,7 @@ param_save <- function(self, private, dir = NULL, separate = TRUE, copy_external
     # save model
     path_param <- private$m_model_store$materialize_cases(path_param,
         copy_external = copy_external)$paths
-    # copy weather
-    path_epw <- private$m_epws_path
-    if (!is.null(path_epw)) {
-        path_epw <- file_copy(
-            rep(path_epw, length(path_param)),
-            file.path(dirname(path_param), basename(path_epw))
-        )
-    } else {
-        path_epw <- NA_character_
-    }
+    path_epw <- param_copy_weather_files(private$m_epws_path, dirname(path_param))
 
     data.table(model = path_param, weather = path_epw)
 }
@@ -878,12 +1010,7 @@ param_print <- function(self, private) {
     if (is.na(path_idf)) {
         path_idf <- private$m_model_store$model_prepared_path(private$m_model_store$seed_model_id())
     }
-    print_job_header(title = "EnergPlus Parametric Simulation Job",
-        path_idf = path_idf,
-        path_epw = private$m_epws_path,
-        eplus_ver = param_version(self, private),
-        name_idf = "Seed", name_epw = "Weather"
-    )
+    param_print_header(private, path_idf)
 
     if (!private$m_model_store$has_cases()) {
         cli::cat_line("<< No measure has been applied >>",
@@ -901,9 +1028,184 @@ param_print <- function(self, private) {
         cli::cat_line(paste0("Applied Measure: ", surround(private$m_log$measure_name)))
     }
 
-    cli::cat_line(paste0("Parametric Models [", private$m_model_store$case_count(), "]: "))
+    cli::cat_line(paste0("Parametric Models [", length(private$m_model_case_ids), "]: "))
+    if (nrow(private$m_weather_cases) > 1L) {
+        cli::cat_line(paste0("Weather Cases [", nrow(private$m_weather_cases), "]: "))
+    }
 
-    epgroup_print_status(self, private, epw = FALSE)
+    epgroup_print_status(self, private, epw = nrow(private$m_weather_cases) > 1L)
+}
+# }}}
+
+# param_weather_cases {{{
+param_weather_cases <- function(epws = NULL, names = NULL) {
+    assert_character(names, null.ok = TRUE, any.missing = FALSE)
+
+    if (is.null(epws)) {
+        epws <- list(NULL)
+    } else if (is_epw(epws) || checkmate::test_string(epws)) {
+        epws <- list(epws)
+    } else {
+        epws <- as.list(epws)
+    }
+
+    if (!length(epws)) epws <- list(NULL)
+
+    paths <- vcapply(epws, function(epw) {
+        if (is.null(epw)) return(NA_character_)
+        if (length(epw) == 1L && is.na(epw)) return(NA_character_)
+        get_init_epw(epw)
+    })
+
+    if (!is.null(names)) {
+        assert_same_len(paths, names)
+        weather_names <- names
+    } else if (checkmate::test_names(names(epws))) {
+        weather_names <- names(epws)
+    } else {
+        weather_names <- tools::file_path_sans_ext(basename(paths))
+        weather_names[is.na(paths)] <- "design_day"
+    }
+
+    weather_names <- make.unique(as.character(weather_names), sep = "_")
+
+    data.table(
+        weather_index = seq_along(paths),
+        weather_case = weather_names,
+        epw = paths
+    )
+}
+# }}}
+# param_refresh_run_cases {{{
+param_refresh_run_cases <- function(private) {
+    weather <- private$m_weather_cases
+    if (is.null(weather) || !nrow(weather)) {
+        weather <- param_weather_cases(NULL)
+        private$m_weather_cases <- weather
+    }
+
+    has_model_cases <- length(private$m_model_case_ids) > 0L
+    if (has_model_cases && !private$m_model_store$cases_valid()) {
+        private$m_run_cases <- NULL
+        return(invisible(FALSE))
+    }
+
+    if (has_model_cases) {
+        model_ids <- private$m_model_case_ids
+        model_names <- private$m_model_case_names
+    } else if (nrow(weather) > 1L) {
+        model_ids <- private$m_model_store$seed_model_id()
+        model_names <- "seed"
+    } else {
+        private$m_model_store$set_cases(integer())
+        private$m_run_cases <- NULL
+        private$m_epws_path <- if (is.na(weather$epw[[1L]])) NULL else weather$epw[[1L]]
+        private$m_log$unsaved <- logical()
+        return(invisible(FALSE))
+    }
+
+    run <- data.table(
+        model_index = rep(seq_along(model_ids), each = nrow(weather)),
+        model_case = rep(model_names, each = nrow(weather)),
+        model_id = rep(model_ids, each = nrow(weather)),
+        weather_index = rep(weather$weather_index, times = length(model_ids)),
+        weather_case = rep(weather$weather_case, times = length(model_ids)),
+        epw = rep(weather$epw, times = length(model_ids))
+    )
+
+    if (nrow(weather) == 1L && has_model_cases) {
+        case <- model_names
+    } else if (!has_model_cases) {
+        case <- weather$weather_case
+    } else {
+        case <- paste(run$model_case, run$weather_case, sep = "__")
+    }
+    set(run, NULL, "index", seq_len(nrow(run)))
+    set(run, NULL, "case", make.unique(case, sep = "_"))
+    setcolorder(run, c("index", "case", "model_index", "model_case",
+        "model_id", "weather_index", "weather_case", "epw"))
+
+    private$m_run_cases <- data.table::copy(run[, setdiff(names(run), "model_id"), with = FALSE])
+    private$m_model_store$set_cases(run$model_id, run$case)
+    private$m_epws_path <- if (all(is.na(run$epw))) NULL else run$epw
+    private$m_log$unsaved <- rep(FALSE, nrow(run))
+
+    invisible(TRUE)
+}
+# }}}
+# param_normalize_case_names {{{
+param_normalize_case_names <- function(names, n, type) {
+    if (length(names) == 1L && n > 1L) {
+        names <- paste(names, lpad(seq_len(n), "0"), sep = "_")
+    } else if (length(names) != n) {
+        abort(paste(
+            "Invalid", type, "names found.",
+            n, "cases exist but", length(names), "names given"
+        ), "param_names")
+    }
+
+    make.unique(names, sep = "_")
+}
+# }}}
+# param_assert_not_running {{{
+param_assert_not_running <- function(private) {
+    proc <- private$m_job
+    if ((inherits(proc, "process") || inherits(proc, "r_process")) && proc$is_alive()) {
+        abort(paste0(
+            "Cannot change ParametricJob inputs while simulations are still running. ",
+            "Please call `$kill()` first."
+        ), "param_running")
+    }
+    invisible(TRUE)
+}
+# }}}
+# param_clear_run_state {{{
+param_clear_run_state <- function(private, new_uuid = TRUE) {
+    private$m_job <- NULL
+    private$m_log$start_time <- NULL
+    private$m_log$end_time <- NULL
+    private$m_log$killed <- NULL
+    private$m_log$stdout <- NULL
+    private$m_log$stderr <- NULL
+    if (isTRUE(new_uuid)) private$log_new_uuid()
+    invisible(TRUE)
+}
+# }}}
+# param_copy_weather_files {{{
+param_copy_weather_files <- function(epws, dirs) {
+    out <- rep(NA_character_, length(dirs))
+    if (is.null(epws)) return(out)
+
+    if (length(epws) == 1L) epws <- rep(epws, length(dirs))
+    assert_same_len(epws, dirs)
+
+    has_epw <- !is.na(epws)
+    if (any(has_epw)) {
+        out[has_epw] <- file_copy(
+            epws[has_epw],
+            file.path(dirs[has_epw], basename(epws[has_epw]))
+        )
+    }
+    out
+}
+# }}}
+# param_print_header {{{
+param_print_header <- function(private, path_idf) {
+    weather <- private$m_weather_cases
+    if (is.null(weather) || !nrow(weather) || all(is.na(weather$epw))) {
+        path_epw <- NULL
+    } else if (nrow(weather) == 1L) {
+        path_epw <- weather$epw[[1L]]
+    } else {
+        path_epw <- NULL
+    }
+
+    print_job_header(title = "EnergPlus Parametric Simulation Job",
+        path_idf = path_idf,
+        path_epw = path_epw,
+        eplus_ver = private$m_model_store$model_version(private$m_model_store$seed_model_id()),
+        name_idf = "Seed", name_epw = "Weather"
+    )
 }
 # }}}
 

--- a/man/ParametricJob.Rd
+++ b/man/ParametricJob.Rd
@@ -82,6 +82,16 @@ param$weather()
 
 
 ## ------------------------------------------------
+## Method `ParametricJob$weathers`
+## ------------------------------------------------
+
+\dontrun{
+param$weathers()
+param$weathers(c(sf = "USA_CA_San.Francisco.epw", golden = "USA_CO_Golden.epw"))
+}
+
+
+## ------------------------------------------------
 ## Method `ParametricJob$param`
 ## ------------------------------------------------
 
@@ -246,6 +256,7 @@ Hongyuan Jia
 \item \href{#method-ParametricJob-version}{\code{ParametricJob$version()}}
 \item \href{#method-ParametricJob-seed}{\code{ParametricJob$seed()}}
 \item \href{#method-ParametricJob-weather}{\code{ParametricJob$weather()}}
+\item \href{#method-ParametricJob-weathers}{\code{ParametricJob$weathers()}}
 \item \href{#method-ParametricJob-param}{\code{ParametricJob$param()}}
 \item \href{#method-ParametricJob-apply_measure}{\code{ParametricJob$apply_measure()}}
 \item \href{#method-ParametricJob-models}{\code{ParametricJob$models()}}
@@ -403,6 +414,52 @@ when creating the \code{ParametricJob} object, \code{NULL} is returned.
 \if{html}{\out{<div class="r example copy">}}
 \preformatted{\dontrun{
 param$weather()
+}
+
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ParametricJob-weathers"></a>}}
+\if{latex}{\out{\hypertarget{method-ParametricJob-weathers}{}}}
+\subsection{Method \code{weathers()}}{
+Get or set weather cases
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$weathers(epws, names = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{epws}}{A path, a character vector of paths, an \link{Epw} object, or a
+list of paths and \link{Epw} objects. \code{NULL} or \code{NA} entries indicate
+design-day-only weather cases. If missing, the current weather case
+table is returned.}
+
+\item{\code{names}}{Optional weather case names. If \code{NULL}, names are taken
+from \code{epws}, file names, or \code{"design_day"}.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\verb{$weathers()} returns the current weather case table. \verb{$weathers(epws)}
+replaces the weather cases and rebuilds the actual run cases used by
+\verb{$run()}, \verb{$save()} and \verb{$cases(type = "run")}. Existing generated
+parametric models are kept.
+}
+
+\subsection{Returns}{
+If \code{epws} is missing, a \code{\link[data.table:data.table]{data.table::data.table()}}. Otherwise,
+the modified \code{ParametricJob} object invisibly.
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+param$weathers()
+param$weathers(c(sf = "USA_CA_San.Francisco.epw", golden = "USA_CO_Golden.epw"))
 }
 
 }
@@ -668,16 +725,27 @@ param$models()
 \if{html}{\out{<a id="method-ParametricJob-cases"></a>}}
 \if{latex}{\out{\hypertarget{method-ParametricJob-cases}{}}}
 \subsection{Method \code{cases()}}{
-Get a summary of parametric models and parameters
+Get a summary of parametric or run cases
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$cases()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{ParametricJob$cases(type = c("model", "run"))}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{type}}{\code{"model"} returns parameter model cases and preserves the
+historical \verb{$cases()} behavior. \code{"run"} returns the actual simulation
+cases. Default: \code{"model"}.}
+}
+\if{html}{\out{</div>}}
+}
 \subsection{Details}{
 \verb{$cases()} returns a \link[data.table:data.table]{data.table} giving a
-summary of parametric models and parameter values.
+summary of parametric models and parameter values. With
+\code{type = "run"}, it returns the actual simulation case table created
+from parametric model cases and weather cases.
 
-The returned \code{data.table} has the following columns:
+The model case \code{data.table} has the following columns:
 \itemize{
 \item \code{index}: Integer type. The indices of parameter models
 \item \code{case}: Character type. The names of parameter models
@@ -688,11 +756,23 @@ you specified in \code{.names}. For the case of
 \code{ParametricJob$apply_measure()}, this will be the argument names of
 the measure functions.
 }
+
+The run case \code{data.table} has the following columns:
+\itemize{
+\item \code{index}: Integer type. The indices of actual simulations
+\item \code{case}: Character type. The names of actual simulations
+\item \code{model_index}: Integer type. The indices of parameter models
+\item \code{model_case}: Character type. The names of parameter models
+\item \code{weather_index}: Integer type. The indices of weather cases
+\item \code{weather_case}: Character type. The names of weather cases
+\item \code{epw}: Character type. The paths of weather files. \code{NA} means
+design-day-only simulation.
+}
 }
 
 \subsection{Returns}{
-If no parametric models have been created, \code{NULL} is
-returned. Otherwise, a \link[data.table:data.table]{data.table}.
+If no corresponding cases exist, \code{NULL} is returned.
+Otherwise, a \link[data.table:data.table]{data.table}.
 }
 \subsection{Examples}{
 \if{html}{\out{<div class="r example copy">}}

--- a/tests/testthat/test-job-json.R
+++ b/tests/testthat/test-job-json.R
@@ -157,28 +157,51 @@ test_that("ParametricJob generated models are snapshotted and restored", {
     skip_if_not(is_avail_eplus(LATEST_EPLUS_VER))
 
     path_idf <- copy_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")
-    path_epw <- path_eplus_weather(LATEST_EPLUS_VER, "USA_CO_Golden-NREL.724666_TMY3.epw")
+    path_epws <- path_eplus_weather(LATEST_EPLUS_VER,
+        c("USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
+          "USA_CO_Golden-NREL.724666_TMY3.epw")
+    )
 
-    param <- param_job(path_idf, path_epw)
-    param$apply_measure(function(idf, num) idf, num = 1:2)
+    param <- param_job(path_idf, NULL)
+    param$weathers(path_epws, names = c("sf", "golden"))
+    param$apply_measure(function(idf, num) idf, num = 1:2, .names = "case")
 
     path <- tempfile(fileext = ".json")
     save_job(param, path)
+
+    manifest <- jsonlite::fromJSON(path,
+        simplifyVector = FALSE, simplifyDataFrame = FALSE, simplifyMatrix = FALSE)
+    expect_length(manifest$inputs$weather_cases, 2L)
+    expect_length(manifest$parametric$model_cases, 2L)
+    expect_length(manifest$parametric$run_cases, 4L)
 
     snap_dir <- file.path(dirname(path),
         paste0(tools::file_path_sans_ext(basename(path)), "_files"), "model_store")
     expect_true(dir.exists(snap_dir))
     expect_length(list.files(snap_dir, "\\.idf$", full.names = TRUE, recursive = TRUE), 3L)
 
-    invalid_kind <- jsonlite::fromJSON(path,
-        simplifyVector = FALSE, simplifyDataFrame = FALSE, simplifyMatrix = FALSE)
+    invalid_kind <- manifest
     invalid_kind$parametric <- NULL
     invalid <- tempfile(fileext = ".json")
     write_job_manifest(invalid_kind, invalid)
     expect_error(read_job(invalid), class = "eplusr_error_job_json_kind")
 
+    invalid_weather <- manifest
+    invalid_weather$inputs$weather_cases[[1L]]$weather_index <- NULL
+    invalid <- tempfile(fileext = ".json")
+    write_job_manifest(invalid_weather, invalid)
+    expect_error(read_job(invalid), class = "eplusr_error_job_json_kind")
+
+    invalid_run <- manifest
+    invalid_run$parametric$run_cases[[1L]]$weather_index <- "bad"
+    invalid <- tempfile(fileext = ".json")
+    write_job_manifest(invalid_run, invalid)
+    expect_error(read_job(invalid), class = "eplusr_error_job_json_kind")
+
     restored <- read_job(path)
     expect_s3_class(restored, "ParametricJob")
     expect_equal(names(restored$models()), names(param$models()))
+    expect_equal(restored$weathers(), param$weathers())
     expect_equal(restored$cases(), param$cases())
+    expect_equal(restored$cases("run"), param$cases("run"))
 })

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -19,6 +19,22 @@ test_that("Parametric methods", {
     # $weather()
     expect_s3_class(param$weather(), "Epw")
     expect_null(param_job(path_idf, NULL)$weather())
+
+    # $weathers()
+    path_epws <- path_eplus_weather(LATEST_EPLUS_VER,
+        c("USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
+          "USA_CO_Golden-NREL.724666_TMY3.epw")
+    )
+    param <- param_job(path_idf, NULL)
+    expect_s3_class(param$weathers(path_epws, names = c("sf", "golden")), "ParametricJob")
+    expect_equal(
+        ignore_attr = TRUE,
+        param$weathers(),
+        data.table(weather_index = 1:2, weather_case = c("sf", "golden"),
+            epw = normalizePath(path_epws)
+        )
+    )
+    expect_type(param$weather(), "list")
 })
 
 test_that("$apply_measure()", {
@@ -150,6 +166,43 @@ test_that("$cases()", {
             eff = c(0.1, 0.2), sch = c("FanAvailSched", "Always On")
         )
     )
+
+    path_epws <- path_eplus_weather(LATEST_EPLUS_VER,
+        c("USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
+          "USA_CO_Golden-NREL.724666_TMY3.epw")
+    )
+    param$weathers(path_epws, names = c("sf", "golden"))
+    expect_equal(
+        ignore_attr = TRUE,
+        param$cases("run"),
+        data.table(
+            index = 1:4,
+            case = c("case_1__sf", "case_1__golden", "case_2__sf", "case_2__golden"),
+            model_index = c(1L, 1L, 2L, 2L),
+            model_case = c("case_1", "case_1", "case_2", "case_2"),
+            weather_index = c(1L, 2L, 1L, 2L),
+            weather_case = c("sf", "golden", "sf", "golden"),
+            epw = normalizePath(path_epws[c(1L, 2L, 1L, 2L)]),
+            eff = c(0.1, 0.1, 0.2, 0.2),
+            sch = c("FanAvailSched", "FanAvailSched", "Always On", "Always On")
+        )
+    )
+
+    param <- param_job(path, path_epws)
+    expect_null(param$cases())
+    expect_equal(
+        ignore_attr = TRUE,
+        param$cases("run"),
+        data.table(
+            index = 1:2,
+            case = tools::file_path_sans_ext(basename(path_epws)),
+            model_index = c(1L, 1L),
+            model_case = c("seed", "seed"),
+            weather_index = 1:2,
+            weather_case = tools::file_path_sans_ext(basename(path_epws)),
+            epw = normalizePath(path_epws)
+        )
+    )
 })
 
 test_that("$run()", {
@@ -212,6 +265,26 @@ test_that("$save()", {
         data.table(
             model = normalizePath(file.path(tempdir(), c("case_1.idf", "case_2.idf"))),
             weather = normalizePath(file.path(tempdir(), "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw"))
+        )
+    )
+
+    path_epws <- path_eplus_weather(LATEST_EPLUS_VER,
+        c("USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
+          "USA_CO_Golden-NREL.724666_TMY3.epw")
+    )
+    param <- param_job(path, NULL)
+    param$weathers(path_epws, names = c("sf", "golden"))
+    param$apply_measure(function(idf, num) idf, num = 1:2)
+    expect_equal(
+        ignore_attr = TRUE,
+        param$save(separate = FALSE),
+        data.table(
+            model = normalizePath(file.path(tempdir(),
+                c("case_1__sf.idf", "case_1__golden.idf", "case_2__sf.idf", "case_2__golden.idf")
+            )),
+            weather = normalizePath(file.path(tempdir(),
+                basename(path_epws[c(1L, 2L, 1L, 2L)])
+            ))
         )
     )
 })


### PR DESCRIPTION
Closes #617.

Adds multi-EPW weather cases to ParametricJob via `$weathers()`, keeps `$cases()` compatible for model cases, and adds `$cases(type = "run")` for the actual simulation list. Job JSON manifests now persist and validate weather/model/run case state with object-specific schemate schemas, with docs, NEWS, and tests updated.