### PR TITLE
refactor: remove redundant `field` resets from transition functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: eplusr
 Title: A Toolkit for Using Whole Building Simulation Program
     'EnergyPlus'
-Version: 0.17.0.9015
+Version: 0.17.0.9016
 Authors@R: c(
     person(given = "Hongyuan",
            family = "Jia",

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@
 
 ## Internal refactor
 
+* Remove redundant `field` resets from `trans_funs$f2510t2520()` and
+  `trans_funs$f2520t2610()` because transition loading is driven by `class` and
+  `index` (#646).
+
 * Run tests serially by default and reserve network, transition, preprocessor,
   and other heavy external-program checks for an explicit integration mode,
   while retaining latest-version SQLite output coverage in the default suite

--- a/R/transition.R
+++ b/R/transition.R
@@ -5027,7 +5027,6 @@ trans_funs$f2510t2520 <- function(idf) {
     dt3 <- trans_action(idf, "GroundHeatExchanger:System", insert = list(11:12))
 
     dt <- rbindlist(mget(paste0("dt", 1:3)), use.names = TRUE)
-    set(dt, NULL, "field", NA_character_)
 
     trans_process(new_idf, idf, dt)
 
@@ -5057,7 +5056,6 @@ trans_funs$f2520t2610 <- function(idf) {
     dt2 <- delete_shift(trans_action(idf, "AirTerminal:SingleDuct:SeriesPIU:Reheat"), 9L)
 
     dt <- rbindlist(mget(paste0("dt", 1:2)), use.names = TRUE)
-    set(dt, NULL, "field", NA_character_)
 
     trans_process(new_idf, idf, dt)
 


### PR DESCRIPTION
## Summary

Remove redundant `field` resets from `trans_funs$f2510t2520()` and `trans_funs$f2520t2610()`.

Closes #645.

## Changes

- Delete the two redundant `set()` calls from `R/transition.R`.
- Increment the development version in `DESCRIPTION` from `0.17.0.9015` to `0.17.0.9016`.
- Document the cleanup in `NEWS.md`.