### PR TITLE
perf(test): reduce default suite runtime

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,18 +49,13 @@ jobs:
         config:
           - {os: windows-latest, r: 'release', not_cran: false}
           - {os: macOS-latest,   r: 'release', not_cran: false}
-          - {os: ubuntu-latest,  r: 'devel',   not_cran: true, _EPLUSR_SKIP_TESTS_TRANSITION_: true, _EPLUSR_SKIP_TESTS_DOWNLOAD_EPW_: true, _EPLUSR_SKIP_TESTS_DOWNLOAD_IDD_: true, _EPLUSR_SKIP_TESTS_BASEMENT_: true, _EPLUSR_SKIP_TESTS_INSTALL_OLD_: true}
+          - {os: ubuntu-latest,  r: 'devel',   not_cran: true}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: true
       NOT_CRAN: ${{ matrix.config.not_cran }}
       RGL_USE_NULL: true
-      _EPLUSR_SKIP_TESTS_TRANSITION_: ${{ matrix.config['_EPLUSR_SKIP_TESTS_TRANSITION_'] || '' }}
-      _EPLUSR_SKIP_TESTS_DOWNLOAD_EPW_: ${{ matrix.config['_EPLUSR_SKIP_TESTS_DOWNLOAD_EPW_'] || '' }}
-      _EPLUSR_SKIP_TESTS_DOWNLOAD_IDD_: ${{ matrix.config['_EPLUSR_SKIP_TESTS_DOWNLOAD_IDD_'] || '' }}
-      _EPLUSR_SKIP_TESTS_BASEMENT_: ${{ matrix.config['_EPLUSR_SKIP_TESTS_BASEMENT_'] || '' }}
-      _EPLUSR_SKIP_TESTS_INSTALL_OLD_: ${{ matrix.config['_EPLUSR_SKIP_TESTS_INSTALL_OLD_'] || '' }}
       # for check non-character input in `base::numeric_version()`
       _R_CHECK_STOP_ON_INVALID_NUMERIC_VERSION_INPUTS_: true
       DISPLAY: 99 # for rgl

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -84,6 +84,8 @@ jobs:
           out <- Sys.getenv("GITHUB_OUTPUT")
           cat("path=", dir, "\n", file = out, append = TRUE, sep = "")
           cat("version=", as.character(utils::packageVersion("duckdb")), "\n", file = out, append = TRUE, sep = "")
