### PR TITLE
fix: relax incomplete extensible validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,9 @@
 
 ## Bug fixes
 
+* Allow optional fields with default values to remain empty inside active
+  extensible groups during validation (#640).
+
 * Reject character field values that contain IDF delimiters, preventing comma or
   semicolon inputs from corrupting generated IDF syntax (#67).
 

--- a/R/impl-epw.R
+++ b/R/impl-epw.R
@@ -706,12 +706,19 @@ validate_epw_header_basic <- function(idd_env, header, class = NULL, field = NUL
     # TEMPERATURES'
     if (nrow(valid$incomplete_extensible) && EPW_CLASS$ground %chin% valid$incomplete_extensible$class_name) {
         add_field_property(idd_env, valid$incomplete_extensible, "extensible_group")
+        add_class_property(idd_env, valid$incomplete_extensible,
+            c("first_extensible", "num_extensible"))
+
+        # Validation now contains only invalid empty fields, so derive each
+        # field's position from the IDD instead of its row order in the result.
         valid$incomplete_extensible[extensible_group > 0,
-            extensible_field_index := seq_len(.N), by = c("object_id", "extensible_group")]
+            extensible_field_index :=
+                (field_index - first_extensible) %% num_extensible + 1L]
 
         ext_grp <- valid$incomplete_extensible[J(EPW_CLASS$ground), on = "class_name",
-            by = "extensible_group", list(incomplete = anyNA(value_chr[-(2:4)]))
-        ][J(FALSE), on = "incomplete", nomatch = NULL, extensible_group]
+            by = "extensible_group",
+            list(soil_properties_only = all(extensible_field_index %in% 2:4))
+        ][J(TRUE), on = "soil_properties_only", nomatch = NULL, extensible_group]
 
         if (length(ext_grp)) {
             valid$incomplete_extensible <- valid$incomplete_extensible[
@@ -719,7 +726,10 @@ validate_epw_header_basic <- function(idd_env, header, class = NULL, field = NUL
                 on = c("class_name", "extensible_group")]
         }
 
-        set(valid$incomplete_extensible, NULL, c("extensible_group", "extensible_field_index"), NULL)
+        set(valid$incomplete_extensible, NULL,
+            c("extensible_group", "first_extensible", "num_extensible",
+              "extensible_field_index"),
+            NULL)
     }
 
     setattr(valid, "class", c("EpwValidity", class(valid)))

--- a/R/validate.R
+++ b/R/validate.R
@@ -301,7 +301,11 @@ validate_objects <- function
     # add field attributes used for validating {{{
     # add field index
     cols_add <- c("type_enum", "ip_units", "units")
-    if (isTRUE(extensible)) cols_add <- c(cols_add, "extensible_group")
+    if (isTRUE(extensible)) {
+        # Extensible validation distinguishes required fields and optional
+        # fields without defaults from optional fields that can be defaulted.
+        cols_add <- c(cols_add, "extensible_group", "required_field", "default_chr")
+    }
     if (isTRUE(required_field)) cols_add <- c(cols_add, "required_field")
     if (isTRUE(auto_field)) cols_add <- c(cols_add, "autosizable", "autocalculatable")
     if (isTRUE(choice)) cols_add <- c(cols_add, "choice")
@@ -446,7 +450,8 @@ check_conflict_name <- function(idd_env, idf_env, env_in) {
 check_incomplete_extensible <- function(idd_env, idf_env, env_in) {
     # extensible groups in input
     ext <- env_in$value[extensible_group > 0L,
-        list(object_id, field_index, field_id, extensible_group, value_chr)]
+        list(object_id, field_index, field_id, extensible_group, required_field,
+             default_chr, value_id, value_chr)]
 
     if (!nrow(ext)) return(env_in)
 
@@ -461,11 +466,22 @@ check_incomplete_extensible <- function(idd_env, idf_env, env_in) {
     empty_info[can_be_na == FALSE | is.na(can_be_na), can_be_na := can_be_na[1L],
         by = list(cumsum(!is.na(can_be_na)), object_id)]
     empty_info[is.na(can_be_na), can_be_na := TRUE]
-    incomplete <- empty_info[has_any_na == TRUE & can_be_na == FALSE, list(object_id, extensible_group)]
+    incomplete_group <- empty_info[
+        has_any_na == TRUE & can_be_na == FALSE,
+        list(object_id, extensible_group)
+    ]
+
+    # Within an active group, optional fields with defaults can stay empty.
+    # Report required fields and optional fields for which no default exists.
+    incomplete <- ext[incomplete_group, on = c("object_id", "extensible_group")][
+        is.na(value_chr) & (required_field == TRUE | is.na(default_chr)),
+        list(value_id)
+    ]
     setorderv(incomplete, names(incomplete))
 
     if (nrow(incomplete)) {
-        add_validity(idd_env, idf_env, env_in, incomplete, "incomplete_extensible", c("object_id", "extensible_group"))
+        add_validity(idd_env, idf_env, env_in, incomplete,
+            "incomplete_extensible", "value_id")
     }
 
     env_in

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -121,11 +121,29 @@ test_that("Validate method", {
     env_in$validity <- empty_validity()
     add_joined_cols(env_in$object, env_in$value, "object_id", c("class_id", "object_name"))
     add_class_property(idd_env, env_in$value, c("class_id", "class_name"))
-    add_field_property(idd_env, env_in$value, c("extensible_group", "field_index", "field_name", "units", "ip_units", "type_enum"))
+    add_field_property(idd_env, env_in$value, c(
+        "extensible_group", "required_field", "default_chr", "field_index",
+        "field_name", "units", "ip_units", "type_enum"
+    ))
     expect_equal(nrow(check_incomplete_extensible(idd_env, idf_env, env_in)$validity$incomplete_extensible), 0L)
     invisible(env_in$value[extensible_group == 3L, value_chr := NA_character_])
     expect_silent({err <- check_incomplete_extensible(idd_env, idf_env, env_in)$validity$incomplete_extensible})
     expect_equal(err$object_id, rep(3L, 3))
+    expect_equal(err$field_index, 18:20)
+    expect_equal(err$value_id, 32:34)
+
+    # Optional fields with defaults can remain empty in an active group.
+    invisible(env_in$value[field_index == 18L, `:=`(
+        required_field = FALSE,
+        default_chr = "0.0"
+    )])
+    err <- check_incomplete_extensible(idd_env, idf_env, env_in)$validity$incomplete_extensible
+    expect_equal(err$field_index, 19:20)
+    expect_equal(err$value_id, 33:34)
+
+    # Required fields remain invalid even when a default is available.
+    invisible(env_in$value[field_index == 18L, required_field := TRUE])
+    err <- check_incomplete_extensible(idd_env, idf_env, env_in)$validity$incomplete_extensible
     expect_equal(err$field_index, 18:20)
     expect_equal(err$value_id, 32:34)
     # }}}


### PR DESCRIPTION
## Summary

- Relax `check_incomplete_extensible()` so optional fields with a defined `default_chr` can remain empty in active extensible groups.
- Preserve the existing distinction between active groups and fully empty trailing groups.

## Changes

- Filter incomplete extensible results using `required_field` and `default_chr`.
- Derive EPW extensible field positions from `first_extensible` and `num_extensible`, preserving the `GROUND TEMPERATURES` soil-property exception after result filtering.
- Add regression coverage for required fields, optional fields without defaults, and optional fields with defaults.
- Closes #639.
