### PR TITLE
fix(viewer): support decido 0.5 triangulation

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -79,13 +79,14 @@ jobs:
         id: duckdb-ext-cache
         if: ${{ matrix.config.os == 'ubuntu-latest' && matrix.config.not_cran }}
         run: |
-          dir <- file.path(tools::R_user_dir("duckdb", "data"), "extensions")
+          home <- tools::R_user_dir("duckdb", "data")
+          dir <- file.path(home, "extensions")
           dir.create(dir, recursive = TRUE, showWarnings = FALSE)
           out <- Sys.getenv("GITHUB_OUTPUT")
           cat("path=", dir, "\n", file = out, append = TRUE, sep = "")
           cat("version=", as.character(utils::packageVersion("duckdb")), "\n", file = out, append = TRUE, sep = "")
           # DuckDB otherwise uses a per-session temp directory that later checks cannot share.
-          cat("DUCKDB_EXTENSION_DIRECTORY=", dir, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
+          cat("DUCKDB_R_HOME=", home, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
         shell: Rscript {0}
 
       - name: Restore DuckDB extension cache

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -41,13 +41,14 @@ jobs:
       - name: Locate DuckDB extension cache
         id: duckdb-ext-cache
         run: |
-          dir <- file.path(tools::R_user_dir("duckdb", "data"), "extensions")
+          home <- tools::R_user_dir("duckdb", "data")
+          dir <- file.path(home, "extensions")
           dir.create(dir, recursive = TRUE, showWarnings = FALSE)
           out <- Sys.getenv("GITHUB_OUTPUT")
           cat("path=", dir, "\n", file = out, append = TRUE, sep = "")
           cat("version=", as.character(utils::packageVersion("duckdb")), "\n", file = out, append = TRUE, sep = "")
           # DuckDB otherwise uses a per-session temp directory that callr subprocesses cannot share.
-          cat("DUCKDB_EXTENSION_DIRECTORY=", dir, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
+          cat("DUCKDB_R_HOME=", home, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
         shell: Rscript {0}
 
       - name: Restore DuckDB extension cache

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -60,13 +60,14 @@ jobs:
       - name: Locate DuckDB extension cache
         id: duckdb-ext-cache
         run: |
-          dir <- file.path(tools::R_user_dir("duckdb", "data"), "extensions")
+          home <- tools::R_user_dir("duckdb", "data")
+          dir <- file.path(home, "extensions")
           dir.create(dir, recursive = TRUE, showWarnings = FALSE)
           out <- Sys.getenv("GITHUB_OUTPUT")
           cat("path=", dir, "\n", file = out, append = TRUE, sep = "")
           cat("version=", as.character(utils::packageVersion("duckdb")), "\n", file = out, append = TRUE, sep = "")
           # DuckDB otherwise uses a per-session temp directory that covr cannot share.
-          cat("DUCKDB_EXTENSION_DIRECTORY=", dir, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
+          cat("DUCKDB_R_HOME=", home, "\n", file = Sys.getenv("GITHUB_ENV"), append = TRUE, sep = "")
         shell: Rscript {0}
 
       - name: Restore DuckDB extension cache

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.17.0.9014
+Version: 0.17.0.9015
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,9 @@
 
 ## Bug fixes
 
+* Keep `IdfViewer` triangulation compatible with decido 0.5.0 and infer
+  detailed fenestration vertices from populated XYZ coordinate fields (#643).
+
 * Validate active extensible groups using the first-group required-field
   template, allowing optional fields without defaults to remain empty (#641,
   #642).

--- a/R/impl-geom.R
+++ b/R/impl-geom.R
@@ -411,10 +411,20 @@ extract_geom_subsurface_detailed <- function(idf, geom_class = NULL, object = NU
 
     # vertices
     fldid_start <- get_first_vertex_field_index(idf$version())[["FenestrationSurface:Detailed"]]
-    # NOTE: currently fenestrations only support triangle and rectangles
+    # NOTE: currently fenestrations only support triangles and quadrilaterals
     vertices <- dt[J(fldid_start:(fldid_start + 11L)), on = "field_index"][, by = "object_id",
         list(index = rep(1:4, each = 3L), field = rep(c("x", "y", "z"), 4L), value_num)]
     vertices <- dcast.data.table(vertices, object_id + index ~ field, value.var = "value_num")
+
+    # A triangle has a fully blank fourth XYZ group, regardless of the value in
+    # Number of Vertices. Keep partially populated groups for validation below.
+    vertices <- vertices[!(index == 4L & is.na(x) & is.na(y) & is.na(z))]
+    if (any(!is.finite(vertices$x) | !is.finite(vertices$y) | !is.finite(vertices$z))) {
+        abort(
+            "'FenestrationSurface:Detailed' objects must contain three or four complete, finite XYZ vertex groups.",
+            "invalid_geom_vertices"
+        )
+    }
     setnames(vertices, "object_id", "id")
 
     list(meta = meta, vertices = vertices)

--- a/R/impl-viewer.R
+++ b/R/impl-viewer.R
@@ -520,7 +520,8 @@ triangulate_surfaces <- function(vertices) {
     vert <- vertices[, by = "id", {
         hole <- which(index == -1L)
         if (!length(hole)) hole <- 0L
-        tri <- decido::earcut(list(inv_x, inv_y), hole)
+        # Preserve triangulation quality with the Earcut 3.x code in decido.
+        tri <- decido::earcut(list(inv_x, inv_y), hole, refine = TRUE)
         list(index = seq_along(tri), x = inv_x[tri], y = inv_y[tri], z = inv_z[tri])
     }]
 

--- a/tests/testthat/test-impl-geom.R
+++ b/tests/testthat/test-impl-geom.R
@@ -1,4 +1,51 @@
 # GEOMETRY EXTRACTION {{{
+test_that("Detailed fenestration vertices use populated XYZ fields", {
+    skip_on_cran()
+
+    idf <- read_idf(path_eplus_example(LATEST_EPLUS_VER, "AirflowNetwork3zVent.idf"))
+    fenestration <- idf[["FenestrationSurface:Detailed"]]
+
+    # A blank declared count must not add an empty fourth vertex to a triangle.
+    without_checking(fenestration$WINDOW11$set(
+        number_of_vertices = NULL, .default = FALSE, .empty = TRUE
+    ))
+    triangle <- extract_geom_subsurface_detailed(idf, object = fenestration$WINDOW11$id())
+    expect_equal(
+        triangle$vertices[, .(index, x, y, z)],
+        data.table(
+            index = 1:3,
+            x = c(1, 1, 5),
+            y = c(0, 0, 0),
+            z = c(2.5, 1, 1)
+        )
+    )
+    expect_false(anyNA(triangle$vertices))
+
+    # An inconsistent declared count is also ignored in favor of XYZ groups.
+    without_checking(fenestration$WINDOW11$set(number_of_vertices = 4L))
+    expect_equal(
+        extract_geom_subsurface_detailed(
+            idf, object = fenestration$WINDOW11$id()
+        )$vertices,
+        triangle$vertices
+    )
+
+    rectangle <- extract_geom_subsurface_detailed(
+        idf, object = fenestration$DoorInSurface_3$id()
+    )
+    expect_equal(nrow(rectangle$vertices), 4L)
+    expect_false(anyNA(rectangle$vertices))
+
+    # Partial coordinate groups are rejected before reaching the triangulator.
+    without_checking(fenestration$WINDOW11$set(
+        vertex_3_z_coordinate = NULL, .default = FALSE, .empty = TRUE
+    ))
+    expect_error(
+        extract_geom_subsurface_detailed(idf, object = fenestration$WINDOW11$id()),
+        class = "eplusr_error_invalid_geom_vertices"
+    )
+})
+
 test_that("Geometry Extraction", {
     skip_on_cran()
 

--- a/tests/testthat/test-impl-viewer.R
+++ b/tests/testthat/test-impl-viewer.R
@@ -1,4 +1,43 @@
 # IdfViewer Implemention {{{
+test_that("Geometry triangulation preserves polygon holes", {
+    skip_if_not_installed("decido")
+
+    geoms <- list(
+        surface = data.table(id = 1L, name = "wall"),
+        subsurface = data.table(
+            id = 2L, name = "window", building_surface_name = "wall"
+        ),
+        vertices = rbindlist(list(
+            data.table(
+                id = 1L, index = 1:4,
+                x = c(0, 4, 4, 0), y = c(0, 0, 4, 4), z = 0
+            ),
+            data.table(
+                id = 2L, index = 1:3,
+                x = c(1, 2, 1), y = c(1, 1, 2), z = 0
+            )
+        ))
+    )
+
+    triangulated <- triangulate_geoms(geoms)
+    expect_true(all(is.finite(triangulated$x)))
+    expect_true(all(is.finite(triangulated$y)))
+    expect_true(all(is.finite(triangulated$z)))
+    expect_equal(nrow(triangulated[id == 1L]), 21L)
+    expect_equal(nrow(triangulated[id == 2L]), 3L)
+
+    # Compare total triangle area instead of implementation-specific indices.
+    surface <- triangulated[id == 1L]
+    surface[, triangle := rep(seq_len(.N %/% 3L), each = 3L)]
+    area <- surface[, by = "triangle", .(
+        area = abs(
+            (x[2L] - x[1L]) * (y[3L] - y[1L]) -
+                (x[3L] - x[1L]) * (y[2L] - y[1L])
+        ) / 2
+    )][, sum(area)]
+    expect_equal(area, 15.5, tolerance = 1e-10)
+})
+
 test_that("IdfViewer Implemention", {
     skip_on_cran()
     skip_on_os("mac")


### PR DESCRIPTION
Closes #643.

## Summary
- request refined Earcut triangulation explicitly for decido 0.5.0;
- remove a fully blank fourth XYZ group from triangular detailed fenestrations while ignoring Number of Vertices;
- reject partially populated or non-finite XYZ groups and add geometry-invariant regression tests.

## Validation
- focused geometry and viewer tests pass with decido 0.3.0 and 0.4.9003: 162 passed, 1 macOS UI skip;
- AirflowNetwork3zVent.idf triangulates to 162 finite vertices with decido 0.4.9003;
- R CMD check: 0 errors, 0 warnings, 0 notes;
- diff coverage gate passed for all changed executable R lines.