### PR TITLE
feat(idf): add IdfObject field presence check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.17.0.9002
+Version: 0.17.0.9007
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # eplusr (development version)
 
+## New features
+
+* `IdfObject$is_valid_field()` can now check whether fields are present in the
+  current object instead of only being defined in the IDD (#391).
+
 ## Internal refactor
 
 * Use cli conditions for eplusr verbose logging, package warnings, errors, and

--- a/R/idfobj.R
+++ b/R/idfobj.R
@@ -341,6 +341,34 @@ IdfObject <- R6::R6Class(classname = "IdfObject",
             idfobj_value(self, private, which, all, simplify, unit),
         # }}}
 
+        # is_valid_field {{{
+        #' @description
+        #' Check if fields exist in current object.
+        #'
+        #' @details
+        #' `$is_valid_field()` returns `TRUE` if the specified fields are present
+        #' in the current `IdfObject`. It checks fields that the object actually
+        #' contains, not all possible fields defined in the underlying [Idd].
+        #' Fields with blank values are still treated as existing.
+        #'
+        #' Field names can be given in underscore style, e.g. `"outside_layer"`
+        #' is equivalent to `"Outside Layer"`.
+        #'
+        #' @param which An integer vector of field indexes or a character vector
+        #'        of field names.
+        #'
+        #' @return A logical vector with the same length as `which`.
+        #'
+        #' @examples
+        #' \dontrun{
+        #' con <- idf$Construction[[1L]]
+        #' con$is_valid_field(c("Name", "Layer 5"))
+        #' }
+        #'
+        is_valid_field = function(which)
+            idfobj_is_valid_field(self, private, which),
+        # }}}
+
         # set {{{
         #' @description
         #' Modify object field values.
@@ -1567,6 +1595,21 @@ idfobj_comment <- function(self, private, comment, append = TRUE, width = 0L) {
 # idfobj_value {{{
 idfobj_value <- function(self, private, which = NULL, all = FALSE, simplify = FALSE, unit = FALSE) {
     get_idfobj_value(private$idd_env(), private$idf_env(), private$m_object_id, which, all, simplify, unit)
+}
+# }}}
+# idfobj_is_valid_field {{{
+#' @importFrom checkmate assert_character test_integerish
+idfobj_is_valid_field <- function(self, private, which) {
+    val <- private$idf_env()$value[J(private$m_object_id), on = "object_id", nomatch = 0L]
+    fld <- private$idd_env()$field[J(val$field_id), on = "field_id", nomatch = 0L]
+
+    if (test_integerish(which, lower = 1L, any.missing = FALSE)) {
+        return(as.integer(which) %in% fld$field_index)
+    }
+
+    assert_character(which, any.missing = FALSE)
+
+    lower_name(which) %chin% lower_name(fld$field_name)
 }
 # }}}
 # idfobj_set {{{

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -191,6 +191,16 @@ mat[c("Name", "Density")]
 
 
 ## ------------------------------------------------
+## Method `IdfObject$is_valid_field`
+## ------------------------------------------------
+
+\dontrun{
+con <- idf$Construction[[1L]]
+con$is_valid_field(c("Name", "Layer 5"))
+}
+
+
+## ------------------------------------------------
 ## Method `IdfObject$set`
 ## ------------------------------------------------
 
@@ -434,6 +444,7 @@ Hongyuan Jia
 \item \href{#method-IdfObject-definition}{\code{IdfObject$definition()}}
 \item \href{#method-IdfObject-comment}{\code{IdfObject$comment()}}
 \item \href{#method-IdfObject-value}{\code{IdfObject$value()}}
+\item \href{#method-IdfObject-is_valid_field}{\code{IdfObject$is_valid_field()}}
 \item \href{#method-IdfObject-set}{\code{IdfObject$set()}}
 \item \href{#method-IdfObject-value_possible}{\code{IdfObject$value_possible()}}
 \item \href{#method-IdfObject-validate}{\code{IdfObject$validate()}}
@@ -867,6 +878,49 @@ mat$Roughness
 mat[["Specific_Heat"]]
 mat[c(1,2)]
 mat[c("Name", "Density")]
+}
+
+}
+\if{html}{\out{</div>}}
+
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-IdfObject-is_valid_field"></a>}}
+\if{latex}{\out{\hypertarget{method-IdfObject-is_valid_field}{}}}
+\subsection{Method \code{is_valid_field()}}{
+Check if fields exist in current object.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{IdfObject$is_valid_field(which)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{which}}{An integer vector of field indexes or a character vector
+of field names.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Details}{
+\verb{$is_valid_field()} returns \code{TRUE} if the specified fields are present
+in the current \code{IdfObject}. It checks fields that the object actually
+contains, not all possible fields defined in the underlying \link{Idd}.
+Fields with blank values are still treated as existing.
+
+Field names can be given in underscore style, e.g. \code{"outside_layer"}
+is equivalent to \code{"Outside Layer"}.
+}
+
+\subsection{Returns}{
+A logical vector with the same length as \code{which}.
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+con <- idf$Construction[[1L]]
+con$is_valid_field(c("Name", "Layer 5"))
 }
 
 }

--- a/man/IdfSchedule.Rd
+++ b/man/IdfSchedule.Rd
@@ -153,6 +153,7 @@ Hongyuan Jia
 <li><span class="pkg-link" data-pkg="eplusr" data-topic="IdfObject" data-id="has_ref_node"><a href='../../eplusr/html/IdfObject.html#method-IdfObject-has_ref_node'><code>eplusr::IdfObject$has_ref_node()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="eplusr" data-topic="IdfObject" data-id="has_ref_to"><a href='../../eplusr/html/IdfObject.html#method-IdfObject-has_ref_to'><code>eplusr::IdfObject$has_ref_to()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="eplusr" data-topic="IdfObject" data-id="id"><a href='../../eplusr/html/IdfObject.html#method-IdfObject-id'><code>eplusr::IdfObject$id()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="eplusr" data-topic="IdfObject" data-id="is_valid_field"><a href='../../eplusr/html/IdfObject.html#method-IdfObject-is_valid_field'><code>eplusr::IdfObject$is_valid_field()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="eplusr" data-topic="IdfObject" data-id="name"><a href='../../eplusr/html/IdfObject.html#method-IdfObject-name'><code>eplusr::IdfObject$name()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="eplusr" data-topic="IdfObject" data-id="parent"><a href='../../eplusr/html/IdfObject.html#method-IdfObject-parent'><code>eplusr::IdfObject$parent()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="eplusr" data-topic="IdfObject" data-id="print"><a href='../../eplusr/html/IdfObject.html#method-IdfObject-print'><code>eplusr::IdfObject$print()</code></a></span></li>

--- a/tests/testthat/test-idfobj.R
+++ b/tests/testthat/test-idfobj.R
@@ -181,6 +181,27 @@ test_that("$value()", {
 })
 # }}}
 
+# IS_VALID_FIELD {{{
+test_that("$is_valid_field()", {
+    skip_on_cran()
+    expect_s3_class(idf <- read_idf(idftext("idf")), "Idf")
+    expect_s3_class(con <- IdfObject$new(2, parent = idf), "IdfObject")
+
+    expect_equal(
+        con$is_valid_field(c("Name", "Layer 4", "Layer 5", "Wrong")),
+        c(TRUE, TRUE, FALSE, FALSE)
+    )
+    expect_equal(con$is_valid_field(c(1L, 5L, 6L)), c(TRUE, TRUE, FALSE))
+
+    expect_true(con$is_valid_field("layer_4"))
+    expect_true(con$is_valid_field("layer 4"))
+    expect_false(con$is_valid_field("layer_5"))
+
+    expect_silent(without_checking(con$set(`Layer 5` = "", .empty = TRUE)))
+    expect_true(con$is_valid_field("Layer 5"))
+})
+# }}}
+
 # SET {{{
 test_that("$set()", {
     skip_on_cran()


### PR DESCRIPTION
Closes #391.

## Summary
- Add `IdfObject$is_valid_field()` to check whether fields are actually present in the current object.
- Treat IDD-defined but absent fields as `FALSE`, while preserving `TRUE` for present blank fields.
- Document the new R6 method and add focused `IdfObject` tests.