### PR TITLE
feat: allow to_string without field names

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,6 +3,7 @@
 ^\.Rproj\.user$
 \.Rproj$
 ^\.gitignore$
+^\.git$
 ^\.travis\.yml$
 ^appveyor\.yml$
 ^.appveyor_clear_cache.txt$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.17.0.9007
+Version: 0.17.0.9008
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * `IdfObject$is_valid_field()` can now check whether fields are present in the
   current object instead of only being defined in the IDD (#391).
 
+* Add a `field` argument to `$to_string()` methods to optionally omit field
+  name comments from generated IDF strings (#77).
+
 ## Internal refactor
 
 * Use cli conditions for eplusr verbose logging, package warnings, errors, and

--- a/R/format.R
+++ b/R/format.R
@@ -135,7 +135,7 @@ format_idf <- function(
     dt_value, dt_object = NULL, dt_order = NULL,
     header = TRUE, comment = TRUE, save_format = c("sorted", "new_top", "new_bot"),
     special_format = FALSE, leading = 4L, sep_at = 29L, index = FALSE,
-    blank = FALSE, end = TRUE, required = FALSE
+    blank = FALSE, end = TRUE, required = FALSE, field = TRUE
 )
 {
     assert_names(names(dt_value), must.include = c("object_id", "class_id", "class_name", "field_index"))
@@ -147,12 +147,14 @@ format_idf <- function(
     assert_flag(blank)
     assert_flag(end)
     assert_flag(required)
+    assert_flag(field)
 
     setorderv(dt_value, c("object_id", "field_index"))
 
     # get field value
     fld <- format_field(dt_value, leading = leading, sep_at = sep_at,
-        index = index, blank = blank, end = end, required = required)
+        index = index, blank = blank, end = end, required = required,
+        field = field)
 
     # init output as field values
     set(dt_value, NULL, "fmt", fld)
@@ -874,20 +876,24 @@ format_field <- function(dt,
                           # value
                           value = TRUE, quote = FALSE, blank = FALSE, end = TRUE, required = FALSE,
                           # field
-                          prefix = TRUE) {
+                          field = TRUE, prefix = TRUE) {
+    assert_flag(field)
+
     idx <- NULL
+    show_field <- field && sep_at >= 0L
 
     if (index) {
         idx <- paste0(format_index(dt, required = required, pad_char = pad_char), ": ")
     }
 
     if (value) {
-        val <- format_value(dt, leading = leading, length = sep_at, quote = quote, blank = blank, end = end)
+        val <- format_value(dt, leading = leading, length = if (show_field) sep_at else -1L,
+            quote = quote, blank = blank, end = end)
     } else {
         val <- NULL
     }
 
-    nm <- if (sep_at < 0L) "" else format_name(dt, prefix)
+    nm <- if (show_field) format_name(dt, prefix) else ""
 
     paste0(idx, val, nm)
 }

--- a/R/idd.R
+++ b/R/idd.R
@@ -667,6 +667,8 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
         #'        between different classes. Default: `0`.
         #' @param all If `TRUE`, all available fields defined in IDD for
         #'        specified class will be returned. Default: `FALSE`.
+        #' @param field If `FALSE`, field names will not be included as comments.
+        #'        Default: `TRUE`.
         #'
         #' @return A character vector.
         #'
@@ -682,8 +684,9 @@ Idd <- R6::R6Class(classname = "Idd", cloneable = FALSE,
         #' idd$to_string(c("Material", "Construction"), leading = 0, sep_at = 0, sep_each = 5)
         #' }
         #'
-        to_string = function(class, leading = 4L, sep_at = 29L, sep_each = 0L, all = FALSE)
-            idd_to_string(self, private, class, leading, sep_at, sep_each, all),
+        to_string = function(class, leading = 4L, sep_at = 29L, sep_each = 0L, all = FALSE, field = TRUE)
+            idd_to_string(self, private, class = class, leading = leading,
+                sep_at = sep_at, sep_each = sep_each, all = all, field = field),
         # }}}
         # }}}
 
@@ -879,8 +882,9 @@ idd_to_table <- function(self, private, class, all) {
 }
 # }}}
 # idd_to_string {{{
-idd_to_string <- function(self, private, class, leading = 4L, sep_at = 29L, sep_each = 0L, all = FALSE) {
-    get_idd_string(private$m_idd_env, class, leading, sep_at, sep_each, all)
+idd_to_string <- function(self, private, class, leading = 4L, sep_at = 29L, sep_each = 0L, all = FALSE, field = TRUE) {
+    get_idd_string(private$m_idd_env, class = class, leading = leading,
+        sep_at = sep_at, sep_each = sep_each, all = all, field = field)
 }
 # }}}
 # idd_print {{{

--- a/R/iddobj.R
+++ b/R/iddobj.R
@@ -1389,6 +1389,8 @@ IddObject <- R6::R6Class(classname = "IddObject", cloneable = FALSE,
         #'        string. Default: `29L` which is the same as IDF Editor.
         #' @param all If `TRUE`, all available fields defined in IDD for
         #'        specified class will be returned. Default: `FALSE`.
+        #' @param field If `FALSE`, field names will not be included as comments.
+        #'        Default: `TRUE`.
         #'
         #' @return A character vector.
         #'
@@ -1404,8 +1406,9 @@ IddObject <- R6::R6Class(classname = "IddObject", cloneable = FALSE,
         #' surf$to_string(c("This", "will", "be", "comments"))
         #' }
         #'
-        to_string = function(comment = NULL, leading = 4L, sep_at = 29L, all = FALSE)
-            iddobj_to_string(self, private, comment, leading, sep_at = sep_at, all = all),
+        to_string = function(comment = NULL, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE)
+            iddobj_to_string(self, private, comment = comment, leading = leading,
+                sep_at = sep_at, all = all, field = field),
         # }}}
         # }}}
 
@@ -1827,9 +1830,9 @@ iddobj_to_table <- function(self, private, all = FALSE) {
 }
 # }}}
 # iddobj_to_string {{{
-iddobj_to_string <- function(self, private, comment = NULL, leading = 4L, sep_at = 29L, all = FALSE) {
+iddobj_to_string <- function(self, private, comment = NULL, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE) {
     get_iddobj_string(private$idd_env(), private$m_class_id, comment = comment,
-        leading = leading, sep_at = sep_at, all = all
+        leading = leading, sep_at = sep_at, all = all, field = field
     )
 }
 # }}}
@@ -1931,6 +1934,8 @@ format.IddObject <- function(x, ver = TRUE, ...) {
 #' @param leading Leading spaces added to each field. Default: `4`.
 #' @param sep_at The character width to separate value string and field string.
 #'        Default: `29` which is the same as IDF Editor.'
+#' @param field If `FALSE`, field names will not be included as comments.
+#'        Default: `TRUE`.
 #' @param ... Further arguments passed to or from other methods.
 #'
 #' @return A character vector.
@@ -1941,8 +1946,9 @@ format.IddObject <- function(x, ver = TRUE, ...) {
 #'
 #' @export
 # as.character.IddObject {{{
-as.character.IddObject <- function(x, comment = NULL, leading = 4L, sep_at = 29L, all = FALSE, ...) {
-    x$to_string(comment = comment, leading = leading, sep_at = sep_at, all = all)
+as.character.IddObject <- function(x, comment = NULL, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE, ...) {
+    x$to_string(comment = comment, leading = leading, sep_at = sep_at,
+        all = all, field = field)
 }
 # }}}
 

--- a/R/idf.R
+++ b/R/idf.R
@@ -2140,6 +2140,8 @@ Idf <- R6::R6Class(classname = "Idf",
         #' @param leading Leading spaces added to each field. Default: `4L`.
         #' @param sep_at The character width to separate value string and field
         #'        string. Default: `29L` which is the same as IDF Editor.
+        #' @param field If `FALSE`, field names will not be included as comments.
+        #'        Default: `TRUE`.
         #'
         #' @return A character vector.
         #'
@@ -2163,10 +2165,10 @@ Idf <- R6::R6Class(classname = "Idf",
         #'
         to_string = function(which = NULL, class = NULL, comment = TRUE,
                               header = TRUE, format = eplusr_option("save_format"),
-                              leading = 4L, sep_at = 29L)
+                              leading = 4L, sep_at = 29L, field = TRUE)
             idf_to_string(self, private, which, class, comment = comment,
                           header = header, format = format,
-                          leading = leading, sep_at = sep_at),
+                          leading = leading, sep_at = sep_at, field = field),
         # }}}
 
         # to_table {{{
@@ -3327,12 +3329,12 @@ idf_is_valid <- function(self, private, level = eplusr_option("validate_level"))
 # idf_to_string {{{
 idf_to_string <- function(self, private, which = NULL, class = NULL,
                            comment = TRUE, header = TRUE, format = eplusr_option("save_format"),
-                           leading = 4L, sep_at = 29L) {
+                           leading = 4L, sep_at = 29L, field = TRUE) {
     if (format == "asis") format <- private$m_log$save_format
 
     get_idf_string(private$idd_env(), private$idf_env(), private$m_log$order,
         class, which, comment = comment, header = header, format = format,
-        leading = leading, sep_at = sep_at
+        leading = leading, sep_at = sep_at, field = field
     )
 }
 # }}}
@@ -3948,6 +3950,8 @@ str.Idf <- function(object, zoom = "class", ...) {
 #' @param leading Leading spaces added to each field. Default: `4L`.
 #' @param sep_at The character width to separate value string and field string.
 #' Default: `29L` which is the same as IDF Editor.
+#' @param field If `FALSE`, field names will not be included as comments.
+#' Default: `TRUE`.
 #' @param ... Further arguments passed to or from other methods.
 #' @return A single length string.
 #' @examples
@@ -3960,10 +3964,10 @@ str.Idf <- function(object, zoom = "class", ...) {
 # format.idf {{{
 format.Idf <- function(x, comment = TRUE, header = TRUE,
                         format = eplusr_option("save_format"),
-                        leading = 4L, sep_at = 29L, ...) {
+                        leading = 4L, sep_at = 29L, field = TRUE, ...) {
     paste0(
         x$to_string(comment = comment, header = header, format = format,
-            leading = leading, sep_at = sep_at, ...
+            leading = leading, sep_at = sep_at, field = field, ...
         ),
         collapse = "\n"
     )
@@ -3986,9 +3990,9 @@ format.Idf <- function(x, comment = TRUE, header = TRUE,
 # as.character.Idf {{{
 as.character.Idf <- function(x, comment = TRUE, header = TRUE,
                         format = eplusr_option("save_format"),
-                        leading = 4L, sep_at = 29L, ...) {
+                        leading = 4L, sep_at = 29L, field = TRUE, ...) {
     x$to_string(comment = comment, header = header, format = format,
-        leading = leading, sep_at = sep_at, ...
+        leading = leading, sep_at = sep_at, field = field, ...
     )
 }
 # }}}

--- a/R/idfobj.R
+++ b/R/idfobj.R
@@ -1366,6 +1366,9 @@ IdfObject <- R6::R6Class(classname = "IdfObject",
         #'        class that objects belong to will be returned. Default:
         #'        `FALSE`.
         #'
+        #' @param field If `FALSE`, field names will not be included as comments.
+        #'        Default: `TRUE`.
+        #'
         #' @return A character vector.
         #'
         #' @examples
@@ -1381,8 +1384,9 @@ IdfObject <- R6::R6Class(classname = "IdfObject",
         #' mat$to_string(leading = 0)
         #' }
         #'
-        to_string = function(comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE)
-            idfobj_to_string(self, private, comment, leading, sep_at, all),
+        to_string = function(comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE)
+            idfobj_to_string(self, private, comment = comment, leading = leading,
+                sep_at = sep_at, all = all, field = field),
         # }}}
 
         # print {{{
@@ -1832,9 +1836,10 @@ idfobj_to_table <- function(self, private, all = FALSE, string_value = TRUE,
 }
 # }}}
 # idfobj_to_string {{{
-idfobj_to_string <- function(self, private, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE) {
+idfobj_to_string <- function(self, private, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE) {
     get_idfobj_string(private$idd_env(), private$idf_env(), private$m_object_id,
-        comment = comment, leading = leading, sep_at = sep_at, all = all
+        comment = comment, leading = leading, sep_at = sep_at, all = all,
+        field = field
     )
 }
 # }}}
@@ -1890,6 +1895,8 @@ idfobj_print <- function(self, private, comment = TRUE, auto_sep = FALSE, brief 
 #' Default: `29L` which is the same as IDF Editor.
 #' @param all If `TRUE`, values of all possible fields in current class the
 #'   [IdfObject] belongs to are returned. Default: `FALSE`
+#' @param field If `FALSE`, field names will not be included as comments.
+#' Default: `TRUE`.
 #' @param ... Further arguments passed to or from other methods.
 #' @return A character vector.
 #' @examples
@@ -1905,8 +1912,9 @@ idfobj_print <- function(self, private, comment = TRUE, auto_sep = FALSE, brief 
 #'
 #' @export
 # format.IdfObject {{{
-format.IdfObject <- function(x, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, ...) {
-    paste0(x$to_string(comment = comment, leading = leading, sep_at = sep_at, all = all), collapse = "\n")
+format.IdfObject <- function(x, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE, ...) {
+    paste0(x$to_string(comment = comment, leading = leading, sep_at = sep_at,
+        all = all, field = field), collapse = "\n")
 }
 # }}}
 
@@ -1929,8 +1937,9 @@ format.IdfObject <- function(x, comment = TRUE, leading = 4L, sep_at = 29L, all 
 #'
 #' @export
 # as.character.IdfObject {{{
-as.character.IdfObject <- function(x, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, ...) {
-    x$to_string(comment = comment, leading = leading, sep_at = sep_at, all = all)
+as.character.IdfObject <- function(x, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE, ...) {
+    x$to_string(comment = comment, leading = leading, sep_at = sep_at,
+        all = all, field = field)
 }
 # }}}
 

--- a/R/impl-idd.R
+++ b/R/impl-idd.R
@@ -1071,7 +1071,7 @@ get_idd_table <- function(idd_env, class, all = FALSE) {
 
 # STRING
 # get_idd_string {{{
-get_idd_string <- function(idd_env, class, leading = 4L, sep_at = 29L, sep_each = 0L, all = FALSE) {
+get_idd_string <- function(idd_env, class, leading = 4L, sep_at = 29L, sep_each = 0L, all = FALSE, field = TRUE) {
     assert_valid_type(class, "Class Index|Name")
     assert_count(sep_each)
 
@@ -1079,7 +1079,7 @@ get_idd_string <- function(idd_env, class, leading = 4L, sep_at = 29L, sep_each 
 
     # add fake value in order to correctly format
     set(fld, NULL, "value_chr", NA_character_)
-    set(fld, NULL, "field", format_field(fld, leading = leading, sep_at = sep_at))
+    set(fld, NULL, "field", format_field(fld, leading = leading, sep_at = sep_at, field = field))
 
     sep <- rep("", sep_each)
     out <- fld[, list(out = list(c(paste0(class_name[[1L]], ","), field, sep))), by = "class_id"]

--- a/R/impl-iddobj.R
+++ b/R/impl-iddobj.R
@@ -94,12 +94,12 @@ get_iddobj_table <- function(idd_env, class_id = NULL, all = FALSE) {
 }
 # }}}
 # get_iddobj_string {{{
-get_iddobj_string <- function(idd_env, class_id = NULL, comment = NULL, leading = 4L, sep_at = 29L, all = FALSE) {
+get_iddobj_string <- function(idd_env, class_id = NULL, comment = NULL, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE) {
     fld <- get_idd_field(idd_env, class_id, property = c("units", "ip_units"), all = all)
     # add fake value in order to correctly format
     set(fld, NULL, "value_chr", NA_character_)
 
-    str_fld <- format_field(fld, leading = leading, sep_at = sep_at)
+    str_fld <- format_field(fld, leading = leading, sep_at = sep_at, field = field)
     str_cls <- paste0(fld$class_name[[1L]], ",")
     str_cmt <- NULL
 

--- a/R/impl-idf.R
+++ b/R/impl-idf.R
@@ -4521,7 +4521,7 @@ dt_to_load <- function(dt, string_value = TRUE) {
 get_idf_string <- function(idd_env, idf_env, dt_order = NULL, class = NULL, object = NULL,
                             in_ip = FALSE, comment = TRUE, header = TRUE,
                             format = c("sorted", "new_top", "new_bot"),
-                            leading = 4L, sep_at = 29L, flat = TRUE) {
+                            leading = 4L, sep_at = 29L, flat = TRUE, field = TRUE) {
     format <- match.arg(format)
 
     # IP - SI conversion
@@ -4543,7 +4543,8 @@ get_idf_string <- function(idd_env, idf_env, dt_order = NULL, class = NULL, obje
                     idf_env$value[J(obj$object_id), on = "object_id"],
                     idf_env$object[J(obj$object_id), on = "object_id"],
                     dt_order, header = header, comment = comment,
-                    save_format = format, leading = leading, sep_at = sep_at
+                    save_format = format, leading = leading, sep_at = sep_at,
+                    field = field
                 )
             )
         ))
@@ -4552,7 +4553,7 @@ get_idf_string <- function(idd_env, idf_env, dt_order = NULL, class = NULL, obje
             with_option(list(view_in_ip = temp_ip),
                 format_idf(idf_env$value, idf_env$object, dt_order,
                     header = header, comment = comment, save_format = format,
-                    leading = leading, sep_at = sep_at
+                    leading = leading, sep_at = sep_at, field = field
                 )
             )
         ))

--- a/R/impl-idfobj.R
+++ b/R/impl-idfobj.R
@@ -196,14 +196,15 @@ get_idfobj_table <- function(idd_env, idf_env, object_id, all = FALSE,
 }
 # }}}
 # get_idfobj_string {{{
-get_idfobj_string <- function(idd_env, idf_env, object_id, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE) {
+get_idfobj_string <- function(idd_env, idf_env, object_id, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, field = TRUE) {
     val <- get_idf_value(idd_env, idf_env, object = object_id, property = c("units", "ip_units"), all = all)
 
     cls <- paste0(val$class_name[[1L]], ",")
 
     # get field value
     fld <- format_field(val, leading = leading, sep_at = sep_at,
-        index = FALSE, blank = FALSE, end = TRUE, required = FALSE)
+        index = FALSE, blank = FALSE, end = TRUE, required = FALSE,
+        field = field)
 
     if (comment) {
         id <- object_id

--- a/man/Idd.Rd
+++ b/man/Idd.Rd
@@ -1183,7 +1183,14 @@ idd$to_table(c("Construction", "Material"))
 \subsection{Method \code{to_string()}}{
 Format \code{Idf} classes as a character vector
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Idd$to_string(class, leading = 4L, sep_at = 29L, sep_each = 0L, all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Idd$to_string(
+  class,
+  leading = 4L,
+  sep_at = 29L,
+  sep_each = 0L,
+  all = FALSE,
+  field = TRUE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -1201,6 +1208,9 @@ between different classes. Default: \code{0}.}
 
 \item{\code{all}}{If \code{TRUE}, all available fields defined in IDD for
 specified class will be returned. Default: \code{FALSE}.}
+
+\item{\code{field}}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/IddObject.Rd
+++ b/man/IddObject.Rd
@@ -2499,7 +2499,13 @@ surf$to_table(TRUE)
 \subsection{Method \code{to_string()}}{
 Format an \code{IdfObject} as a character vector
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{IddObject$to_string(comment = NULL, leading = 4L, sep_at = 29L, all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{IddObject$to_string(
+  comment = NULL,
+  leading = 4L,
+  sep_at = 29L,
+  all = FALSE,
+  field = TRUE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -2515,6 +2521,9 @@ string. Default: \code{29L} which is the same as IDF Editor.}
 
 \item{\code{all}}{If \code{TRUE}, all available fields defined in IDD for
 specified class will be returned. Default: \code{FALSE}.}
+
+\item{\code{field}}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Idf.Rd
+++ b/man/Idf.Rd
@@ -3589,7 +3589,8 @@ Format \code{Idf} as a character vector
   header = TRUE,
   format = eplusr_option("save_format"),
   leading = 4L,
-  sep_at = 29L
+  sep_at = 29L,
+  field = TRUE
 )}\if{html}{\out{</div>}}
 }
 
@@ -3625,6 +3626,9 @@ options \code{"Sorted"}, \code{"Original with New at Top"}, and \code{"Original 
 
 \item{\code{sep_at}}{The character width to separate value string and field
 string. Default: \code{29L} which is the same as IDF Editor.}
+
+\item{\code{field}}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/IdfObject.Rd
+++ b/man/IdfObject.Rd
@@ -2126,7 +2126,13 @@ surf$to_table(group_ext = "index", wide = TRUE, string_value = FALSE, unit = TRU
 \subsection{Method \code{to_string()}}{
 Format current object as a character vector
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{IdfObject$to_string(comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{IdfObject$to_string(
+  comment = TRUE,
+  leading = 4L,
+  sep_at = 29L,
+  all = FALSE,
+  field = TRUE
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -2143,6 +2149,9 @@ string. Default: \code{29L} which is the same as IDF Editor.}
 \item{\code{all}}{If \code{TRUE}, all available fields defined in IDD for the
 class that objects belong to will be returned. Default:
 \code{FALSE}.}
+
+\item{\code{field}}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/as.character.IddObject.Rd
+++ b/man/as.character.IddObject.Rd
@@ -4,7 +4,15 @@
 \alias{as.character.IddObject}
 \title{Coerce an IddObject into a Character Vector}
 \usage{
-\method{as.character}{IddObject}(x, comment = NULL, leading = 4L, sep_at = 29L, all = FALSE, ...)
+\method{as.character}{IddObject}(
+  x,
+  comment = NULL,
+  leading = 4L,
+  sep_at = 29L,
+  all = FALSE,
+  field = TRUE,
+  ...
+)
 }
 \arguments{
 \item{x}{An \link{IddObject} object.}
@@ -19,6 +27,9 @@ Default: \code{29} which is the same as IDF Editor.'}
 
 \item{all}{If \code{TRUE}, all fields in current class are returned, otherwise
 only minimum fields are returned.}
+
+\item{field}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 
 \item{...}{Further arguments passed to or from other methods.}
 }

--- a/man/as.character.Idf.Rd
+++ b/man/as.character.Idf.Rd
@@ -11,6 +11,7 @@
   format = eplusr_option("save_format"),
   leading = 4L,
   sep_at = 29L,
+  field = TRUE,
   ...
 )
 }
@@ -28,6 +29,9 @@
 
 \item{sep_at}{The character width to separate value string and field string.
 Default: \code{29L} which is the same as IDF Editor.}
+
+\item{field}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 
 \item{...}{Further arguments passed to or from other methods.}
 }

--- a/man/as.character.IdfObject.Rd
+++ b/man/as.character.IdfObject.Rd
@@ -4,7 +4,15 @@
 \alias{as.character.IdfObject}
 \title{Coerce an IdfObject into a Character Vector}
 \usage{
-\method{as.character}{IdfObject}(x, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, ...)
+\method{as.character}{IdfObject}(
+  x,
+  comment = TRUE,
+  leading = 4L,
+  sep_at = 29L,
+  all = FALSE,
+  field = TRUE,
+  ...
+)
 }
 \arguments{
 \item{x}{An \link{IdfObject} object.}
@@ -18,6 +26,9 @@ Default: \code{29L} which is the same as IDF Editor.}
 
 \item{all}{If \code{TRUE}, values of all possible fields in current class the
 \link{IdfObject} belongs to are returned. Default: \code{FALSE}}
+
+\item{field}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 
 \item{...}{Further arguments passed to or from other methods.}
 }

--- a/man/format.Idf.Rd
+++ b/man/format.Idf.Rd
@@ -11,6 +11,7 @@
   format = eplusr_option("save_format"),
   leading = 4L,
   sep_at = 29L,
+  field = TRUE,
   ...
 )
 }
@@ -28,6 +29,9 @@
 
 \item{sep_at}{The character width to separate value string and field string.
 Default: \code{29L} which is the same as IDF Editor.}
+
+\item{field}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 
 \item{...}{Further arguments passed to or from other methods.}
 }

--- a/man/format.IdfObject.Rd
+++ b/man/format.IdfObject.Rd
@@ -4,7 +4,15 @@
 \alias{format.IdfObject}
 \title{Format an IdfObject}
 \usage{
-\method{format}{IdfObject}(x, comment = TRUE, leading = 4L, sep_at = 29L, all = FALSE, ...)
+\method{format}{IdfObject}(
+  x,
+  comment = TRUE,
+  leading = 4L,
+  sep_at = 29L,
+  all = FALSE,
+  field = TRUE,
+  ...
+)
 }
 \arguments{
 \item{x}{An \link{IdfObject} object.}
@@ -18,6 +26,9 @@ Default: \code{29L} which is the same as IDF Editor.}
 
 \item{all}{If \code{TRUE}, values of all possible fields in current class the
 \link{IdfObject} belongs to are returned. Default: \code{FALSE}}
+
+\item{field}{If \code{FALSE}, field names will not be included as comments.
+Default: \code{TRUE}.}
 
 \item{...}{Further arguments passed to or from other methods.}
 }

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -40,6 +40,14 @@ test_that("Formatting", {
           "  Test Character Field 2"
         )
     )
+
+    expect_equal(
+        format_field(
+            copy(idd_parsed$field[1:2])[, value_chr := c("Alpha", "Beta")],
+            leading = 2, sep_at = 10, field = FALSE
+        ),
+        c("  Alpha,", "  Beta;")
+    )
     expect_equal(format_objects(idd_parsed$group, component = "group")$out,
         c("Group: <TestGroup1>", "Group: <TestGroup2>")
     )

--- a/tests/testthat/test-idd.R
+++ b/tests/testthat/test-idd.R
@@ -263,6 +263,15 @@ test_that("Idd class", {
         )
 
     )
+    expect_equal(idd$to_string("TestSlash", all = TRUE, field = FALSE),
+        c(
+        "TestSlash,",
+        "    ,",
+        "    ,",
+        "    ,",
+        "    ;"
+        )
+    )
 
     # can print without error
     expect_output(idd$print())

--- a/tests/testthat/test-iddobj.R
+++ b/tests/testthat/test-iddobj.R
@@ -249,6 +249,14 @@ test_that("IddObject class", {
         )
     )
     expect_equal(
+        slash$to_string(field = FALSE),
+        c("TestSlash,",
+          "    ,",
+          "    ,",
+          "    ;"
+        )
+    )
+    expect_equal(
         slash$to_string(c("comment1", "comment2"), leading = 0L, sep_at = 0L),
         c("!comment1",
           "!comment2",
@@ -266,6 +274,7 @@ test_that("IddObject class", {
     expect_equal(format(slash, ver = FALSE), "<IddObject: 'TestSlash'>")
     expect_output(str(slash))
     expect_equal(as.character(slash), slash$to_string())
+    expect_equal(as.character(slash, field = FALSE), slash$to_string(field = FALSE))
     # }}}
 
     skip_on_cran()

--- a/tests/testthat/test-idf.R
+++ b/tests/testthat/test-idf.R
@@ -937,6 +937,24 @@ test_that("$to_string()", {
     )
     expect_silent(idf_1 <- read_idf(paste0(idf_string, collapse = "\n")))
     expect_equal(idf_1$to_string(format = "new_top"), idf_string)
+    expect_equal(
+        idf_1$to_string(format = "new_top", field = FALSE),
+        c(
+            "!-Generator eplusr",
+            "!-Option OriginalOrderTop",
+            "",
+            "!-NOTE: All comments with '!-' are ignored by the IDFEditor and are generated automatically.",
+            "!-      Use '!' comments if they need to be retained when using the IDFEditor.",
+            "",
+            "Construction,",
+            "    WALL-1,",
+            "    WD01;",
+            "",
+            "Version,",
+            sprintf("    %s;", LATEST_EPLUS_VER),
+            ""
+        )
+    )
 
     expect_s3_class(idf <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")), "Idf")
     expect_equal(idf$to_string()[2], "!-Option OriginalOrderTop")

--- a/tests/testthat/test-idfobj.R
+++ b/tests/testthat/test-idfobj.R
@@ -556,6 +556,14 @@ test_that("$to_string()", {
           "IN02,     !- Layer 3",
           "GP01;     !- Layer 4")
     )
+    expect_equal(con$to_string(leading = 0, sep_at = 10, field = FALSE),
+        c("Construction,",
+          "WALL-1,",
+          "WD01,",
+          "PW03,",
+          "IN02,",
+          "GP01;")
+    )
     expect_equal(con$to_string(leading = 0, sep_at = 10, all = TRUE),
         c("Construction,",
           "WALL-1,   !- Name",
@@ -603,6 +611,10 @@ test_that("format.IdfObject, as.character.IdfObject, etc", {
 
     expect_type(format(con), "character")
     expect_equal(as.character(con), con$to_string())
+    expect_equal(format(con, field = FALSE),
+        paste0(con$to_string(field = FALSE), collapse = "\n")
+    )
+    expect_equal(as.character(con, field = FALSE), con$to_string(field = FALSE))
     expect_output(str(con))
     expect_output(print(con))
 })


### PR DESCRIPTION
Closes #77.

## Summary

Adds a `field` argument to `$to_string()` methods so callers can omit generated field-name comments while keeping default output unchanged.

## Changes

- Threads `field` through `Idf`, `IdfObject`, `Idd`, and `IddObject` string formatting.
- Updates roxygen docs, NEWS, focused tests, and build ignore handling for git worktree checks.