### PR TITLE
fix: reject IDF delimiter characters in field values

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.17.0.9001
+Version: 0.17.0.9002
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 
 ## Bug fixes
 
+* Reject character field values that contain IDF delimiters, preventing comma or
+  semicolon inputs from corrupting generated IDF syntax (#67).
+
 * Skip CRAN checks that would otherwise download the latest EnergyPlus IDD during
   IDD relation tests.
 

--- a/R/idf.R
+++ b/R/idf.R
@@ -1975,7 +1975,8 @@ Idf <- R6::R6Class(classname = "Idf",
         #' * `invalid_autocalculate`: Result of `auto_field` checking for
         #'   invalid `Autocalculate` field values.
         #' * `invalid_character`: Result of `type` checking for invalid
-        #'   character field values.
+        #'   character field values, including character values that contain
+        #'   IDF delimiters `,` or `;`.
         #' * `invalid_numeric`: Result of `type` checking for invalid
         #'   numeric field values.
         #' * `invalid_integer`: Result of `type` checking for invalid

--- a/R/idfobj.R
+++ b/R/idfobj.R
@@ -574,7 +574,8 @@ IdfObject <- R6::R6Class(classname = "IdfObject",
         #' * `invalid_autocalculate`: Result of `auto_field` checking for
         #'   invalid `Autocalculate` field values.
         #' * `invalid_character`: Result of `type` checking for invalid
-        #'   character field values.
+        #'   character field values, including character values that contain
+        #'   IDF delimiters `,` or `;`.
         #' * `invalid_numeric`: Result of `type` checking for invalid
         #'   numeric field values.
         #' * `invalid_integer`: Result of `type` checking for invalid

--- a/R/validate.R
+++ b/R/validate.R
@@ -95,9 +95,10 @@ exclude_invalid <- function(env_in, invalid, on) {
 #' `FALSE`.
 #' @param auto_field Check if all fields with value `"Autosize"` and
 #' `"Autocalculate"` are valid or not. Default: `FALSE`.
-#' @param type Check if all fields have values with valid types, i.e. 
+#' @param type Check if all fields have values with valid types, i.e.
 #' character, numeric and integer fields should be filled with corresponding
-#' type of values. Default: `FALSE`.
+#' type of values, and character fields should not contain IDF delimiters `,` or
+#' `;`. Default: `FALSE`.
 #' @param choice Check if all choice fields have valid choice values. Default:
 #' `FALSE`.
 #' @param range Check if all numeric fields have values within defined ranges.
@@ -503,9 +504,15 @@ check_invalid_autocalculate <- function(idd_env, idf_env, env_in) {
     env_in
 }
 # }}}
-# check_invalid_character: invalid numeric fields {{{
+# check_invalid_character: invalid character fields {{{
 check_invalid_character <- function(idd_env, idf_env, env_in) {
-    invalid_character <- env_in$value[type_enum > IDDFIELD_TYPE$real & !is.na(value_num)]
+    check_idf_delimiter <- !"WEATHER DATA" %chin% idd_env$class$class_name
+    invalid_character <- env_in$value[
+        type_enum > IDDFIELD_TYPE$real &
+            (!is.na(value_num) |
+                (check_idf_delimiter & !is.na(value_chr) &
+                    (stri_detect_fixed(value_chr, ",") | stri_detect_fixed(value_chr, ";"))))
+    ]
 
     if (!nrow(invalid_character)) return(env_in)
 
@@ -713,7 +720,7 @@ format_single_validity <- function(single_validity, type, epw = FALSE) {
         invalid_autosize = "Fields below cannot be `autosize`:",
         invalid_autocalculate = "Fields below cannot be `autocalculate`:",
         invalid_numeric = "Fields below should be numbers but are not:",
-        invalid_character = "Fields below should be characters but are not:",
+        invalid_character = "Character fields below should not be numeric inputs or contain IDF delimiters `,` or `;`:",
         invalid_integer = "Fields below are not or cannot be coerced into integers:",
         invalid_choice = "Fields below are not one of prescribed choices:",
         invalid_range = "Fields below exceed prescribed ranges:",

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -3425,7 +3425,8 @@ represents the results from a single validation checking component.
 \item \code{invalid_autocalculate}: Result of \code{auto_field} checking for
 invalid \code{Autocalculate} field values.
 \item \code{invalid_character}: Result of \code{type} checking for invalid
-character field values.
+character field values, including character values that contain
+IDF delimiters \verb{,} or \verb{;}.
 \item \code{invalid_numeric}: Result of \code{type} checking for invalid
 numeric field values.
 \item \code{invalid_integer}: Result of \code{type} checking for invalid

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -1119,7 +1119,8 @@ represents the results from a single validation checking component.
 \item \code{invalid_autocalculate}: Result of \code{auto_field} checking for
 invalid \code{Autocalculate} field values.
 \item \code{invalid_character}: Result of \code{type} checking for invalid
-character field values.
+character field values, including character values that contain
+IDF delimiters \verb{,} or \verb{;}.
 \item \code{invalid_numeric}: Result of \code{type} checking for invalid
 numeric field values.
 \item \code{invalid_integer}: Result of \code{type} checking for invalid

--- a/man/custom_validate.Rd
+++ b/man/custom_validate.Rd
@@ -38,7 +38,8 @@ Default: \code{FALSE}.}
 
 \item{type}{Check if all fields have values with valid types, i.e.
 character, numeric and integer fields should be filled with corresponding
-type of values. Default: \code{FALSE}.}
+type of values, and character fields should not contain IDF delimiters \verb{,} or
+\verb{;}. Default: \code{FALSE}.}
 
 \item{choice}{Check if all choice fields have valid choice values. Default:
 \code{FALSE}.}

--- a/tests/testthat/test-idf.R
+++ b/tests/testthat/test-idf.R
@@ -438,6 +438,11 @@ test_that("$add()", {
     expect_silent(idf_full <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")))
     expect_error(idf_full$add("Building" = list()))
 
+    expect_s3_class(err <- catch_cnd(idf$add("Building" = list("Bad,Name"))), "eplusr_error_validity_check")
+    expect_equal(err$data$invalid_character$value_chr, "Bad,Name")
+    expect_s3_class(err <- catch_cnd(idf$add("Building" = list("Bad;Name"))), "eplusr_error_validity_check")
+    expect_equal(err$data$invalid_character$value_chr, "Bad;Name")
+
     # adding empty object
     expect_s3_class(idf$add("Building" = list())[[1L]], "IdfObject")
 
@@ -514,6 +519,9 @@ test_that("$add()", {
 test_that("$set()", {
     skip_on_cran()
     expect_s3_class(idf <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")), "Idf")
+
+    expect_s3_class(err <- catch_cnd(idf$set(..8 = list(name = "rp,test"))), "eplusr_error_validity_check")
+    expect_equal(err$data$invalid_character$value_chr, "rp,test")
 
     # set new values and comments
     expect_type(type = "list",

--- a/tests/testthat/test-idfobj.R
+++ b/tests/testthat/test-idfobj.R
@@ -204,6 +204,10 @@ test_that("$set()", {
     # can stop when invalid names are given for a non-extensible class
     expect_error(mat$set(wrong = "something"), class = "eplusr_error_invalid_field_name")
 
+    # can stop when character fields contain IDF delimiters
+    expect_s3_class(err <- catch_cnd(mat$set(name = "Bad;Name")), "eplusr_error_validity_check")
+    expect_equal(err$data$invalid_character$value_chr, "Bad;Name")
+
     # can stop when invalid names are given for an extensible class
     expect_error(con$set(name = "first", wrong = "second"), class = "eplusr_error_invalid_field_name")
 

--- a/tests/testthat/test-impl-epw.R
+++ b/tests/testthat/test-impl-epw.R
@@ -35,14 +35,14 @@ test_that("Epw Header", {
             TYPICAL/EXTREME PERIODS
             GROUND TEMPERATURES
             HOLIDAYS/DAYLIGHT SAVINGS,yes,0,0,0
-            COMMENTS 1
+            COMMENTS 1,Allowed; comment
             COMMENTS 2
             DATA PERIODS,1,1, Data, Friday, 2016/01/01, 2016/12/31
             "
         )
     )
     expect_equal(h$value[object_id %in% c(2, 3, 4), value_num], rep(0, 3))
-    expect_equal(h$value[object_id %in% c(6, 7), value_chr], rep(NA_character_, 2))
+    expect_equal(h$value[object_id %in% c(6, 7), value_chr], c("Allowed; comment", NA_character_))
 
     # can fix mismatched extensible group and value of number field
     suppressWarnings(expect_warning(

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -185,6 +185,19 @@ test_that("Validate method", {
     expect_equal(chr$object_id, 1:4)
     expect_equal(chr$field_index, rep(1L, 4L))
     expect_equal(chr$value_id, c(1L, 10L, 15L, 41L))
+
+    env_in <- list2env(parse_idf_file(idftext("idf")))
+    env_in$validity <- empty_validity()
+    add_joined_cols(env_in$object, env_in$value, "object_id", c("class_id", "object_name"))
+    add_class_property(idd_env, env_in$value, c("class_id", "class_name"))
+    add_field_property(idd_env, env_in$value, c("field_index", "field_name", "units", "ip_units", "type_enum"))
+    invisible(env_in$value[value_id %in% c(1L, 10L), value_chr := c("Building,One", "Construction;One")])
+
+    expect_silent({chr <- check_invalid_character(idd_env, idf_env, env_in)$validity$invalid_character})
+    expect_equal(chr$object_id, 1:2)
+    expect_equal(chr$field_index, rep(1L, 2L))
+    expect_equal(chr$value_id, c(1L, 10L))
+    expect_equal(chr$value_chr, c("Building,One", "Construction;One"))
     # }}}
 
     # INVALID NUMERIC {{{


### PR DESCRIPTION
Closes #67.

## Summary
- Reject comma and semicolon delimiters in IDF character field values during type validation.
- Preserve EPW header validation semantics where semicolons in comments are valid.
- Update validation docs, NEWS, and focused tests.