+          # DuckDB otherwise uses a per-session temp directory that later checks cannot share.
+          cat("DUCKDB_EXTENSION_DIRECTORY=", dir, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
         shell: Rscript {0}
 
       - name: Restore DuckDB extension cache

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -46,6 +46,8 @@ jobs:
           out <- Sys.getenv("GITHUB_OUTPUT")
           cat("path=", dir, "\n", file = out, append = TRUE, sep = "")
           cat("version=", as.character(utils::packageVersion("duckdb")), "\n", file = out, append = TRUE, sep = "")
+          # DuckDB otherwise uses a per-session temp directory that callr subprocesses cannot share.
+          cat("DUCKDB_EXTENSION_DIRECTORY=", dir, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
         shell: Rscript {0}
 
       - name: Restore DuckDB extension cache

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -65,6 +65,8 @@ jobs:
           out <- Sys.getenv("GITHUB_OUTPUT")
           cat("path=", dir, "\n", file = out, append = TRUE, sep = "")
           cat("version=", as.character(utils::packageVersion("duckdb")), "\n", file = out, append = TRUE, sep = "")
+          # DuckDB otherwise uses a per-session temp directory that covr cannot share.
+          cat("DUCKDB_EXTENSION_DIRECTORY=", dir, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
         shell: Rscript {0}
 
       - name: Restore DuckDB extension cache

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -39,6 +39,7 @@ jobs:
       RGL_USE_NULL: true
       NOT_CRAN: true
       TESTTHAT_CPUS: 1
+      _EPLUSR_RUN_INTEGRATION_TESTS_: true
       R_KEEP_PKG_SOURCE: true
       COVR_COVRIGNORE: ".github/workflows/.covrignore"
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.17.0.9012
+Version: 0.17.0.9013
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",
@@ -92,4 +92,4 @@ Collate:
     'viewer.R'
     'zzz.R'
 Config/testthat/edition: 3
-Config/testthat/parallel: true
+Config/testthat/parallel: false

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,11 @@
 
 ## Internal refactor
 
+* Run tests serially by default and reserve network, transition, preprocessor,
+  and other heavy external-program checks for an explicit integration mode,
+  while retaining latest-version SQLite output coverage in the default suite
+  (#637).
+
 * Use DuckDB to read EnergyPlus SQLite output files, reducing eplusr's
   recursive dependency chain and raising the minimum supported R version to
   4.2.0 (#635).

--- a/tests/testthat/helper-eplus.R
+++ b/tests/testthat/helper-eplus.R
@@ -1,3 +1,12 @@
+# Skip tests that exercise external programs or network services unless the
+# single integration-test mode is explicitly enabled.
+skip_if_not_integration <- function() {
+    skip_if_not(
+        identical(Sys.getenv("_EPLUSR_RUN_INTEGRATION_TESTS_"), "true"),
+        "integration tests are disabled"
+    )
+}
+
 if (identical(Sys.getenv("NOT_CRAN"), "true") &&
     identical(Sys.getenv("CI"), "true") &&
     !is_avail_eplus(LATEST_EPLUS_VER)) {
@@ -5,5 +14,8 @@ if (identical(Sys.getenv("NOT_CRAN"), "true") &&
     # NOTE: From EnergyPlus v23.1, the supported oldest version for transition
     # is v9.0. Have to install at least one version before v23.1 for testing
     # older version transitions
-    if (!is_avail_eplus("22.2")) install_eplus("22.2", local = TRUE)
+    if (identical(Sys.getenv("_EPLUSR_RUN_INTEGRATION_TESTS_"), "true") &&
+        !is_avail_eplus("22.2")) {
+        install_eplus("22.2", local = TRUE)
+    }
 }

--- a/tests/testthat/helper-latest-output.R
+++ b/tests/testthat/helper-latest-output.R
@@ -1,0 +1,52 @@
+# Keep one authoritative latest-version EnergyPlus run for read-only consumers
+# during a testthat session. This is intentionally not persisted across runs.
+.latest_output_bundle <- new.env(parent = emptyenv())
+
+# Generate the shared output lazily so CRAN and skipped integration tests never
+# invoke EnergyPlus merely by loading the test helpers.
+latest_output_bundle <- function() {
+    if (!exists("value", envir = .latest_output_bundle, inherits = FALSE)) {
+        example <- copy_example()
+        output_dir <- tempfile("eplusr-latest-output-")
+        dir.create(output_dir)
+
+        idf <- read_idf(example$idf)
+        epw <- read_epw(example$epw)
+        job <- idf$run(example$epw, output_dir, echo = FALSE)
+
+        assign(
+            "value",
+            list(
+                idf = idf,
+                epw = epw,
+                idf_path = example$idf,
+                epw_path = example$epw,
+                job = job
+            ),
+            envir = .latest_output_bundle
+        )
+    }
+
+    get("value", envir = .latest_output_bundle, inherits = FALSE)
+}
+
+# Copy the bundle before a test mutates any generated output, then redirect the
+# cloned job result to that private directory.
+copy_latest_output_bundle <- function() {
+    bundle <- latest_output_bundle()
+    source_dir <- bundle$job$output_dir()
+    output_dir <- tempfile("eplusr-latest-output-copy-")
+    dir.create(output_dir)
+    copied <- file.copy(
+        list.files(source_dir, full.names = TRUE), output_dir,
+        recursive = TRUE, copy.mode = TRUE, copy.date = TRUE
+    )
+    stopifnot(all(copied))
+
+    job <- unserialize(serialize(bundle$job, NULL))
+    private <- get_priv_env(job)
+    private$m_job$output_dir <- normalizePath(output_dir)
+
+    bundle$job <- job
+    bundle
+}

--- a/tests/testthat/test-diagram.R
+++ b/tests/testthat/test-diagram.R
@@ -1,13 +1,17 @@
 test_that("HVAC Diagram", {
     skip_on_cran()
+    skip_if_not_integration()
 
-    example <- copy_example()
+    bundle <- latest_output_bundle()
 
-    expect_s3_class(job <- eplus_job(example$idf, example$epw), "EplusJob")
+    expect_s3_class(
+        pending_job <- eplus_job(bundle$idf_path, bundle$epw_path),
+        "EplusJob"
+    )
 
-    expect_warning(res <- hvac_diagram(job$version(), tempfile()))
+    expect_warning(res <- hvac_diagram(pending_job$version(), tempfile()))
 
-    expect_s3_class(job$run(wait = TRUE, echo = FALSE), "EplusJob")
+    expect_s3_class(job <- bundle$job, "EplusJob")
 
     expect_warning(res <- hvac_diagram(job$version(), job$locate_output(".bnd")))
     expect_type(res, "character")

--- a/tests/testthat/test-epw.R
+++ b/tests/testthat/test-epw.R
@@ -541,7 +541,7 @@ test_that("==.Epw & !=.Epw", {
 test_that("download_weather()", {
     skip_on_cran()
 
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_DOWNLOAD_EPW_") != "")
+    skip_if_not_integration()
     # download weather
     expect_message({path_epw <- with_verbose(
         download_weather("USA_CA_San.Francisco.Intl.AP.724940_TMY3", ask = FALSE, type = "epw", dir = tempdir(), max_match = 2)

--- a/tests/testthat/test-group.R
+++ b/tests/testthat/test-group.R
@@ -1,22 +1,17 @@
 test_that("Group methods", {
     skip_on_cran()
+    skip_if_not_integration()
 
     eplusr_option(verbose_info = FALSE)
 
     path_idfs <- path_eplus_example(LATEST_EPLUS_VER,
-        c("1ZoneDataCenterCRAC_wPumpedDXCoolingCoil.idf",
-          "1ZoneEvapCooler.idf",
-          "1ZoneParameterAspect.idf",
-          "1ZoneUncontrolled_DD2009.idf",
-          "1ZoneUncontrolled_DDChanges.idf"
+        c("1ZoneEvapCooler.idf",
+          "1ZoneParameterAspect.idf"
         )
     )
     path_epws <- path_eplus_weather(LATEST_EPLUS_VER,
-        c("USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw",
-          "USA_CO_Golden-NREL.724666_TMY3.epw",
-          "USA_FL_Tampa.Intl.AP.722110_TMY3.epw",
-          "USA_IL_Chicago-OHare.Intl.AP.725300_TMY3.epw",
-          "USA_VA_Sterling-Washington.Dulles.Intl.AP.724030_TMY3.epw"
+        c("USA_CO_Golden-NREL.724666_TMY3.epw",
+          "USA_FL_Tampa.Intl.AP.722110_TMY3.epw"
         )
     )
 
@@ -39,7 +34,7 @@ test_that("Group methods", {
     expect_equal(grp$status(),
         list(run_before = FALSE, alive = FALSE, terminated = NA,
             successful = NA, changed_after = NA,
-            job_status = data.table(index = 1:5, status = "idle",
+            job_status = data.table(index = 1:2, status = "idle",
                 idf = path_idfs, epw = NA_character_
             )
         )
@@ -50,15 +45,17 @@ test_that("Group methods", {
     expect_equal({
         grp$run(dir = file.path(tempdir(), "test"), separate = FALSE)
         basename(grp$status()$job_status$output_dir)
-    }, rep("test", 5L))
+    }, rep("test", 2L))
     # can run in different folders
     expect_equal({
-        grp$run(dir = file.path(tempdir(), "test"), separate = TRUE)
-        basename(grp$status()$job_status$output_dir)
+        grp$run(dir = file.path(tempdir(), "test"), separate = TRUE, echo = FALSE)
+        status <- grp$status()
+        basename(status$job_status$output_dir)
     }, tools::file_path_sans_ext(basename(path_idfs)))
 
-    # can run the simulation and get status of simulation
-    expect_equal({grp$run(dir = file.path(tempdir(), "test"), echo = FALSE); status <- grp$status(); names(status)},
+    # Reuse the final real run for status and output getters instead of running
+    # the same two-model group a third time.
+    expect_equal(names(status),
         c("run_before", "alive", "terminated", "successful", "changed_after", "job_status")
     )
     expect_equal(status[c("run_before", "alive", "terminated", "successful", "changed_after")],
@@ -71,62 +68,62 @@ test_that("Group methods", {
           "output_dir", "energyplus", "stdout", "stderr"
         )
     )
-    expect_equal(status$job_status$exit_status, c(0L, 0L, 1L, 0L, 0L))
+    expect_equal(status$job_status$exit_status, c(0L, 1L))
     # }}}
 
     # Errors {{{
-    expect_silent(grp$errors(2))
-    expect_warning(grp$errors(3), class = "eplusr_warning_job_error")
+    expect_silent(grp$errors(1))
+    expect_warning(grp$errors(2), class = "eplusr_warning_job_error")
     # }}}
 
     # Output Dir{{{
     expect_silent(grp$output_dir(1))
-    expect_warning(grp$output_dir(3), class = "eplusr_warning_job_error")
+    expect_warning(grp$output_dir(2), class = "eplusr_warning_job_error")
     # }}}
 
     # Table {{{
     expect_error(grp$list_table())
-    expect_silent(lsts <- grp$list_table(c(1, 2, 4)))
+    expect_silent(lsts <- grp$list_table(1))
     expect_type(lsts, "list")
-    expect_equal(length(lsts), 3L)
+    expect_equal(length(lsts), 1L)
 
     expect_error(grp$read_table())
-    expect_silent(tables <- grp$read_table(c(1, 2, 4), "Zones"))
+    expect_silent(tables <- grp$read_table(1, "Zones"))
     expect_equal(names(tables)[1:2], c("index", "case"))
     # }}}
 
     # RDD & MDD {{{
-    expect_error(grp$read_rdd(3))
-    expect_silent(rdds <- grp$read_rdd(c(1, 2, 4)))
+    expect_error(grp$read_rdd(2))
+    expect_silent(rdds <- grp$read_rdd(1))
     expect_s3_class(rdds, "data.table")
-    expect_error(grp$read_mdd(3))
-    expect_silent(mdds <- grp$read_mdd(c(1, 2, 4)))
+    expect_error(grp$read_mdd(2))
+    expect_silent(mdds <- grp$read_mdd(1))
     expect_s3_class(mdds, "data.table")
     # }}}
 
     # Report Data Dict {{{
     expect_error(grp$report_data_dict(), class = "eplusr_error_job_error")
-    expect_s3_class(grp$report_data_dict(c(1, 2, 4, 5)), "data.table")
-    expect_true(has_names(grp$report_data_dict(c(1, 2, 4, 5)), "index"))
-    expect_true(has_names(grp$report_data_dict(c(1, 2, 4, 5)), "case"))
-    expect_equal(nrow(grp$report_data_dict(2)), 23)
+    expect_s3_class(grp$report_data_dict(1), "data.table")
+    expect_true(has_names(grp$report_data_dict(1), "index"))
+    expect_true(has_names(grp$report_data_dict(1), "case"))
+    expect_equal(nrow(grp$report_data_dict(1)), 23)
     expect_equal(nrow(grp$report_data_dict("1zoneevapcooler")), 23)
     # }}}
 
     # Tabular Data {{{
-    expect_equal(nrow(grp$tabular_data(c(1, 2, 4, 5))), 22460L)
-    expect_equal(nrow(grp$tabular_data(c(1, 2, 4, 5),
+    expect_equal(nrow(grp$tabular_data(1)), 4739L)
+    expect_equal(nrow(grp$tabular_data(1,
         report_name = c(
             "AnnualBuildingUtilityPerformanceSummary",
             "Initialization Summary"
         ))),
-        3344L
+        829L
     )
-    expect_equal(nrow(grp$tabular_data(c(1, 2, 4, 5), table_name = "Site and Source Energy")), 12 * 4)
-    expect_equal(nrow(grp$tabular_data(c(1, 2, 4, 5), column_name = "Total Energy")), 4 * 4)
-    expect_equal(nrow(grp$tabular_data(c(1, 2, 4, 5), row_name = "Total Site Energy")), 3 * 4)
-    expect_equal(nrow(grp$tabular_data(2)), 4739)
-    expect_equal(nrow(grp$tabular_data(2,
+    expect_equal(nrow(grp$tabular_data(1, table_name = "Site and Source Energy")), 12)
+    expect_equal(nrow(grp$tabular_data(1, column_name = "Total Energy")), 4)
+    expect_equal(nrow(grp$tabular_data(1, row_name = "Total Site Energy")), 3)
+    expect_equal(nrow(grp$tabular_data(1)), 4739)
+    expect_equal(nrow(grp$tabular_data(1,
         report_name = c(
             "AnnualBuildingUtilityPerformanceSummary",
             "Initialization Summary"
@@ -157,13 +154,13 @@ test_that("Group methods", {
     # }}}
 
     # Report Data {{{
-    expect_equal(nrow(grp$report_data(2, grp$report_data_dict(2))), 920)
-    expect_equal(nrow(grp$report_data(2)), 920)
-    expect_equal(nrow(grp$report_data(2, name = c("Electricity:Facility", "Electricity:HVAC"))), 8)
-    expect_equal(lubridate::tz(grp$report_data(2, tz = "Asia/Shanghai")$datetime),
+    expect_equal(nrow(grp$report_data(1, grp$report_data_dict(1))), 920)
+    expect_equal(nrow(grp$report_data(1)), 920)
+    expect_equal(nrow(grp$report_data(1, name = c("Electricity:Facility", "Electricity:HVAC"))), 8)
+    expect_equal(lubridate::tz(grp$report_data(1, tz = "Asia/Shanghai")$datetime),
         "Asia/Shanghai"
     )
-    expect_equal(names(grp$report_data(2, all = TRUE)),
+    expect_equal(names(grp$report_data(1, all = TRUE)),
         c("index", "case", "datetime", "month", "day", "hour", "minute", "dst", "interval",
           "simulation_days", "day_type", "environment_name",
           "environment_period_index", "is_meter", "type", "index_group",
@@ -172,17 +169,17 @@ test_that("Group methods", {
         )
     )
 
-    expect_equal(nrow(grp$report_data(2, period = seq(
+    expect_equal(nrow(grp$report_data(1, period = seq(
         lubridate::ymd_hms("2019-12-21 1:0:0"), lubridate::ymd_hms("2019-12-22 0:0:0"), "1 hour")
     )), 437)
-    expect_equal(nrow(grp$report_data(2, month = 12)), 460)
-    expect_equal(nrow(grp$report_data(2, month = 12, hour = 1)), 19)
-    expect_equal(nrow(grp$report_data(2, minute = 0)), 920)
+    expect_equal(nrow(grp$report_data(1, month = 12)), 460)
+    expect_equal(nrow(grp$report_data(1, month = 12, hour = 1)), 19)
+    expect_equal(nrow(grp$report_data(1, minute = 0)), 920)
     # See https://github.com/NREL/EnergyPlus/issues/8367
-    expect_equal(nrow(grp$report_data(2, interval = 60)), 920)
-    expect_equal(nrow(grp$report_data(2, simulation_days = 1)), 920)
-    expect_equal(nrow(grp$report_data(2, day_type = "WinterDesignDay")), 460)
-    expect_equal(nrow(grp$report_data(2, environment_name = "DENVER CENTENNIAL ANN HTG 99.6% CONDNS DB")), 460)
+    expect_equal(nrow(grp$report_data(1, interval = 60)), 920)
+    expect_equal(nrow(grp$report_data(1, simulation_days = 1)), 920)
+    expect_equal(nrow(grp$report_data(1, day_type = "WinterDesignDay")), 460)
+    expect_equal(nrow(grp$report_data(1, environment_name = "DENVER CENTENNIAL ANN HTG 99.6% CONDNS DB")), 460)
     # }}}
 
     # S3 {{{
@@ -194,32 +191,30 @@ test_that("Group methods", {
     skip_on_os("mac")
     # Locate Output {{{
     expect_error(grp$locate_output(suffix = ".sql"))
-    expect_equal(grp$locate_output(2, suffix = ".sql"),
+    expect_equal(grp$locate_output(1, suffix = ".sql"),
         normalizePath(file.path(tempdir(), "test",
-            tools::file_path_sans_ext(basename(path_idfs[2])),
-            paste0(tools::file_path_sans_ext(basename(path_idfs[2])), ".sql")
+            tools::file_path_sans_ext(basename(path_idfs[1])),
+            paste0(tools::file_path_sans_ext(basename(path_idfs[1])), ".sql")
         ))
     )
     # }}}
 
     # List files {{{
-    expect_type(files <- grp$list_files(c(1, 2), simplify = TRUE), "list")
-    expect_equal(length(files), 2L)
+    expect_type(files <- grp$list_files(1, simplify = TRUE), "list")
+    expect_equal(length(files), 1L)
     expect_equal(length(files[[1]]), 21L)
-    expect_equal(length(files[[2]]), 21L)
 
-    expect_type(files <- grp$list_files(c(1, 2), simplify = TRUE, full = TRUE), "list")
-    expect_equal(length(files), 2L)
+    expect_type(files <- grp$list_files(1, simplify = TRUE, full = TRUE), "list")
+    expect_equal(length(files), 1L)
     expect_equal(normalizePath(dirname(files[[1]])), rep(grp$output_dir(1), 21L))
-    expect_equal(normalizePath(dirname(files[[2]])), rep(grp$output_dir(2), 21L))
 
-    expect_s3_class(files <- grp$list_files(c(1, 2), simplify = FALSE), "data.table")
+    expect_s3_class(files <- grp$list_files(1, simplify = FALSE), "data.table")
     expect_equal(names(files), c("index", "type", "file"))
-    expect_equal(nrow(files), 114L)
+    expect_equal(nrow(files), 57L)
 
-    expect_s3_class(files <- grp$list_files(c(1, 2), simplify = FALSE, full = TRUE), "data.table")
+    expect_s3_class(files <- grp$list_files(1, simplify = FALSE, full = TRUE), "data.table")
     expect_equal(names(files), c("index", "type", "file"))
-    expect_equal(nrow(files), 114L)
+    expect_equal(nrow(files), 57L)
     # }}}
 })
 

--- a/tests/testthat/test-idd.R
+++ b/tests/testthat/test-idd.R
@@ -3,13 +3,24 @@ test_that("download_idd() can download IDD from EnergyPlus repo", {
     expect_error(download_idd(1, tempdir()), class = "eplusr_error_invalid_eplus_ver")
 
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_DOWNLOAD_IDD_") != "")
+    skip_if_not_integration()
 
     # should download IDD v9.0.1 if input is 9, 9.0, 9.0.1
     expect_equal(read_idd(attr(download_idd("9.0", tempdir()), "file"))$version(), numeric_version("9.0.1"))
     expect_equal(read_idd(attr(download_idd("9.0.1", tempdir()), "file"))$version(), numeric_version("9.0.1"))
 })
 # }}}
+
+# Network-backed IDD discovery is integration-only; local parsing remains in
+# the default suite below.
+test_that("use_idd() can download IDDs", {
+    skip_on_cran()
+    skip_if_not_integration()
+
+    rm_global_cache("idd")
+    expect_s3_class(use_idd("8.4", download = TRUE), "Idd")
+    expect_s3_class(use_idd("latest", download = TRUE), "Idd")
+})
 
 # use_idd() {{{
 test_that("can read IDD", {
@@ -25,17 +36,16 @@ test_that("can read IDD", {
     # can stop if failed to read input file
     expect_error(use_idd(""), class = "eplusr_error_read_lines")
 
-    # can directly download from EnergyPlus GitHub repo
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_DOWNLOAD_IDD_") != "")
-    expect_s3_class(idd <- use_idd("8.4", download = TRUE), "Idd")
+    # can use the IDD in EnergyPlus VersionUpdater folder
+    expect_s3_class(idd <- use_idd("9.0"), "Idd")
 
     # can directly return if input is an Idd
     expect_s3_class(use_idd(idd), "Idd")
 
     # can directly return if parsed previously
-    expect_s3_class(use_idd("8.4"), "Idd")
+    expect_s3_class(use_idd("9.0"), "Idd")
 
-    # can use the IDD in EnergyPlus VersionUpdater folder
+    # can rediscover an IDD in the EnergyPlus VersionUpdater folder
     rm_global_cache("idd")
     # NOTE: from EnergyPlus v23.1, the oldest IDD version shipped with
     # EnergyPlus is EnergyPlus v9.0
@@ -63,29 +73,8 @@ test_that("can read IDD", {
     use_eplus(LATEST_EPLUS_VER)
     expect_s3_class(use_idd(LATEST_EPLUS_VER), "Idd")
 
-    # can search in VersionUpdater folder if "Energy+.idd" is not found in
-    # EnergyPlus folder
-    use_eplus(LATEST_EPLUS_VER)
-    f1 <- path_eplus(LATEST_EPLUS_VER, "Energy+.idd")
-    f1_bak <- paste0(f1, ".bak")
-    file.rename(f1, f1_bak)
-    expect_s3_class(use_idd(LATEST_EPLUS_VER), "Idd")
-    file.rename(f1_bak, f1)
-
-    # can stop if no available IDD found in any existing VersionUpdater folder
-    rm_global_cache("eplus")
-    use_eplus(LATEST_EPLUS_VER)
-    rm_global_cache("idd")
-    f2 <- find_idd_from_updater("9.0")
-    f2_bak <- paste0(f2, ".bak")
-    file.rename(f2, f2_bak)
-    expect_error(use_idd("9.0"), class = "eplusr_error_locate_idd")
-    # but "auto" still work in this case
-    expect_s3_class(use_idd("9.0", "auto"), "Idd")
-    file.rename(f2_bak, f2)
-
     # can use "latest" notation
-    expect_s3_class(use_idd("latest", download = TRUE), "Idd")
+    expect_s3_class(use_idd("latest"), "Idd")
 
     # helper functions
     expect_true(numeric_version(LATEST_EPLUS_VER) %in% avail_idd())
@@ -122,6 +111,32 @@ test_that("can read IDD", {
     expect_warning(get_idd_from_ver(NULL, NULL), "latest")
 })
 # }}}
+
+test_that("can fall back across installed IDD locations", {
+    skip_on_cran()
+    skip_if_not_integration()
+
+    # Verify VersionUpdater fallback using the real installed layout.
+    use_eplus(LATEST_EPLUS_VER)
+    f1 <- path_eplus(LATEST_EPLUS_VER, "Energy+.idd")
+    f1_bak <- paste0(f1, ".bak")
+    expect_true(file.rename(f1, f1_bak))
+    on.exit(if (file.exists(f1_bak)) file.rename(f1_bak, f1), add = TRUE)
+    expect_s3_class(use_idd(LATEST_EPLUS_VER), "Idd")
+    expect_true(file.rename(f1_bak, f1))
+
+    # Verify the error and auto-selection paths when an updater IDD is absent.
+    rm_global_cache("eplus")
+    use_eplus(LATEST_EPLUS_VER)
+    rm_global_cache("idd")
+    f2 <- find_idd_from_updater("9.0")
+    f2_bak <- paste0(f2, ".bak")
+    expect_true(file.rename(f2, f2_bak))
+    on.exit(if (file.exists(f2_bak)) file.rename(f2_bak, f2), add = TRUE)
+    expect_error(use_idd("9.0"), class = "eplusr_error_locate_idd")
+    expect_s3_class(use_idd("9.0", "auto"), "Idd")
+    expect_true(file.rename(f2_bak, f2))
+})
 
 # Idd class {{{
 test_that("Idd class", {

--- a/tests/testthat/test-idf.R
+++ b/tests/testthat/test-idf.R
@@ -1424,6 +1424,7 @@ test_that("$save()", {
 # RUN {{{
 test_that("$run()", {
     skip_on_cran()
+    skip_if_not_integration()
     expect_error(read_idf(idftext("idf", LATEST_EPLUS_VER))$save(), class = "eplusr_error")
     expect_s3_class(idf <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")), "Idf")
     expect_s3_class(job <- idf$run(NULL, tempdir(), echo = FALSE), "EplusJob")
@@ -1437,6 +1438,7 @@ test_that("$run()", {
 # LAST_JOB {{{
 test_that("$last_job()", {
     skip_on_cran()
+    skip_if_not_integration()
     expect_s3_class(idf <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")), "Idf")
     expect_null(idf$last_job())
     expect_s3_class({idf$run(NULL, tempdir(), echo = FALSE); idf$last_job()}, "EplusJob")

--- a/tests/testthat/test-impl-idd.R
+++ b/tests/testthat/test-impl-idd.R
@@ -299,7 +299,7 @@ test_that("Idd implementation", {
     )
 
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_DOWNLOAD_IDD_") != "")
+    skip_if_not_integration()
 
     idd <- use_idd(LATEST_EPLUS_VER, "auto")
     idd_env <- get_priv_env(idd)$idd_env()

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -272,7 +272,7 @@ test_that("Linux installs without uninstall.sh are removed directly", {
 
 test_that("Install EnergyPlus v9.0 and below", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_INSTALL_OLD_") != "")
+    skip_if_not_integration()
     skip_if_not(testthat:::on_ci())
 
     expect_equal(sort(as.character(avail_eplus())), sort(names(.globals$eplus)))

--- a/tests/testthat/test-job-json.R
+++ b/tests/testthat/test-job-json.R
@@ -72,13 +72,13 @@ test_that("save_job() and read_job() round-trip job manifests", {
 
 test_that("completed EplusJob results can be restored from JSON", {
     skip_on_cran()
+    skip_if_not_integration()
     skip_if_not(is_avail_eplus(LATEST_EPLUS_VER))
 
-    path_idf <- copy_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")
-    path_epw <- path_eplus_weather(LATEST_EPLUS_VER, "USA_CO_Golden-NREL.724666_TMY3.epw")
-
-    job <- eplus_job(path_idf, path_epw)
-    job$run(wait = TRUE, echo = FALSE)
+    # The hash-verification branch changes the ERR file, so work on a private
+    # copy of the session-level real output bundle.
+    bundle <- copy_latest_output_bundle()
+    job <- bundle$job
 
     path <- tempfile(fileext = ".json")
     save_job(job, path)
@@ -106,13 +106,13 @@ test_that("completed EplusJob results can be restored from JSON", {
 
 test_that("EplusGroupJob run state can be restored from JSON", {
     skip_on_cran()
+    skip_if_not_integration()
     skip_if_not(is_avail_eplus(LATEST_EPLUS_VER))
 
-    path_idf <- copy_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")
-    path_epw <- path_eplus_weather(LATEST_EPLUS_VER, "USA_CO_Golden-NREL.724666_TMY3.epw")
-
-    job <- eplus_job(path_idf, path_epw)
-    job$run(wait = TRUE, echo = FALSE)
+    bundle <- copy_latest_output_bundle()
+    path_idf <- bundle$idf_path
+    path_epw <- bundle$epw_path
+    job <- bundle$job
     result <- get_priv_env(job)$m_job
 
     group <- group_job(path_idf, path_epw)

--- a/tests/testthat/test-job.R
+++ b/tests/testthat/test-job.R
@@ -1,5 +1,6 @@
 test_that("Job methods", {
     skip_on_cran()
+    skip_if_not_integration()
 
     path_idf <- copy_eplus_example(LATEST_EPLUS_VER, "5Zone_Transformer.idf")
     path_epw <- path_eplus_weather(LATEST_EPLUS_VER, "USA_CO_Golden-NREL.724666_TMY3.epw")

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -214,6 +214,7 @@ test_that("$cases()", {
 
 test_that("$run()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     path <- copy_eplus_example(LATEST_EPLUS_VER, "5Zone_Transformer.idf")
     param <- param_job(path, NULL)

--- a/tests/testthat/test-rdd.R
+++ b/tests/testthat/test-rdd.R
@@ -1,8 +1,10 @@
 test_that("Rdd", {
     skip_on_cran()
+    skip_if_not_integration()
 
-    idf <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf"))
-    job <- idf$run(NULL, dir = tempdir(), echo = FALSE)
+    bundle <- latest_output_bundle()
+    idf <- bundle$idf
+    job <- bundle$job
 
     expect_s3_class(parse_rdd_file(tempfile()), "RddFile")
 

--- a/tests/testthat/test-reload.R
+++ b/tests/testthat/test-reload.R
@@ -1,17 +1,18 @@
 # Reload {{{
 test_that("Reload", {
     skip_on_cran()
+    skip_if_not_integration()
     eplusr_option(verbose_info = FALSE)
 
     # default
     expect_equal(reload(1L), 1L)
 
-    example <- copy_example()
+    bundle <- latest_output_bundle()
 
     idd <- use_idd(LATEST_EPLUS_VER)
-    idf <- read_idf(example$idf)
-    epw <- read_epw(example$epw)
-    job <- idf$run(NULL, tempdir(), echo = FALSE)
+    idf <- bundle$idf
+    epw <- bundle$epw
+    job <- bundle$job
     grp <- group_job(idf, NULL)$run(tempdir())
     par <- param_job(idf, NULL)
     par$apply_measure(function(x, y) x, 1:2)

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -56,6 +56,7 @@ test_that("copy_energyplus_idd()", {
 
 test_that("EPMacro()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     out_dir <- file.path(tempdir(), "EPMacro")
     if (!dir.exists(out_dir)) dir.create(out_dir)
@@ -117,6 +118,7 @@ test_that("EPMacro()", {
 
 test_that("ExpandObjects()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     out_dir <- file.path(tempdir(), "ExpandObjects")
     if (!dir.exists(out_dir)) dir.create(out_dir)
@@ -186,8 +188,7 @@ test_that("ExpandObjects()", {
 
 test_that("Basement()", {
     skip_on_cran()
-
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_BASEMENT_") != "")
+    skip_if_not_integration()
     out_dir <- file.path(tempdir(), "Basement")
     if (!dir.exists(out_dir)) dir.create(out_dir)
 
@@ -298,8 +299,7 @@ test_that("Basement()", {
 
 test_that("Slab()", {
     skip_on_cran()
-
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_BASEMENT_") != "")
+    skip_if_not_integration()
     out_dir <- file.path(tempdir(), "Basement")
     if (!dir.exists(out_dir)) dir.create(out_dir)
 
@@ -389,6 +389,7 @@ test_that("Slab()", {
 
 test_that("EnergyPlus()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     out_dir <- file.path(tempdir(), "Energyplus")
     if (!dir.exists(out_dir)) dir.create(out_dir)
@@ -436,6 +437,7 @@ test_that("EnergyPlus()", {
 
 test_that("convertESOMTR()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     out_dir <- file.path(tempdir(), "convertESOMTR")
     if (!dir.exists(out_dir)) dir.create(out_dir)
@@ -482,6 +484,7 @@ test_that("convertESOMTR()", {
 
 test_that("ReadVarsESO()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     out_dir <- file.path(tempdir(), "ReadVarsESO")
     if (!dir.exists(out_dir)) dir.create(out_dir)
@@ -527,6 +530,7 @@ test_that("ReadVarsESO()", {
 
 test_that("HVAC_Diagram()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     out_dir <- file.path(tempdir(), "HVAC_Diagram")
     if (!dir.exists(out_dir)) dir.create(out_dir)
@@ -553,6 +557,7 @@ test_that("HVAC_Diagram()", {
 
 test_that("energyplus()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     out_dir <- file.path(tempdir(), "run-energyplus")
     if (!dir.exists(out_dir)) dir.create(out_dir)
@@ -613,57 +618,55 @@ test_that("energyplus()", {
     expect_true(is.na(files["experr"]))
     unlink(c(path_exp, out_dir), recursive = TRUE)
 
-    if(Sys.getenv("_EPLUSR_SKIP_TESTS_BASEMENT_") == "") {
-        # NOTE: There is a bug in the basement preprocessor in EnergyPlus from v9.4 to v22.1
-        # Ref: https://github.com/NREL/EnergyPlus/pull/9356
-        if (numeric_version(LATEST_EPLUS_VER) > "22.1") {
-            # can run Basement
-            path_base <- copy_eplus_example(LATEST_EPLUS_VER, "LgOffVAVusingBasement.idf")
-            expect_error(energyplus(path_base, NULL, out_dir, echo = FALSE))
-            # modify the input in order to reduce the simulation time
-            l <- read_lines(path_base)
-            l[grepl("IYRS: Maximum number of yearly iterations", string), string := "1;"]
-            l[grepl("NMAT: Number of materials in this domain", string), string := "1,"]
-            l[grepl("CLEARANCE: Distance from outside of wall", string), string := "1,"]
-            l[grepl("BaseDepth: Depth of the basement wall", string), string := "0.5;"]
-            write_lines(l, path_base)
-            res_base <- energyplus(path_base, weather, out_dir, design_day = TRUE, echo = FALSE)
-            expect_equal(length(res_base$file), 57L)
-            # NOTE: From EnergyPlus v22.1.0, Sqlite.err is only generated if there is
-            # a SQLite output
-            expect_equal({files <- unlist(res_base$file); files <- files[!is.na(files)]; length(files)}, 26L)
-            expect_equal(sum(!file.exists(file.path(out_dir, files))), 0L)
-            expect_equal(sort(unname(files[names(files) != "epw"])), list.files(out_dir, "LgOffVAVusingBasement"))
-            expect_equal(res_base$run[program == "Basement", exit_status], list(0L))
-            expect_true(file.exists(file.path(out_dir, files["expidf"])))
-            expect_true(file.exists(file.path(out_dir, files["bsmt_idf"])))
-            expect_true(file.exists(file.path(out_dir, files["bsmt_csv"])))
-            expect_true(file.exists(file.path(out_dir, files["bsmt_out"])))
-            expect_true(file.exists(file.path(out_dir, files["bsmt_audit"])))
-            unlink(c(path_base, out_dir), recursive = TRUE)
-        }
-
-        # can run Slab
-        path_slab <- copy_eplus_example(LATEST_EPLUS_VER, "5ZoneAirCooledWithSlab.idf")
-        expect_error(energyplus(path_slab, NULL, out_dir, echo = FALSE))
+    # NOTE: There is a bug in the basement preprocessor in EnergyPlus from v9.4 to v22.1
+    # Ref: https://github.com/NREL/EnergyPlus/pull/9356
+    if (numeric_version(LATEST_EPLUS_VER) > "22.1") {
+        # can run Basement
+        path_base <- copy_eplus_example(LATEST_EPLUS_VER, "LgOffVAVusingBasement.idf")
+        expect_error(energyplus(path_base, NULL, out_dir, echo = FALSE))
         # modify the input in order to reduce the simulation time
-        l <- read_lines(path_slab)
-        l[grepl("IYRS: Number of years to iterate", string), string := "1,"]
-        l[grepl("ConvTol: Convergence Tolerance", string), string := "1;"]
-        write_lines(l, path_slab)
-        res_slab <- energyplus(path_slab, weather, out_dir, echo = FALSE)
-        expect_equal(length(res_slab$file), 57L)
+        l <- read_lines(path_base)
+        l[grepl("IYRS: Maximum number of yearly iterations", string), string := "1;"]
+        l[grepl("NMAT: Number of materials in this domain", string), string := "1,"]
+        l[grepl("CLEARANCE: Distance from outside of wall", string), string := "1,"]
+        l[grepl("BaseDepth: Depth of the basement wall", string), string := "0.5;"]
+        write_lines(l, path_base)
+        res_base <- energyplus(path_base, weather, out_dir, design_day = TRUE, echo = FALSE)
+        expect_equal(length(res_base$file), 57L)
         # NOTE: From EnergyPlus v22.1.0, Sqlite.err is only generated if there is
         # a SQLite output
-        expect_equal({files <- unlist(res_slab$file); files <- files[!is.na(files)]; length(files)}, 25L)
+        expect_equal({files <- unlist(res_base$file); files <- files[!is.na(files)]; length(files)}, 26L)
         expect_equal(sum(!file.exists(file.path(out_dir, files))), 0L)
-        expect_equal(sort(unname(files[names(files) != "epw"])), list.files(out_dir, "5ZoneAirCooledWithSlab"))
-        expect_equal(res_slab$run[program == "Slab", exit_status], list(0L))
-        expect_true(file.exists(file.path(out_dir, files["slab_ger"])))
-        expect_true(file.exists(file.path(out_dir, files["slab_gtp"])))
-        expect_true(file.exists(file.path(out_dir, files["slab_out"])))
-        unlink(c(path_slab, out_dir), recursive = TRUE)
+        expect_equal(sort(unname(files[names(files) != "epw"])), list.files(out_dir, "LgOffVAVusingBasement"))
+        expect_equal(res_base$run[program == "Basement", exit_status], list(0L))
+        expect_true(file.exists(file.path(out_dir, files["expidf"])))
+        expect_true(file.exists(file.path(out_dir, files["bsmt_idf"])))
+        expect_true(file.exists(file.path(out_dir, files["bsmt_csv"])))
+        expect_true(file.exists(file.path(out_dir, files["bsmt_out"])))
+        expect_true(file.exists(file.path(out_dir, files["bsmt_audit"])))
+        unlink(c(path_base, out_dir), recursive = TRUE)
     }
+
+    # can run Slab
+    path_slab <- copy_eplus_example(LATEST_EPLUS_VER, "5ZoneAirCooledWithSlab.idf")
+    expect_error(energyplus(path_slab, NULL, out_dir, echo = FALSE))
+    # modify the input in order to reduce the simulation time
+    l <- read_lines(path_slab)
+    l[grepl("IYRS: Number of years to iterate", string), string := "1,"]
+    l[grepl("ConvTol: Convergence Tolerance", string), string := "1;"]
+    write_lines(l, path_slab)
+    res_slab <- energyplus(path_slab, weather, out_dir, echo = FALSE)
+    expect_equal(length(res_slab$file), 57L)
+    # NOTE: From EnergyPlus v22.1.0, Sqlite.err is only generated if there is
+    # a SQLite output
+    expect_equal({files <- unlist(res_slab$file); files <- files[!is.na(files)]; length(files)}, 25L)
+    expect_equal(sum(!file.exists(file.path(out_dir, files))), 0L)
+    expect_equal(sort(unname(files[names(files) != "epw"])), list.files(out_dir, "5ZoneAirCooledWithSlab"))
+    expect_equal(res_slab$run[program == "Slab", exit_status], list(0L))
+    expect_true(file.exists(file.path(out_dir, files["slab_ger"])))
+    expect_true(file.exists(file.path(out_dir, files["slab_gtp"])))
+    expect_true(file.exists(file.path(out_dir, files["slab_out"])))
+    unlink(c(path_slab, out_dir), recursive = TRUE)
 
     # can convert eso to IP
     path_ip <- copy_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")
@@ -712,6 +715,7 @@ test_that("energyplus()", {
 
 test_that("run_idf()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     path_idf <- copy_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf")
     path_epw <- path_eplus_weather(LATEST_EPLUS_VER, "USA_CO_Golden-NREL.724666_TMY3.epw")
@@ -767,6 +771,7 @@ test_that("run_idf()", {
 
 test_that("run_multi()", {
     skip_on_cran()
+    skip_if_not_integration()
 
     path_idf <- copy_eplus_example(LATEST_EPLUS_VER, c("1ZoneUncontrolled.idf", "5Zone_Transformer.idf"))
     path_epw <- path_eplus_weather(LATEST_EPLUS_VER, "USA_CA_San.Francisco.Intl.AP.724940_TMY3.epw")

--- a/tests/testthat/test-sql.R
+++ b/tests/testthat/test-sql.R
@@ -115,10 +115,8 @@ test_that("DuckDB SQL query failures are preserved", {
 test_that("Sql methods", {
     skip_on_cran()
 
-    example <- copy_example()
-    idf <- read_idf(example$idf)
-
-    expect_s3_class(job <- idf$run(example$epw, NULL, echo = FALSE), "EplusJob")
+    bundle <- latest_output_bundle()
+    expect_s3_class(job <- bundle$job, "EplusJob")
     expect_silent(sql <- eplus_sql(job$locate_output(".sql")))
 
     expect_output(sql$print())
@@ -126,8 +124,8 @@ test_that("Sql methods", {
     expect_type(format(sql), "character")
 
     # path
-    expect_equal(sql$path(), normalizePath(file.path(tempdir(), "5Zone_Transformer.sql")))
-    expect_equal(sql$path_idf(), normalizePath(file.path(tempdir(), "5Zone_Transformer.idf")))
+    expect_equal(sql$path(), normalizePath(job$locate_output(".sql")))
+    expect_equal(sql$path_idf(), normalizePath(job$locate_output(".idf")))
 
     # can get all table names
     expect_equal(length(sql$list_table()), 44L)
@@ -207,9 +205,7 @@ test_that("Sql methods", {
 
     expect_equal(
         ignore_attr = TRUE,
-        read_idf(path_eplus_example(LATEST_EPLUS_VER, "1ZoneUncontrolled.idf"))$
-            run(NULL, tempdir(), echo = FALSE)$
-            tabular_data(table_name = "Site and Source Energy", wide = TRUE)[[1]][
+        sql$tabular_data(table_name = "Site and Source Energy", wide = TRUE)[[1]][
             , lapply(.SD, class)],
         data.table(
             case = "character",
@@ -238,20 +234,24 @@ test_that("Sql methods", {
 
     # can get path
     if (!is_macos()) expect_equal(sql$path(), job$locate_output(".sql"))
-    clean_wd(example$idf)
-    unlink(c(example$idf, example$epw))
 })
 
 test_that("Data extraction", {
     skip_on_cran()
 
     # can handle multiple time resolution
-    example <- copy_example()
+    bundle <- latest_output_bundle()
+    example <- list(
+        idf = tempfile(fileext = ".idf"),
+        epw = tempfile(fileext = ".epw")
+    )
+    expect_true(file.copy(bundle$idf_path, example$idf))
+    expect_true(file.copy(bundle$epw_path, example$epw))
     all_freq <- c("Detailed", "Timestep", "Hourly", "Daily", "Monthly",
           "RunPeriod", "Environment", "Annual"
     )
     idf <- read_idf(example$idf)
-    job <- idf$run(NULL, echo = FALSE)
+    job <- bundle$job
     # remove original run periods
     idf$RunPeriod <- NULL
     # define new run periods
@@ -273,21 +273,31 @@ test_that("Data extraction", {
     res1 <- job$report_data(wide = TRUE)
     res2 <- job$report_data(all = TRUE, wide = TRUE)
     expect_equal(nrow(res1), nrow(res2))
+    expect_silent(data_all <- job$report_data(all = TRUE))
 
-    jobs <- lapply(all_freq, function (freq) {
-        idf$`Output:Variable`<- NULL
+    # EnergyPlus stores Detailed/Timestep using canonical SQLite names and
+    # combines RunPeriod/Environment under the same Run Period frequency.
+    dict <- job$report_data_dict()
+    actual_freq <- dict[, .N, by = reporting_frequency]
+    expected_freq <- data.table(
+        reporting_frequency = c(
+            "HVAC System Timestep", "Zone Timestep", "Hourly", "Daily",
+            "Monthly", "Run Period", "Annual"
+        ),
+        N = c(2L, 2L, 2L, 2L, 2L, 4L, 2L)
+    )
+    expect_equal(
+        setorder(actual_freq, reporting_frequency),
+        setorder(expected_freq, reporting_frequency)
+    )
 
-        dt <- idf$to_table(class = "Output:Meter")
-        dt[index == 2L, value := freq]
-        idf$update(dt)
-
-        idf$save(tempfile(fileext = ".idf"))
-
-        idf$run(NULL, echo = FALSE)
-    })
-
-    expect_silent(data_all <- lapply(jobs, function (job) get_sql_report_data(job$locate_output(".sql"), all = TRUE)))
-    expect_silent(data_wide <- lapply(jobs, function (job) get_sql_report_data(job$locate_output(".sql"), all = TRUE, wide = TRUE)))
+    # Verify every real frequency in the single long and wide extraction from
+    # the authoritative latest-version SQLite output.
+    for (freq in expected_freq$reporting_frequency) {
+        item <- dict[reporting_frequency == freq][1L]
+        expect_true(freq %in% data_all$reporting_frequency)
+        expect_true(any(stri_detect_fixed(names(res2), item$name)))
+    }
 
     clean_wd(example$idf)
     unlink(c(example$idf, example$epw))

--- a/tests/testthat/test-transition.R
+++ b/tests/testthat/test-transition.R
@@ -1,7 +1,11 @@
 # HELPER {{{
 test_that("Transition Helper", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
+
+    # EnergyPlus 23.1+ no longer ships pre-9.0 updater assets; register the
+    # integration prerequisite prepared by CI before exercising all versions.
+    use_eplus("22.2")
 
     idf <- read_idf(system.file("extdata/1ZoneUncontrolled.idf", package = "eplusr"))
 
@@ -102,7 +106,7 @@ test_that("Transition Helper", {
 # v7.2 --> v8.0 {{{
 test_that("Transition v7.2 --> v8.0", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "7.2"
     to <- "8.0"
     expect_s3_class(
@@ -370,7 +374,7 @@ test_that("Transition v7.2 --> v8.0", {
 # v8.0 --> v8.1 {{{
 test_that("Transition v8.0 --> v8.1", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.0"
     to <- "8.1"
     expect_s3_class(
@@ -508,7 +512,7 @@ test_that("Transition v8.0 --> v8.1", {
 # v8.1 --> v8.2 {{{
 test_that("Transition v8.1 --> v8.2", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.1"
     to <- "8.2"
     expect_s3_class(
@@ -637,7 +641,7 @@ test_that("Transition v8.1 --> v8.2", {
 # v8.2 --> v8.3 {{{
 test_that("Transition v8.2 --> v8.3", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.2"
     to <- "8.3"
     expect_s3_class(
@@ -684,7 +688,7 @@ test_that("Transition v8.2 --> v8.3", {
 # v8.3 --> v8.4 {{{
 test_that("Transition v8.3 --> v8.4", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.3"
     to <- "8.4"
     expect_s3_class(
@@ -866,7 +870,7 @@ test_that("Transition v8.3 --> v8.4", {
 # v8.4 --> v8.5 {{{
 test_that("Transition v8.4 --> v8.5", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.4"
     to <- "8.5"
     expect_s3_class(
@@ -895,7 +899,7 @@ test_that("Transition v8.4 --> v8.5", {
 # v8.5 --> v8.6 {{{
 test_that("Transition v8.5 --> v8.6", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.5"
     to <- "8.6"
     expect_s3_class(
@@ -1119,7 +1123,7 @@ test_that("Transition v8.5 --> v8.6", {
 # v8.6 --> v8.7 {{{
 test_that("Transition v8.6 --> v8.7", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.6"
     to <- "8.7"
     expect_s3_class(
@@ -1200,7 +1204,7 @@ test_that("Transition v8.6 --> v8.7", {
 # v8.7 --> v8.8 {{{
 test_that("Transition v8.7 --> v8.8", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.7"
     to <- "8.8"
     expect_s3_class(
@@ -1328,7 +1332,7 @@ test_that("Transition v8.7 --> v8.8", {
 # v8.8 --> v8.9 {{{
 test_that("Transition v8.8 --> v8.9", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.8"
     to <- "8.9"
     expect_s3_class(
@@ -1410,7 +1414,7 @@ test_that("Transition v8.8 --> v8.9", {
 # v8.9 --> v9.0 {{{
 test_that("Transition v8.9 --> v9.0", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "8.9"
     to <- "9.0"
     expect_s3_class(
@@ -1508,7 +1512,7 @@ test_that("Transition v8.9 --> v9.0", {
 # v9.0 --> v9.1 {{{
 test_that("Transition v9.0 --> v9.1", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "9.0"
     to <- "9.1"
     expect_s3_class(
@@ -1537,7 +1541,7 @@ test_that("Transition v9.0 --> v9.1", {
 # v9.1 --> v9.2 {{{
 test_that("Transition v9.1 --> v9.2", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "9.1"
     to <- "9.2"
     unlink(file.path(tempdir(), "test.csv"))
@@ -1814,7 +1818,7 @@ test_that("Transition v9.1 --> v9.2", {
 # v9.2 --> v9.3 {{{
 test_that("Transition v9.2 --> v9.3", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "9.2"
     to <- "9.3"
     expect_s3_class(
@@ -2008,7 +2012,7 @@ test_that("Transition v9.2 --> v9.3", {
 # v9.3 --> v9.4 {{{
 test_that("Transition v9.3 --> v9.4", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "9.3"
     to <- "9.4"
     expect_s3_class(
@@ -2094,7 +2098,7 @@ test_that("Transition v9.3 --> v9.4", {
 # v9.4 --> v9.5 {{{
 test_that("Transition v9.4 --> v9.5", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
     from <- "9.4"
     to <- "9.5"
     expect_s3_class(
@@ -2276,7 +2280,7 @@ test_that("Transition v9.4 --> v9.5", {
 # v9.5 --> v9.6 {{{
 test_that("Transition v9.5 --> v9.6", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     # do not install EnergyPlus if not on CI
     skip_if_not(testthat:::on_ci())
@@ -2480,7 +2484,7 @@ test_that("Transition v9.5 --> v9.6", {
 # v9.6 --> v22.1 {{{
 test_that("Transition v9.6 --> v22.1", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "9.6"
     to <- "22.1"
@@ -2505,7 +2509,7 @@ test_that("Transition v9.6 --> v22.1", {
 # v22.1 --> v22.2 {{{
 test_that("Transition v22.1 --> v22.2", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "22.1"
     to <- "22.2"
@@ -2685,7 +2689,7 @@ test_that("Transition v22.1 --> v22.2", {
 # v22.2 --> v23.1 {{{
 test_that("Transition v22.2 --> v23.1", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "22.2"
     to <- "23.1"
@@ -2703,7 +2707,7 @@ test_that("Transition v22.2 --> v23.1", {
 # v23.1 --> v23.2 {{{
 test_that("Transition v23.1 --> v23.2", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "23.1"
     to <- "23.2"
@@ -2813,7 +2817,7 @@ test_that("Transition v23.1 --> v23.2", {
 # v23.2 --> v24.1 {{{
 test_that("Transition v23.2 --> v24.1", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "23.2"
     to <- "24.1"
@@ -2906,7 +2910,7 @@ test_that("Transition v23.2 --> v24.1", {
 # v24.1 --> v24.2 {{{
 test_that("Transition v24.1 --> v24.2", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "24.1"
     to <- "24.2"
@@ -3001,7 +3005,7 @@ test_that("Transition v24.1 --> v24.2", {
 # v24.2 --> v25.1 {{{
 test_that("Transition v24.2 --> v25.1", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "24.2"
     to <- "25.1"
@@ -3045,7 +3049,7 @@ test_that("Transition v24.2 --> v25.1", {
 # v25.1 --> v25.2 {{{
 test_that("Transition v25.1 --> v25.2", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "25.1"
     to <- "25.2"
@@ -3129,7 +3133,7 @@ test_that("Transition v25.1 --> v25.2", {
 # v25.2 --> v26.1 {{{
 test_that("Transition v25.2 --> v26.1", {
     skip_on_cran()
-    skip_if(Sys.getenv("_EPLUSR_SKIP_TESTS_TRANSITION_") != "")
+    skip_if_not_integration()
 
     from <- "25.2"
     to <- "26.1"


### PR DESCRIPTION
Closes #637.

## Summary

- Reduce the default test suite runtime while keeping latest EnergyPlus SQLite output as a real core regression surface.
- Move network, transition, preprocessor, installer, and other external-program checks behind one explicit integration mode.

## Changes

- Run testthat serially by default and enable `_EPLUSR_RUN_INTEGRATION_TESTS_=true` only in coverage CI.
- Reuse one session-level latest EnergyPlus output bundle for read-only consumers, with private copies for mutating JSON checks.
- Collapse SQLite frequency coverage to two real simulations and validate all frequencies from one authoritative output.
- Reduce grouped simulation coverage to two models and two runs while retaining success, failure, status, error, and getter checks.
- Bump the development version to 0.17.0.9013 and document the test-suite refactor.