### PR TITLE
fix(install): locate macOS DMG Qt installer

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.3.9010
+Version: 0.16.3.9011
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@
 
 ## Bug fixes
 
+* Fix macOS installation from mounted EnergyPlus DMG installers that provide a
+  QtIFW `.app` bundle instead of a `.pkg` file (#620).
+
 * Fix EnergyPlus IDD downloads from v23.2.0 and portable macOS tarball
   installation (#601).
 

--- a/R/install.R
+++ b/R/install.R
@@ -506,6 +506,49 @@ sudo_on_mac <- function(cmd) {
     }
 }
 # }}}
+# macos_mount_dmg {{{
+macos_mount_dmg <- function(exec, no_ext) {
+    res <- system(sprintf("hdiutil mount %s", shQuote(exec)))
+    attr(res, "mount_dir") <- file.path("/Volumes", no_ext)
+    res
+}
+# }}}
+# macos_unmount_dmg {{{
+macos_unmount_dmg <- function(mount_dir) {
+    system(sprintf("hdiutil unmount %s", shQuote(mount_dir)))
+}
+# }}}
+# macos_qt_installer_exec {{{
+macos_qt_installer_exec <- function(mount_dir, no_ext) {
+    mount_dir <- normalizePath(mount_dir, mustWork = TRUE)
+
+    app_dirs <- list.files(mount_dir, pattern = "\\.app$", full.names = TRUE)
+    app_dirs <- unique(c(file.path(mount_dir, paste0(no_ext, ".app")), app_dirs))
+    app_dirs <- app_dirs[dir.exists(app_dirs)]
+
+    for (app_dir in app_dirs) {
+        exec_dir <- file.path(app_dir, "Contents", "MacOS")
+        if (!dir.exists(exec_dir)) next
+
+        app_exec <- file.path(exec_dir, tools::file_path_sans_ext(basename(app_dir)))
+        execs <- unique(c(app_exec, list.files(exec_dir, full.names = TRUE)))
+        execs <- execs[file.exists(execs)]
+        info <- file.info(execs)
+        execs <- execs[!is.na(info$isdir) & !info$isdir & file.access(execs, 1L) == 0L]
+
+        if (length(execs)) return(normalizePath(execs[[1L]], mustWork = TRUE))
+    }
+
+    root_exec <- unique(c(file.path(mount_dir, no_ext), list.files(mount_dir, full.names = TRUE)))
+    root_exec <- root_exec[file.exists(root_exec)]
+    info <- file.info(root_exec)
+    root_exec <- root_exec[!is.na(info$isdir) & !info$isdir & file.access(root_exec, 1L) == 0L]
+
+    if (length(root_exec)) return(normalizePath(root_exec[[1L]], mustWork = TRUE))
+
+    abort("Failed to locate the EnergyPlus QtIFW installer executable in mounted disk image '", mount_dir, "'.")
+}
+# }}}
 # install_eplus_macos {{{
 install_eplus_macos <- function(ver, exec, local = FALSE, dir = NULL, portable = FALSE) {
     ver <- standardize_ver(ver)
@@ -528,19 +571,25 @@ install_eplus_macos <- function(ver, exec, local = FALSE, dir = NULL, portable =
         res <- install_eplus_portable(ver, exec, dir)
     } else {
         # mount
-        system(sprintf("hdiutil mount %s", exec))
+        res <- macos_mount_dmg(exec, no_ext)
+        if (res != 0L) return(res)
+
+        mount_dir <- attr(res, "mount_dir")
+        on.exit(macos_unmount_dmg(mount_dir), add = TRUE)
+
         if (ver < "9.1") {
+            pkg <- file.path(mount_dir, paste0(no_ext, ".pkg"))
             if (local) {
-                res <- system(sprintf("installer -pkg /Volumes/%s/%s.pkg -target CurrentUserHomeDirectory", no_ext, no_ext))
+                res <- system(sprintf("installer -pkg %s -target CurrentUserHomeDirectory", shQuote(pkg)))
             } else {
-                res <- sudo_on_mac(sprintf("installer -pkg /Volumes/%s/%s.pkg -target LocalSystem", no_ext, no_ext))
+                res <- sudo_on_mac(sprintf("installer -pkg %s -target LocalSystem", shQuote(pkg)))
             }
             attr(res, "path") <- eplus_default_path(ver, local = local)
         } else {
-            res <- install_eplus_qt(ver, exec, dir, local = local)
+            qt_exec <- macos_qt_installer_exec(mount_dir, no_ext)
+            res <- install_eplus_qt(ver, qt_exec, dir, local = local)
             attr(res, "path") <- dir
         }
-        system(sprintf("hdiutil unmount /Volumes/%s/", no_ext))
     }
     res
 }
@@ -715,7 +764,7 @@ install_eplus_qt <- function(ver, exec, dir, local = FALSE, verbose = FALSE) {
             gui.clickButton(buttons.FinishButton);
         };
     ", collapse = "\n"))
-    res <- system(sprintf("%s %s --script %s", exec, if (verbose) "--verbose " else "", ctrl))
+    res <- system(paste(shQuote(exec), if (verbose) "--verbose" else NULL, "--script", shQuote(ctrl)))
     # sometimes QtIFW returns 1 if success for EnergyPlus v9.5 installer
     if (res == 1L) res <- res - 1L
     res

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -92,6 +92,71 @@ test_that("invalid extra EnergyPlus dirs are ignored quietly", {
     })
 })
 
