### PR TITLE
fix(install): dispatch uninstall by native tools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.16.3.9011
+Version: 0.16.3.9012
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,10 @@
 * Fix macOS installation from mounted EnergyPlus DMG installers that provide a
   QtIFW `.app` bundle instead of a `.pkg` file (#620).
 
+* Fix `uninstall_eplus()` dispatch so native uninstallers are used when
+  available and portable or manual installs fall back to direct directory
+  removal (#622).
+
 * Fix EnergyPlus IDD downloads from v23.2.0 and portable macOS tarball
   installation (#601).
 

--- a/R/install.R
+++ b/R/install.R
@@ -188,33 +188,14 @@ uninstall_eplus <- function(ver) {
 
     verbose_info(sprintf("Start uninstalling EnergyPlus v%s...", ver))
 
-    # detect if it is a portable EnergyPlus installation
-    is_portable <- switch(
-        os_type(),
-        windows = if (ver >= "9.2") {
-            file.exists(file.path(dir, "maintenancetool.exe"))
-        } else {
-            file.exists(file.path(dir, "Uninstall.exe"))
-        },
-        linux = file.exists(file.path(dir, "uninstall.sh")),
-        macos = if (ver >= "9.2") {
-            file.exists(file.path(dir, "maintenancetool.app/Contents/MacOS/maintenancetool"))
-        } else {
-            TRUE
-        }
-    )
     verbose_info("NOTE: Administrative privileges may be required during uninstallation. ",
         "Please make sure R is running with an administrator acount or equivalent.")
 
-    if (is_portable) {
-        res <- uninstall_eplus_portable(ver, dir)
-    } else {
-        res <- switch(os_type(),
-            windows = uninstall_eplus_win(ver, dir),
-            linux   = uninstall_eplus_linux(ver, dir),
-            macos   = uninstall_eplus_macos(ver, dir)
-        )
-    }
+    res <- switch(os_type(),
+        windows = uninstall_eplus_win(ver, dir),
+        linux   = uninstall_eplus_linux(ver, dir),
+        macos   = uninstall_eplus_macos(ver, dir)
+    )
 
     if (res != 0L) abort(paste0("Failed to uninstall EnergyPlus v", ver, "."))
 
@@ -826,51 +807,50 @@ uninstall_eplus_win <- function(ver, dir) {
     ver <- standardize_ver(ver)
 
     if (ver >= "9.2") {
-        uninstall_eplus_qt(ver, dir)
+        if (file.exists(uninstall_eplus_qt_path(dir))) {
+            return(uninstall_eplus_qt(ver, dir))
+        }
     } else {
         uninstaller <- normalizePath(file.path(dir, "Uninstall.exe"), mustWork = FALSE)
-        if (!file.exists(uninstaller)) {
-            abort(sprintf(paste0(
-                "Failed to locate 'Uninstall.exe' under EnergyPlus installation directory '%s'.",
-            ), dir))
+        if (file.exists(uninstaller)) {
+            message(paste("The uninstaller will pop up a message box asking",
+                "whether to remove files copied to the system directory during installation.",
+                "Please make your choice."
+            ))
+            return(system(paste(shQuote(uninstaller), "/S")))
         }
-
-        message(paste("The uninstaller will pop up a message box asking",
-            "whether to remove files copied to the system directory during installation.",
-            "Please make your choice."
-        ))
-        system(sprintf("%s /S", uninstaller))
     }
+
+    uninstall_eplus_portable(ver, dir)
 }
 # }}}
 # uninstall_eplus_macos {{{
 uninstall_eplus_macos <- function(ver, dir) {
     ver <- standardize_ver(ver)
 
-    if (ver >= "9.2") {
-        uninstall_eplus_qt(ver, dir)
-    } else {
-        # test if EnergyPlus directory is accessible for current user
-        if (identical(unname(try(file.access(dir, 2L), silent = TRUE)), 0L)) {
-            system(sprintf("rm -rf %s", dir))
-        } else {
-            sudo_on_mac(sprintf("rm -rf %s", dir))
-        }
+    if (ver >= "9.1" && file.exists(uninstall_eplus_qt_path(dir))) {
+        return(uninstall_eplus_qt(ver, dir))
     }
+
+    uninstall_eplus_portable(ver, dir)
+}
+# }}}
+# uninstall_eplus_qt_path {{{
+uninstall_eplus_qt_path <- function(dir) {
+    exe <- switch(os_type(),
+        windows = "maintenancetool.exe",
+        macos   = "maintenancetool.app/Contents/MacOS/maintenancetool",
+        linux   = "maintenancetool"
+    )
+
+    normalizePath(file.path(dir, exe), mustWork = FALSE)
 }
 # }}}
 # uninstall_eplus_qt {{{
 uninstall_eplus_qt <- function(ver, dir) {
     ver <- standardize_ver(ver)
 
-    ext <- if (is_windows()) ".exe" else ""
-    if (!is_macos()) {
-        exe <- sprintf("maintenancetool%s", ext)
-    } else {
-        exe <- "maintenancetool.app/Contents/MacOS/maintenancetool"
-    }
-
-    uninstaller <- normalizePath(file.path(dir, exe), mustWork = FALSE)
+    uninstaller <- uninstall_eplus_qt_path(dir)
     if (!file.exists(uninstaller)) {
         abort(sprintf(
             "Failed to locate '%s' under EnergyPlus installation directory '%s'.",
@@ -885,27 +865,26 @@ uninstall_eplus_linux <- function(ver, dir, force = FALSE) {
     ver <- standardize_ver(ver)
     uninstaller <- normalizePath(file.path(dir, "uninstall.sh"), mustWork = FALSE)
     if (!file.exists(uninstaller)) {
-        if (!force) {
-            abort(sprintf(paste0(
-                "Failed to locate 'uninstall.sh' under EnergyPlus installation directory '%s'. ",
-                "Unable to remove symbolic links."
-            ), dir))
-        } else {
+        if (force) {
             warn(sprintf(paste0(
                 "Failed to locate 'uninstall.sh' under EnergyPlus installation directory '%s'. ",
                 "Symbolic links will NOT be removed"
             ), dir))
         }
+        return(uninstall_eplus_portable(ver, dir))
     }
 
     if (!utils::file_test("-x", uninstaller)) {
-        system(sprintf("sudo chmod +x %s", uninstaller))
+        res <- system(sprintf("sudo chmod +x %s", shQuote(uninstaller)))
+        if (res != 0L) return(res)
     }
 
     verbose_info(sprintf("Removing symbolic links for EnergyPlus v%s.", ver))
-    system(sprintf("sudo bash %s", uninstaller))
+    res <- system(sprintf("sudo bash %s", shQuote(uninstaller)))
+    if (res != 0L) return(res)
+
     verbose_info(sprintf("Removing installation directory of EnergyPlus v%s.", ver))
-    system(sprintf("sudo rm -rf %s", dir))
+    system(sprintf("sudo rm -rf %s", shQuote(dir)))
 }
 # }}}
 # uninstall_eplus_portable {{{
@@ -918,9 +897,9 @@ uninstall_eplus_portable <- function(ver, dir) {
             unlink(dir, recursive = TRUE, force = TRUE)
         } else {
             if (is_macos()) {
-                sudo_on_mac(sprintf("rm -rf %s", dir))
+                sudo_on_mac(sprintf("rm -rf %s", shQuote(dir)))
             } else {
-                system(sprintf("sudo rm -rf %s", dir))
+                system(sprintf("sudo rm -rf %s", shQuote(dir)))
             }
         }
     }

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -157,6 +157,119 @@ test_that("macOS Qt installer uses executable from mounted DMG", {
     )
 })
 
+test_that("uninstall_eplus() delegates to platform uninstallers", {
+    with_clean_eplus_cache({
+        root <- tempfile()
+        fake <- fake_eplus_install(root, ver = "23.1")
+        dir.create(file.path(fake, "maintenancetool.app", "Contents", "MacOS"), recursive = TRUE)
+        file.create(file.path(fake, "maintenancetool.app", "Contents", "MacOS", "maintenancetool"))
+        suppressMessages(use_eplus(fake))
+
+        called <- NULL
+        local_mocked_bindings(
+            os_type = function() "macos",
+            uninstall_eplus_macos = function(ver, dir) {
+                called <<- "macos"
+                0L
+            },
+            uninstall_eplus_portable = function(ver, dir) {
+                called <<- "portable"
+                0L
+            }
+        )
+
+        expect_equal(ignore_attr = TRUE, uninstall_eplus("23.1"), 0L)
+        expect_identical(called, "macos")
+    })
+})
+
+test_that("macOS Qt installations use the maintenance tool", {
+    dir <- tempfile()
+    mt <- file.path(dir, "maintenancetool.app", "Contents", "MacOS", "maintenancetool")
+    dir.create(dirname(mt), recursive = TRUE)
+    file.create(mt)
+
+    called <- NULL
+    local_mocked_bindings(
+        os_type = function() "macos",
+        uninstall_eplus_qt = function(ver, dir) {
+            called <<- list(ver = as.character(ver), dir = dir)
+            0L
+        }
+    )
+
+    expect_identical(uninstall_eplus_macos("9.4", dir), 0L)
+    expect_identical(called, list(ver = "9.4.0", dir = dir))
+})
+
+test_that("macOS installs without maintenance tools are removed directly", {
+    dir <- fake_eplus_install(tempfile(), ver = "9.4")
+
+    local_mocked_bindings(
+        os_type = function() "macos",
+        uninstall_eplus_qt = function(ver, dir) {
+            abort("Qt uninstaller should not be used.")
+        }
+    )
+
+    expect_identical(uninstall_eplus_macos("9.4", dir), 0L)
+    expect_false(dir.exists(dir))
+})
+
+test_that("Windows Qt installations use the maintenance tool", {
+    dir <- tempfile()
+    dir.create(dir)
+    file.create(file.path(dir, "maintenancetool.exe"))
+
+    called <- NULL
+    local_mocked_bindings(
+        os_type = function() "windows",
+        uninstall_eplus_qt = function(ver, dir) {
+            called <<- list(ver = as.character(ver), dir = dir)
+            0L
+        },
+        uninstall_eplus_portable = function(ver, dir) {
+            abort("Portable uninstaller should not be used.")
+        }
+    )
+
+    expect_identical(uninstall_eplus_win("23.1", dir), 0L)
+    expect_identical(called, list(ver = "23.1.0", dir = dir))
+})
+
+test_that("Windows installs without uninstallers are removed directly", {
+    dir <- tempfile()
+    dir.create(dir)
+
+    called <- NULL
+    local_mocked_bindings(
+        os_type = function() "windows",
+        uninstall_eplus_portable = function(ver, dir) {
+            called <<- list(ver = as.character(ver), dir = dir)
+            0L
+        }
+    )
+
+    expect_identical(uninstall_eplus_win("23.1", dir), 0L)
+    expect_identical(called, list(ver = "23.1.0", dir = dir))
+})
+
+test_that("Linux installs without uninstall.sh are removed directly", {
+    dir <- tempfile()
+    dir.create(dir)
+
+    called <- NULL
+    local_mocked_bindings(
+        uninstall_eplus_portable = function(ver, dir) {
+            called <<- list(ver = as.character(ver), dir = dir)
+            0L
+        }
+    )
+
+    expect_identical(uninstall_eplus_linux("23.1", dir), 0L)
+    expect_identical(called, list(ver = "23.1.0", dir = dir))
+})
+
 test_that("Install EnergyPlus v9.0 and below", {
     skip_on_cran()
     skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_INSTALL_OLD_") != "")


### PR DESCRIPTION
Closes #622.

This fixes `uninstall_eplus()` dispatch so native uninstallers are used when present and portable or manual installations fall back to direct directory removal.

The change covers QtIFW maintenance tools on macOS and Windows, Linux `uninstall.sh`, direct directory removal fallback, NEWS, and focused install/uninstall tests.