+test_that("macOS Qt installer executable is found inside a mounted app bundle", {
+    skip_on_os("windows")
+
+    no_ext <- "EnergyPlus-9.4.0-998c4b761e-Darwin-macOS10.15-x86_64"
+    mount_dir <- tempfile()
+    exec_dir <- file.path(mount_dir, paste0(no_ext, ".app"), "Contents", "MacOS")
+    dir.create(exec_dir, recursive = TRUE)
+
+    exec <- file.path(exec_dir, no_ext)
+    file.create(exec)
+    Sys.chmod(exec, "755")
+
+    expect_identical(macos_qt_installer_exec(mount_dir, no_ext), normalizePath(exec))
+})
+
+test_that("macOS Qt installer executable can be found at mounted volume root", {
+    skip_on_os("windows")
+
+    no_ext <- "EnergyPlus-9.4.0-998c4b761e-Darwin-macOS10.15-x86_64"
+    mount_dir <- tempfile()
+    dir.create(mount_dir)
+
+    exec <- file.path(mount_dir, no_ext)
+    file.create(exec)
+    Sys.chmod(exec, "755")
+
+    expect_identical(macos_qt_installer_exec(mount_dir, no_ext), normalizePath(exec))
+})
+
+test_that("macOS Qt installer uses executable from mounted DMG", {
+    skip_on_os("windows")
+
+    no_ext <- "EnergyPlus-9.4.0-998c4b761e-Darwin-macOS10.15-x86_64"
+    inst <- file.path(tempdir(), paste0(no_ext, ".dmg"))
+    mount_dir <- tempfile()
+    qt_exec <- file.path(mount_dir, paste0(no_ext, ".app"), "Contents", "MacOS", no_ext)
+    used_exec <- NULL
+    unmounted <- FALSE
+
+    local_mocked_bindings(
+        macos_mount_dmg = function(exec, no_ext) {
+            res <- 0L
+            attr(res, "mount_dir") <- mount_dir
+            res
+        },
+        macos_unmount_dmg = function(mount_dir) {
+            unmounted <<- TRUE
+            0L
+        },
+        macos_qt_installer_exec = function(mount_dir, no_ext) qt_exec,
+        install_eplus_qt = function(ver, exec, dir, local = FALSE) {
+            used_exec <<- exec
+            0L
+        }
+    )
+
+    res <- install_eplus_macos("9.4", inst, local = TRUE)
+
+    expect_identical(used_exec, qt_exec)
+    expect_true(unmounted)
+    expect_identical(attr(res, "path"),
+        normalizePath("~/Applications/EnergyPlus-9-4-0", mustWork = FALSE)
+    )
+})
+
 test_that("Install EnergyPlus v9.0 and below", {
     skip_on_cran()
     skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_INSTALL_OLD_") != "")


### PR DESCRIPTION
Closes #620.

This fixes macOS DMG installation for QtIFW-based EnergyPlus installers by resolving the executable inside the mounted volume before running the scripted installer.

The change also quotes installer paths, unmounts DMGs on exit, adds focused installer path tests, and records the fix in NEWS.